### PR TITLE
Make 'List' Umambiguous since it can be defined as an enum/union

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -21,7 +21,7 @@ package io.apibuilder.example.union.types.v0.models {
 
     case class UNDEFINED(override val toString: String) extends UserDiscriminator
 
-    val all: List[UserDiscriminator] = List(RegisteredUser, GuestUser, Uuid)
+    val all: scala.List[UserDiscriminator] = scala.List(RegisteredUser, GuestUser, Uuid)
 
     private[this] val byName: Map[String, UserDiscriminator] = all.map(x => x.toString.toLowerCase -> x).toMap
 
@@ -103,7 +103,7 @@ package io.apibuilder.example.union.types.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[Bar] = List(B)
+    val all: scala.List[Bar] = scala.List(B)
 
     private[this]
     val byName: Map[String, Bar] = all.map(x => x.toString.toLowerCase -> x).toMap
@@ -136,7 +136,7 @@ package io.apibuilder.example.union.types.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[Foo] = List(A)
+    val all: scala.List[Foo] = scala.List(A)
 
     private[this]
     val byName: Map[String, Foo] = all.map(x => x.toString.toLowerCase -> x).toMap

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -21,7 +21,7 @@ package io.apibuilder.example.union.types.v0.models {
 
     case class UNDEFINED(override val toString: String) extends UserDiscriminator
 
-    val all: List[UserDiscriminator] = List(RegisteredUser, GuestUser, Uuid)
+    val all: scala.List[UserDiscriminator] = scala.List(RegisteredUser, GuestUser, Uuid)
 
     private[this] val byName: Map[String, UserDiscriminator] = all.map(x => x.toString.toLowerCase -> x).toMap
 
@@ -103,7 +103,7 @@ package io.apibuilder.example.union.types.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[Bar] = List(B)
+    val all: scala.List[Bar] = scala.List(B)
 
     private[this]
     val byName: Map[String, Bar] = all.map(x => x.toString.toLowerCase -> x).toMap
@@ -136,7 +136,7 @@ package io.apibuilder.example.union.types.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[Foo] = List(A)
+    val all: scala.List[Foo] = scala.List(A)
 
     private[this]
     val byName: Map[String, Foo] = all.map(x => x.toString.toLowerCase -> x).toMap

--- a/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
@@ -14,7 +14,7 @@ package com.gilt.test.v0.models {
   case class UserPatch(
     groups: _root_.scala.Option[Seq[String]] = None,
     permissions: Seq[String] = Nil,
-    preferences: Seq[String] = List("foo")
+    preferences: Seq[String] = scala.List("foo")
   )
 
 }

--- a/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
@@ -14,7 +14,7 @@ package com.gilt.test.v0.models {
   case class UserPatch(
     groups: _root_.scala.Option[Seq[String]] = None,
     permissions: Seq[String] = Nil,
-    preferences: Seq[String] = List("foo")
+    preferences: Seq[String] = scala.List("foo")
   )
 
 }

--- a/lib/src/test/resources/generators/collection-json-defaults-user-patch-case-class.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-user-patch-case-class.txt
@@ -1,5 +1,5 @@
 case class UserPatch(
   groups: _root_.scala.Option[Seq[String]] = None,
   permissions: Seq[String] = Nil,
-  preferences: Seq[String] = List("foo")
+  preferences: Seq[String] = scala.List("foo")
 )

--- a/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
+++ b/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
@@ -371,7 +371,7 @@ package com.gilt.quality.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[ExternalServiceName] = List(Jira)
+    val all: scala.List[ExternalServiceName] = scala.List(Jira)
 
     private[this]
     val byName: Map[String, ExternalServiceName] = all.map(x => x.toString.toLowerCase -> x).toMap
@@ -431,7 +431,7 @@ package com.gilt.quality.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[Publication] = List(IncidentsCreate, IncidentsUpdate, PlansCreate, PlansUpdate, MeetingsAdjourned, IncidentsTeamUpdate)
+    val all: scala.List[Publication] = scala.List(IncidentsCreate, IncidentsUpdate, PlansCreate, PlansUpdate, MeetingsAdjourned, IncidentsTeamUpdate)
 
     private[this]
     val byName: Map[String, Publication] = all.map(x => x.toString.toLowerCase -> x).toMap
@@ -466,7 +466,7 @@ package com.gilt.quality.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[Response] = List(Complete, NotYet, Willnotcomplete)
+    val all: scala.List[Response] = scala.List(Complete, NotYet, Willnotcomplete)
 
     private[this]
     val byName: Map[String, Response] = all.map(x => x.toString.toLowerCase -> x).toMap
@@ -500,7 +500,7 @@ package com.gilt.quality.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[Severity] = List(Low, High)
+    val all: scala.List[Severity] = scala.List(Low, High)
 
     private[this]
     val byName: Map[String, Severity] = all.map(x => x.toString.toLowerCase -> x).toMap
@@ -544,7 +544,7 @@ package com.gilt.quality.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[Task] = List(ReviewTeam, ReviewPlan)
+    val all: scala.List[Task] = scala.List(ReviewTeam, ReviewPlan)
 
     private[this]
     val byName: Map[String, Task] = all.map(x => x.toString.toLowerCase -> x).toMap

--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -103,7 +103,7 @@ package io.apibuilder.reference.api.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[AgeGroup] = List(Youth, Adult)
+    val all: scala.List[AgeGroup] = scala.List(Youth, Adult)
 
     private[this]
     val byName: Map[String, AgeGroup] = all.map(x => x.toString.toLowerCase -> x).toMap

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -103,7 +103,7 @@ package io.apibuilder.reference.api.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[AgeGroup] = List(Youth, Adult)
+    val all: scala.List[AgeGroup] = scala.List(Youth, Adult)
 
     private[this]
     val byName: Map[String, AgeGroup] = all.map(x => x.toString.toLowerCase -> x).toMap

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -103,7 +103,7 @@ package io.apibuilder.reference.api.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[AgeGroup] = List(Youth, Adult)
+    val all: scala.List[AgeGroup] = scala.List(Youth, Adult)
 
     private[this]
     val byName: Map[String, AgeGroup] = all.map(x => x.toString.toLowerCase -> x).toMap

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -103,7 +103,7 @@ package io.apibuilder.reference.api.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[AgeGroup] = List(Youth, Adult)
+    val all: scala.List[AgeGroup] = scala.List(Youth, Adult)
 
     private[this]
     val byName: Map[String, AgeGroup] = all.map(x => x.toString.toLowerCase -> x).toMap

--- a/lib/src/test/resources/play2enums-example.txt
+++ b/lib/src/test/resources/play2enums-example.txt
@@ -21,7 +21,7 @@ object AgeGroup {
    * lower case to avoid collisions with the camel cased values
    * above.
    */
-  val all: List[AgeGroup] = List(Twenties, Thirties)
+  val all: scala.List[AgeGroup] = scala.List(Twenties, Thirties)
 
   private[this]
   val byName: Map[String, AgeGroup] = all.map(x => x.toString.toLowerCase -> x).toMap
@@ -55,7 +55,7 @@ object Genre {
    * lower case to avoid collisions with the camel cased values
    * above.
    */
-  val all: List[Genre] = List(Classical, Jazz)
+  val all: scala.List[Genre] = scala.List(Classical, Jazz)
 
   private[this]
   val byName: Map[String, Genre] = all.map(x => x.toString.toLowerCase -> x).toMap

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -20,7 +20,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
 
     case class UNDEFINED(override val toString: String) extends UserDiscriminator
 
-    val all: List[UserDiscriminator] = List(RegisteredUser, GuestUser, SystemUser, String)
+    val all: scala.List[UserDiscriminator] = scala.List(RegisteredUser, GuestUser, SystemUser, String)
 
     private[this] val byName: Map[String, UserDiscriminator] = all.map(x => x.toString.toLowerCase -> x).toMap
 
@@ -86,7 +86,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
      * lower case to avoid collisions with the camel cased values
      * above.
      */
-    val all: List[SystemUser] = List(System, Anonymous)
+    val all: scala.List[SystemUser] = scala.List(System, Anonymous)
 
     private[this]
     val byName: Map[String, SystemUser] = all.map(x => x.toString.toLowerCase -> x).toMap

--- a/scala-generator/src/main/scala/models/generator/ScalaDatatype.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaDatatype.scala
@@ -313,7 +313,7 @@ object ScalaDatatype {
       val seq = arr.value.map { value =>
         inner.default(value)
       }
-      if (seq.isEmpty) "Nil" else seq.mkString(s"List(", ",", ")")
+      if (seq.isEmpty) "Nil" else seq.mkString(s"scala.List(", ",", ")")
     }
   }
 

--- a/scala-generator/src/main/scala/models/generator/ScalaEnums.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaEnums.scala
@@ -43,7 +43,7 @@ case class UNDEFINED(override val toString: String) extends ${enum.name}
  * above.
  */
 """ +
-    s"val all: List[${enum.name}] = List(" + enum.values.map(_.name).mkString(", ") + ")\n\n" +
+    s"val all: scala.List[${enum.name}] = scala.List(" + enum.values.map(_.name).mkString(", ") + ")\n\n" +
     s"private[this]\n" +
     s"val byName: Map[String, ${enum.name}] = all.map(x => x.toString.toLowerCase -> x).toMap\n\n" +
     s"def apply(value: String): ${enum.name} = fromString(value).getOrElse(UNDEFINED(value))\n\n" +

--- a/scala-generator/src/main/scala/models/generator/ScalaUnionDiscriminator.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaUnionDiscriminator.scala
@@ -33,7 +33,7 @@ case class ScalaUnionDiscriminator(
         ).flatten.mkString("\n")
       }.mkString("\n"),
       s"case class UNDEFINED(override val toString: String) extends $className",
-      s"val all: List[$className] = List(" + union.types.map(_.name).mkString(", ") + ")",
+      s"val all: scala.List[$className] = scala.List(" + union.types.map(_.name).mkString(", ") + ")",
       s"private[this] val byName: Map[String, $className] = all.map(x => x.toString.toLowerCase -> x).toMap",
       s"def apply(value: String): $className = fromString(value).getOrElse(UNDEFINED(value))",
       s"def fromString(value: String): _root_.scala.Option[$className] = byName.get(value.toLowerCase)"

--- a/scala-generator/src/test/scala/models/generator/ScalaUtilSpec.scala
+++ b/scala-generator/src/test/scala/models/generator/ScalaUtilSpec.scala
@@ -191,7 +191,7 @@ class ScalaUtilSpec extends FunSpec with ShouldMatchers {
     }
 
     it ("""default: ["foo"], datatype: [string]""") {
-      ScalaUtil.scalaDefault("""["foo"]""", ScalaDatatype.List(ScalaPrimitive.String)) should be("""List("foo")""")
+      ScalaUtil.scalaDefault("""["foo"]""", ScalaDatatype.List(ScalaPrimitive.String)) should be("""scala.List("foo")""")
     }
 
     it ("default: [], datatype: [string]") {


### PR DESCRIPTION
```
val all: List[ManifestType] = List(All, List)
```

fails with the error:
```
[error] /home/travis/build/flowcommerce/fulfillment/api/app/generated/FlowLabelV0Client.scala:295: io.flow.label.v0.models.ManifestType.List.type does not take parameters
[error]     val all: List[ManifestType] = List(All, List)
```

it used to be:
```
    val all = Seq(All, List)
```

coverting to:
```
val all: List[ManifestType] = List(All, List)
```
seems to work