### PR TITLE
support path and query params with underscores in http4s generator

### DIFF
--- a/lib/src/test/resources/http4s/path-params-015.txt
+++ b/lib/src/test/resources/http4s/path-params-015.txt
@@ -109,6 +109,17 @@ trait ModelRoutes {
     id: String
   ): scalaz.concurrent.Task[GetStringByIdResponse]
 
+  sealed trait GetNamedStringByNamedIdResponse
+
+  object GetNamedStringByNamedIdResponse {
+    case class HTTP200(headers: Seq[org.http4s.Header] = Nil) extends GetNamedStringByNamedIdResponse
+  }
+
+  def getNamedStringByNamedId(
+    _req: org.http4s.Request,
+    namedId: String
+  ): scalaz.concurrent.Task[GetNamedStringByNamedIdResponse]
+
   sealed trait GetStringWithMinByIdResponse
 
   object GetStringWithMinByIdResponse {
@@ -329,6 +340,17 @@ trait ModelRoutes {
     id: io.apibuilder.http4s.test.models.Enum
   ): scalaz.concurrent.Task[GetEnumByIdResponse]
 
+  sealed trait GetNamedEnumByNamedIdResponse
+
+  object GetNamedEnumByNamedIdResponse {
+    case class HTTP200(headers: Seq[org.http4s.Header] = Nil) extends GetNamedEnumByNamedIdResponse
+  }
+
+  def getNamedEnumByNamedId(
+    _req: org.http4s.Request,
+    namedId: io.apibuilder.http4s.test.models.Enum
+  ): scalaz.concurrent.Task[GetNamedEnumByNamedIdResponse]
+
   sealed trait GetEnumWithMinAndMaxByIdResponse
 
   object GetEnumWithMinAndMaxByIdResponse {
@@ -357,6 +379,11 @@ trait ModelRoutes {
     case _req @ GET -> Root / "string" / id if apiVersionMatch(_req) =>
       getStringById(_req, id).flatMap {
         case GetStringByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
+      }
+
+    case _req @ GET -> Root / "named_string" / namedId if apiVersionMatch(_req) =>
+      getNamedStringByNamedId(_req, namedId).flatMap {
+        case GetNamedStringByNamedIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
     case _req @ GET -> Root / "string_with_min" / String10Val(id) if apiVersionMatch(_req) =>
@@ -457,6 +484,11 @@ trait ModelRoutes {
     case _req @ GET -> Root / "enum" / EnumVal(id) if apiVersionMatch(_req) =>
       getEnumById(_req, id).flatMap {
         case GetEnumByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
+      }
+
+    case _req @ GET -> Root / "named_enum" / EnumVal(namedId) if apiVersionMatch(_req) =>
+      getNamedEnumByNamedId(_req, namedId).flatMap {
+        case GetNamedEnumByNamedIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
     case _req @ GET -> Root / "enum_with_min_and_max" / EnumVal(id) if apiVersionMatch(_req) =>

--- a/lib/src/test/resources/http4s/path-params-015.txt
+++ b/lib/src/test/resources/http4s/path-params-015.txt
@@ -381,8 +381,8 @@ trait ModelRoutes {
         case GetStringByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
-    case _req @ GET -> Root / "named_string" / namedId if apiVersionMatch(_req) =>
-      getNamedStringByNamedId(_req, namedId).flatMap {
+    case _req @ GET -> Root / "named_string" / named_id if apiVersionMatch(_req) =>
+      getNamedStringByNamedId(_req, named_id).flatMap {
         case GetNamedStringByNamedIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
@@ -486,8 +486,8 @@ trait ModelRoutes {
         case GetEnumByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
-    case _req @ GET -> Root / "named_enum" / EnumVal(namedId) if apiVersionMatch(_req) =>
-      getNamedEnumByNamedId(_req, namedId).flatMap {
+    case _req @ GET -> Root / "named_enum" / EnumVal(named_id) if apiVersionMatch(_req) =>
+      getNamedEnumByNamedId(_req, named_id).flatMap {
         case GetNamedEnumByNamedIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 

--- a/lib/src/test/resources/http4s/path-params-017.txt
+++ b/lib/src/test/resources/http4s/path-params-017.txt
@@ -381,8 +381,8 @@ trait ModelRoutes {
         case GetStringByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
-    case _req @ GET -> Root / "named_string" / namedId if apiVersionMatch(_req) =>
-      getNamedStringByNamedId(_req, namedId).flatMap {
+    case _req @ GET -> Root / "named_string" / named_id if apiVersionMatch(_req) =>
+      getNamedStringByNamedId(_req, named_id).flatMap {
         case GetNamedStringByNamedIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
@@ -486,8 +486,8 @@ trait ModelRoutes {
         case GetEnumByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
-    case _req @ GET -> Root / "named_enum" / EnumVal(namedId) if apiVersionMatch(_req) =>
-      getNamedEnumByNamedId(_req, namedId).flatMap {
+    case _req @ GET -> Root / "named_enum" / EnumVal(named_id) if apiVersionMatch(_req) =>
+      getNamedEnumByNamedId(_req, named_id).flatMap {
         case GetNamedEnumByNamedIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 

--- a/lib/src/test/resources/http4s/path-params-017.txt
+++ b/lib/src/test/resources/http4s/path-params-017.txt
@@ -109,6 +109,17 @@ trait ModelRoutes {
     id: String
   ): fs2.Task[GetStringByIdResponse]
 
+  sealed trait GetNamedStringByNamedIdResponse
+
+  object GetNamedStringByNamedIdResponse {
+    case class HTTP200(headers: Seq[org.http4s.Header] = Nil) extends GetNamedStringByNamedIdResponse
+  }
+
+  def getNamedStringByNamedId(
+    _req: org.http4s.Request,
+    namedId: String
+  ): fs2.Task[GetNamedStringByNamedIdResponse]
+
   sealed trait GetStringWithMinByIdResponse
 
   object GetStringWithMinByIdResponse {
@@ -329,6 +340,17 @@ trait ModelRoutes {
     id: io.apibuilder.http4s.test.models.Enum
   ): fs2.Task[GetEnumByIdResponse]
 
+  sealed trait GetNamedEnumByNamedIdResponse
+
+  object GetNamedEnumByNamedIdResponse {
+    case class HTTP200(headers: Seq[org.http4s.Header] = Nil) extends GetNamedEnumByNamedIdResponse
+  }
+
+  def getNamedEnumByNamedId(
+    _req: org.http4s.Request,
+    namedId: io.apibuilder.http4s.test.models.Enum
+  ): fs2.Task[GetNamedEnumByNamedIdResponse]
+
   sealed trait GetEnumWithMinAndMaxByIdResponse
 
   object GetEnumWithMinAndMaxByIdResponse {
@@ -357,6 +379,11 @@ trait ModelRoutes {
     case _req @ GET -> Root / "string" / id if apiVersionMatch(_req) =>
       getStringById(_req, id).flatMap {
         case GetStringByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
+      }
+
+    case _req @ GET -> Root / "named_string" / namedId if apiVersionMatch(_req) =>
+      getNamedStringByNamedId(_req, namedId).flatMap {
+        case GetNamedStringByNamedIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
     case _req @ GET -> Root / "string_with_min" / String10Val(id) if apiVersionMatch(_req) =>
@@ -457,6 +484,11 @@ trait ModelRoutes {
     case _req @ GET -> Root / "enum" / EnumVal(id) if apiVersionMatch(_req) =>
       getEnumById(_req, id).flatMap {
         case GetEnumByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
+      }
+
+    case _req @ GET -> Root / "named_enum" / EnumVal(namedId) if apiVersionMatch(_req) =>
+      getNamedEnumByNamedId(_req, namedId).flatMap {
+        case GetNamedEnumByNamedIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
     case _req @ GET -> Root / "enum_with_min_and_max" / EnumVal(id) if apiVersionMatch(_req) =>

--- a/lib/src/test/resources/http4s/path-params.json
+++ b/lib/src/test/resources/http4s/path-params.json
@@ -76,6 +76,29 @@
         },
         {
           "method": "GET",
+          "path": "/named_string/:named_id",
+          "attributes": [],
+          "parameters": [
+            {
+              "name": "named_id",
+              "type": "string",
+              "location": "Path",
+              "required": true
+            }
+          ],
+          "responses": [
+            {
+              "code": {
+                "integer": {
+                  "value": 200
+                }
+              },
+              "type": "unit"
+            }
+          ]
+        },
+        {
+          "method": "GET",
           "path": "/string_with_min/:id",
           "attributes": [],
           "parameters": [
@@ -547,6 +570,29 @@
           "parameters": [
             {
               "name": "id",
+              "type": "enum",
+              "location": "Path",
+              "required": true
+            }
+          ],
+          "responses": [
+            {
+              "code": {
+                "integer": {
+                  "value": 200
+                }
+              },
+              "type": "unit"
+            }
+          ]
+        },
+        {
+          "method": "GET",
+          "path": "/named_enum/:named_id",
+          "attributes": [],
+          "parameters": [
+            {
+              "name": "named_id",
               "type": "enum",
               "location": "Path",
               "required": true

--- a/lib/src/test/resources/http4s/query-params-017.txt
+++ b/lib/src/test/resources/http4s/query-params-017.txt
@@ -108,6 +108,10 @@ private[server] object Matchers {
   }
 
   object IdUUIDMatcher extends QueryParamDecoderMatcher[_root_.java.util.UUID]("id")
+
+  object NamedIdEnumMatcher extends QueryParamDecoderMatcher[io.apibuilder.http4s.test.models.Enum]("named_id")
+
+  object NamedIdStringMatcher extends QueryParamDecoderMatcher[String]("named_id")
 }
 
 trait ModelRoutes {
@@ -126,6 +130,17 @@ trait ModelRoutes {
     _req: org.http4s.Request,
     id: String
   ): fs2.Task[GetStringResponse]
+
+  sealed trait GetNamedStringResponse
+
+  object GetNamedStringResponse {
+    case class HTTP200(headers: Seq[org.http4s.Header] = Nil) extends GetNamedStringResponse
+  }
+
+  def getNamedString(
+    _req: org.http4s.Request,
+    namedId: String
+  ): fs2.Task[GetNamedStringResponse]
 
   sealed trait GetStringWithMinResponse
 
@@ -413,6 +428,17 @@ trait ModelRoutes {
     id: io.apibuilder.http4s.test.models.Enum
   ): fs2.Task[GetEnumResponse]
 
+  sealed trait GetNamedEnumResponse
+
+  object GetNamedEnumResponse {
+    case class HTTP200(headers: Seq[org.http4s.Header] = Nil) extends GetNamedEnumResponse
+  }
+
+  def getNamedEnum(
+    _req: org.http4s.Request,
+    namedId: io.apibuilder.http4s.test.models.Enum
+  ): fs2.Task[GetNamedEnumResponse]
+
   sealed trait GetEnumWithMinAndMaxResponse
 
   object GetEnumWithMinAndMaxResponse {
@@ -430,6 +456,11 @@ trait ModelRoutes {
     case _req @ GET -> Root / "string" :? IdStringMatcher(id) if apiVersionMatch(_req) =>
       getString(_req, id).flatMap {
         case GetStringResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
+      }
+
+    case _req @ GET -> Root / "named_string" :? NamedIdStringMatcher(namedId) if apiVersionMatch(_req) =>
+      getNamedString(_req, namedId).flatMap {
+        case GetNamedStringResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
     case _req @ GET -> Root / "string_with_min" :? IdString10Matcher(id) if apiVersionMatch(_req) =>
@@ -560,6 +591,11 @@ trait ModelRoutes {
     case _req @ GET -> Root / "enum" :? IdEnumMatcher(id) if apiVersionMatch(_req) =>
       getEnum(_req, id).flatMap {
         case GetEnumResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
+      }
+
+    case _req @ GET -> Root / "named_enum" :? NamedIdEnumMatcher(namedId) if apiVersionMatch(_req) =>
+      getNamedEnum(_req, namedId).flatMap {
+        case GetNamedEnumResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
     case _req @ GET -> Root / "enum_with_min_and_max" :? IdEnum10To30DefValueMatcher(id) if apiVersionMatch(_req) =>

--- a/lib/src/test/resources/http4s/query-params-017.txt
+++ b/lib/src/test/resources/http4s/query-params-017.txt
@@ -458,8 +458,8 @@ trait ModelRoutes {
         case GetStringResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
-    case _req @ GET -> Root / "named_string" :? NamedIdStringMatcher(namedId) if apiVersionMatch(_req) =>
-      getNamedString(_req, namedId).flatMap {
+    case _req @ GET -> Root / "named_string" :? NamedIdStringMatcher(named_id) if apiVersionMatch(_req) =>
+      getNamedString(_req, named_id).flatMap {
         case GetNamedStringResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
@@ -593,8 +593,8 @@ trait ModelRoutes {
         case GetEnumResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 
-    case _req @ GET -> Root / "named_enum" :? NamedIdEnumMatcher(namedId) if apiVersionMatch(_req) =>
-      getNamedEnum(_req, namedId).flatMap {
+    case _req @ GET -> Root / "named_enum" :? NamedIdEnumMatcher(named_id) if apiVersionMatch(_req) =>
+      getNamedEnum(_req, named_id).flatMap {
         case GetNamedEnumResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
 

--- a/lib/src/test/resources/http4s/query-params.json
+++ b/lib/src/test/resources/http4s/query-params.json
@@ -76,6 +76,29 @@
         },
         {
           "method": "GET",
+          "path": "/named_string",
+          "attributes": [],
+          "parameters": [
+            {
+              "name": "named_id",
+              "type": "string",
+              "location": "Query",
+              "required": true
+            }
+          ],
+          "responses": [
+            {
+              "code": {
+                "integer": {
+                  "value": 200
+                }
+              },
+              "type": "unit"
+            }
+          ]
+        },
+        {
+          "method": "GET",
           "path": "/string_with_min",
           "attributes": [],
           "parameters": [
@@ -691,6 +714,29 @@
           "parameters": [
             {
               "name": "id",
+              "type": "enum",
+              "location": "Query",
+              "required": true
+            }
+          ],
+          "responses": [
+            {
+              "code": {
+                "integer": {
+                  "value": 200
+                }
+              },
+              "type": "unit"
+            }
+          ]
+        },
+        {
+          "method": "GET",
+          "path": "/named_enum",
+          "attributes": [],
+          "parameters": [
+            {
+              "name": "named_id",
               "type": "enum",
               "location": "Query",
               "required": true

--- a/scala-generator/src/main/scala/models/http4s/server/Http4sServer.scala
+++ b/scala-generator/src/main/scala/models/http4s/server/Http4sServer.scala
@@ -46,7 +46,7 @@ object Http4sServer {
           val minPart = param.param.minimum.fold("")(v => s"$v")
           val maxPart = param.param.maximum.fold("")(v => s"To$v")
           val defPart = param.param.default.fold("")(v => s"Def${ScalaUtil.toClassName(v)}")
-          QueryExtractor(s"${param.name.capitalize}$collPart${typeName(ssd, sp)}$minPart$maxPart${defPart}Matcher", param.name)
+          QueryExtractor(s"${param.name.capitalize}$collPart${typeName(ssd, sp)}$minPart$maxPart${defPart}Matcher", param.originalName)
         case sp: ScalaPrimitive =>
           QueryExtractor(s"${param.name.capitalize}$collPart${typeName(ssd, sp)}Matcher", param.name)
         case ScalaDatatype.List(nested) =>

--- a/scala-generator/src/main/scala/models/http4s/server/Route.scala
+++ b/scala-generator/src/main/scala/models/http4s/server/Route.scala
@@ -19,8 +19,8 @@ case class Route(ssd: ScalaService, resource: ScalaResource, op: ScalaOperation,
     if(!segment.startsWith(":")) {
       Literal(segment)
     } else {
-      val truncated = ScalaUtil.toVariable(segment.drop(1))
-      op.pathParameters.find(_.name == truncated).fold(Literal(segment): PathSegment) { scalaParameter =>
+      val truncated = segment.drop(1) //ScalaUtil.toVariable(segment.drop(1))
+      op.pathParameters.find(_.originalName == truncated).fold(Literal(segment): PathSegment) { scalaParameter =>
         scalaParameter.datatype match {
           case ScalaPrimitive.String if scalaParameter.param.minimum.isEmpty && scalaParameter.param.maximum.isEmpty => PlainString(truncated)
           case _: ScalaPrimitive => Extracted(truncated, scalaParameter)
@@ -82,7 +82,7 @@ case class Route(ssd: ScalaService, resource: ScalaResource, op: ScalaOperation,
   def route(version: Option[Int]): Seq[String] = {
     val args = (
       Seq(Some("_req")) ++
-        op.nonHeaderParameters.map(field => Some(s"${ScalaUtil.quoteNameIfKeyword(field.name)}")) ++
+        op.nonHeaderParameters.map(field => Some(s"${ScalaUtil.quoteNameIfKeyword(field.originalName)}")) ++
         Seq(op.body.map(body => s"_req.attemptAs[${body.datatype.name}]"))
       ).flatten.mkString(", ")
 

--- a/scala-generator/src/main/scala/models/http4s/server/Route.scala
+++ b/scala-generator/src/main/scala/models/http4s/server/Route.scala
@@ -19,7 +19,7 @@ case class Route(ssd: ScalaService, resource: ScalaResource, op: ScalaOperation,
     if(!segment.startsWith(":")) {
       Literal(segment)
     } else {
-      val truncated = segment.drop(1)
+      val truncated = ScalaUtil.toVariable(segment.drop(1))
       op.pathParameters.find(_.name == truncated).fold(Literal(segment): PathSegment) { scalaParameter =>
         scalaParameter.datatype match {
           case ScalaPrimitive.String if scalaParameter.param.minimum.isEmpty && scalaParameter.param.maximum.isEmpty => PlainString(truncated)


### PR DESCRIPTION
Converts the path and query param names to variable names using `ScalaUtil.toVariable`

Fixes #261 