### PR TITLE
Ruby client: Explicitly build full path to underlying service

### DIFF
--- a/lib/src/test/resources/example-response-with-unit-type.txt
+++ b/lib/src/test/resources/example-response-with-unit-type.txt
@@ -184,12 +184,13 @@ module Io
 
         class Request
 
-          attr_reader :path
+          attr_reader :base_uri, :path, :full_uri
 
           def initialize(http_handler, base_uri, path)
             @http_handler = http_handler
             @base_uri = Preconditions.assert_class('base_uri', base_uri, URI)
             @path = Preconditions.assert_class('path', path, String)
+            @full_uri = URI.parse(@base_uri.to_s + @path)
             @params = nil
             @body = nil
             @auth = nil
@@ -270,7 +271,7 @@ module Io
           def do_request(klass)
             Preconditions.assert_class('klass', klass, Class)
 
-            uri = path.dup
+            uri = @full_uri.dup
             if q = to_query(@params)
               uri += "?%s" % q
             end

--- a/lib/src/test/resources/example-union-types-ruby-client.txt
+++ b/lib/src/test/resources/example-union-types-ruby-client.txt
@@ -461,12 +461,13 @@ module Io
 
               class Request
 
-                attr_reader :path
+                attr_reader :base_uri, :path, :full_uri
 
                 def initialize(http_handler, base_uri, path)
                   @http_handler = http_handler
                   @base_uri = Preconditions.assert_class('base_uri', base_uri, URI)
                   @path = Preconditions.assert_class('path', path, String)
+                  @full_uri = URI.parse(@base_uri.to_s + @path)
                   @params = nil
                   @body = nil
                   @auth = nil
@@ -547,7 +548,7 @@ module Io
                 def do_request(klass)
                   Preconditions.assert_class('klass', klass, Class)
 
-                  uri = path.dup
+                  uri = @full_uri.dup
                   if q = to_query(@params)
                     uri += "?%s" % q
                   end

--- a/lib/src/test/resources/ruby-client-generator-gilt-0.0.1-test.txt
+++ b/lib/src/test/resources/ruby-client-generator-gilt-0.0.1-test.txt
@@ -630,12 +630,13 @@ module Io
 
             class Request
 
-              attr_reader :path
+              attr_reader :base_uri, :path, :full_uri
 
               def initialize(http_handler, base_uri, path)
                 @http_handler = http_handler
                 @base_uri = Preconditions.assert_class('base_uri', base_uri, URI)
                 @path = Preconditions.assert_class('path', path, String)
+                @full_uri = URI.parse(@base_uri.to_s + @path)
                 @params = nil
                 @body = nil
                 @auth = nil
@@ -716,7 +717,7 @@ module Io
               def do_request(klass)
                 Preconditions.assert_class('klass', klass, Class)
 
-                uri = path.dup
+                uri = @full_uri.dup
                 if q = to_query(@params)
                   uri += "?%s" % q
                 end

--- a/ruby-generator/src/main/scala/models/RubyHttpClient.scala
+++ b/ruby-generator/src/main/scala/models/RubyHttpClient.scala
@@ -92,12 +92,13 @@ module HttpClient
 
   class Request
 
-    attr_reader :path
+    attr_reader :base_uri, :path, :full_uri
 
     def initialize(http_handler, base_uri, path)
       @http_handler = http_handler
       @base_uri = Preconditions.assert_class('base_uri', base_uri, URI)
       @path = Preconditions.assert_class('path', path, String)
+      @full_uri = URI.parse(@base_uri.to_s + @path)
       @params = nil
       @body = nil
       @auth = nil
@@ -178,7 +179,7 @@ module HttpClient
     def do_request(klass)
       Preconditions.assert_class('klass', klass, Class)
 
-      uri = path.dup
+      uri = @full_uri.dup
       if q = to_query(@params)
         uri += "?%s" % q
       end


### PR DESCRIPTION
- URI::join is dropping the base so a base uri of http://foo.com/bar ends up
    as http://foo.com
  - This match uses a string to build up the full uri of the service