### PR TITLE
Honor the full path from the base_uri

### DIFF
--- a/ruby-generator/src/main/scala/models/RubyHttpClient.scala
+++ b/ruby-generator/src/main/scala/models/RubyHttpClient.scala
@@ -97,7 +97,7 @@ module HttpClient
     def initialize(http_handler, base_uri, path)
       @http_handler = http_handler
       @base_uri = Preconditions.assert_class('base_uri', base_uri, URI)
-      @path = Preconditions.assert_class('path', path, String)
+      @path = URI::join(@base_uri.to_s, Preconditions.assert_class('path', path, String)).path
       @params = nil
       @body = nil
       @auth = nil


### PR DESCRIPTION
If any path beyond the base_uri was specified it was ignored. For
example, if the base_uri was set to:

http://hostname/base_path

and a request was made with path set to '/request_path' then the
resulting request would be made to:

http://hostname/request_path

instead of:

http://hostname/base_path/request_path

This change fixes that behavior.