### PR TITLE
Mock resource method types (mock.Client.cards()) should return interface type (Cards), not mock interface type (MockCards)

### DIFF
--- a/scala-generator/src/main/scala/models/generator/mock/MockClientGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/mock/MockClientGenerator.scala
@@ -75,7 +75,7 @@ class MockClientGenerator(
               s"trait Client extends ${ssd.namespaces.interfaces}.Client {",
               s"""  ${config.formatBaseUrl(Some("http://mock.localhost"))}""",
               ssd.resources.map { resource =>
-                s"override def ${generator.methodName(resource)}: Mock${resource.plural} = Mock${resource.plural}Impl"
+                s"override def ${generator.methodName(resource)}: ${resource.plural} = Mock${resource.plural}Impl"
               }.mkString("\n").indent(2),
               "}",
               ssd.resources.map { resource =>


### PR DESCRIPTION
Used so we can override this with mockito mocks of the resource interface (mock[Cards])