### PR TITLE
Fix the Anorm Parser generator for union types

### DIFF
--- a/lib/src/test/resources/generator/anorm/enum.txt
+++ b/lib/src/test/resources/generator/anorm/enum.txt
@@ -12,10 +12,10 @@ package test.apidoc.apidoctest.v0.anorm.parsers {
 
   object Status {
 
-    def parserWithPrefix(prefix: String, sep: String = "_") = parser(s"$prefix${sep}name")
+    def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[test.apidoc.apidoctest.v0.models.Status] = parser(prefixOpt = Some(s"$prefix$sep"))
 
-    def parser(name: String = "status"): RowParser[test.apidoc.apidoctest.v0.models.Status] = {
-      SqlParser.str(name) map {
+    def parser(name: String = "status", prefixOpt: Option[String] = None): RowParser[test.apidoc.apidoctest.v0.models.Status] = {
+      SqlParser.str(prefixOpt.getOrElse("") + name) map {
         case value => test.apidoc.apidoctest.v0.models.Status(value)
       }
     }
@@ -24,17 +24,15 @@ package test.apidoc.apidoctest.v0.anorm.parsers {
 
   object User {
 
-    def parserWithPrefix(prefix: String, sep: String = "_") = parser(
-      guid = s"$prefix${sep}guid",
-      status = s"$prefix${sep}status"
-    )
+    def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[test.apidoc.apidoctest.v0.models.User] = parser(prefixOpt = Some(s"$prefix$sep"))
 
     def parser(
       guid: String = "guid",
-      status: String = "status"
+      status: String = "status",
+      prefixOpt: Option[String] = None
     ): RowParser[test.apidoc.apidoctest.v0.models.User] = {
-      SqlParser.get[_root_.java.util.UUID](guid) ~
-      test.apidoc.apidoctest.v0.anorm.parsers.Status.parser(status) map {
+      SqlParser.get[_root_.java.util.UUID](prefixOpt.getOrElse("") + guid) ~
+      test.apidoc.apidoctest.v0.anorm.parsers.Status.parser(prefixOpt.getOrElse("") + status) map {
         case guid ~ status => {
           test.apidoc.apidoctest.v0.models.User(
             guid = guid,

--- a/lib/src/test/resources/generator/anorm/list.txt
+++ b/lib/src/test/resources/generator/anorm/list.txt
@@ -12,17 +12,15 @@ package test.apidoc.apidoctest.v0.anorm.parsers {
 
   object User {
 
-    def parserWithPrefix(prefix: String, sep: String = "_") = parser(
-      guid = s"$prefix${sep}guid",
-      emails = s"$prefix${sep}emails"
-    )
+    def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[test.apidoc.apidoctest.v0.models.User] = parser(prefixOpt = Some(s"$prefix$sep"))
 
     def parser(
       guid: String = "guid",
-      emails: String = "emails"
+      emails: String = "emails",
+      prefixOpt: Option[String] = None
     ): RowParser[test.apidoc.apidoctest.v0.models.User] = {
-      SqlParser.get[_root_.java.util.UUID](guid) ~
-      SqlParser.get[Seq[String]](emails) map {
+      SqlParser.get[_root_.java.util.UUID](prefixOpt.getOrElse("") + guid) ~
+      SqlParser.get[Seq[String]](prefixOpt.getOrElse("") + emails) map {
         case guid ~ emails => {
           test.apidoc.apidoctest.v0.models.User(
             guid = guid,

--- a/lib/src/test/resources/generator/anorm/location-parsers.txt
+++ b/lib/src/test/resources/generator/anorm/location-parsers.txt
@@ -12,14 +12,13 @@ package test.apidoc.apidoctest.v0.anorm.parsers {
 
   object Location {
 
-    def parserWithPrefix(prefix: String, sep: String = "_") = parser(
-      ipAddress = s"$prefix${sep}ip_address"
-    )
+    def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[test.apidoc.apidoctest.v0.models.Location] = parser(prefixOpt = Some(s"$prefix$sep"))
 
     def parser(
-      ipAddress: String = "ip_address"
+      ipAddress: String = "ip_address",
+      prefixOpt: Option[String] = None
     ): RowParser[test.apidoc.apidoctest.v0.models.Location] = {
-      SqlParser.str(ipAddress) map {
+      SqlParser.str(prefixOpt.getOrElse("") + ipAddress) map {
         case ipAddress => {
           test.apidoc.apidoctest.v0.models.Location(
             ipAddress = ipAddress

--- a/lib/src/test/resources/generator/anorm/name.txt
+++ b/lib/src/test/resources/generator/anorm/name.txt
@@ -12,17 +12,15 @@ package test.apidoc.apidoctest.v0.anorm.parsers {
 
   object Name {
 
-    def parserWithPrefix(prefix: String, sep: String = "_") = parser(
-      first = s"$prefix${sep}first",
-      last = s"$prefix${sep}last"
-    )
+    def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[test.apidoc.apidoctest.v0.models.Name] = parser(prefixOpt = Some(s"$prefix$sep"))
 
     def parser(
       first: String = "first",
-      last: String = "last"
+      last: String = "last",
+      prefixOpt: Option[String] = None
     ): RowParser[test.apidoc.apidoctest.v0.models.Name] = {
-      SqlParser.str(first).? ~
-      SqlParser.str(last).? map {
+      SqlParser.str(prefixOpt.getOrElse("") + first).? ~
+      SqlParser.str(prefixOpt.getOrElse("") + last).? map {
         case first ~ last => {
           test.apidoc.apidoctest.v0.models.Name(
             first = first,

--- a/lib/src/test/resources/generator/anorm/reference.txt
+++ b/lib/src/test/resources/generator/anorm/reference.txt
@@ -12,14 +12,13 @@ package test.apidoc.apidoctest.v0.anorm.parsers {
 
   object Reference {
 
-    def parserWithPrefix(prefix: String, sep: String = "_") = parser(
-      guid = s"$prefix${sep}guid"
-    )
+    def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[test.apidoc.apidoctest.v0.models.Reference] = parser(prefixOpt = Some(s"$prefix$sep"))
 
     def parser(
-      guid: String = "guid"
+      guid: String = "guid",
+      prefixOpt: Option[String] = None
     ): RowParser[test.apidoc.apidoctest.v0.models.Reference] = {
-      SqlParser.get[_root_.java.util.UUID](guid) map {
+      SqlParser.get[_root_.java.util.UUID](prefixOpt.getOrElse("") + guid) map {
         case guid => {
           test.apidoc.apidoctest.v0.models.Reference(
             guid = guid

--- a/lib/src/test/resources/generator/anorm/union-parsers.txt
+++ b/lib/src/test/resources/generator/anorm/union-parsers.txt
@@ -12,14 +12,13 @@ package test.apidoc.apidoctest.v0.anorm.parsers {
 
   object GuestUser {
 
-    def parserWithPrefix(prefix: String, sep: String = "_") = parser(
-      guid = s"$prefix${sep}guid"
-    )
+    def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[test.apidoc.apidoctest.v0.models.GuestUser] = parser(prefixOpt = Some(s"$prefix$sep"))
 
     def parser(
-      guid: String = "guid"
+      guid: String = "guid",
+      prefixOpt: Option[String] = None
     ): RowParser[test.apidoc.apidoctest.v0.models.GuestUser] = {
-      SqlParser.get[_root_.java.util.UUID](guid) map {
+      SqlParser.get[_root_.java.util.UUID](prefixOpt.getOrElse("") + guid) map {
         case guid => {
           test.apidoc.apidoctest.v0.models.GuestUser(
             guid = guid
@@ -32,14 +31,13 @@ package test.apidoc.apidoctest.v0.anorm.parsers {
 
   object RegisteredUser {
 
-    def parserWithPrefix(prefix: String, sep: String = "_") = parser(
-      guid = s"$prefix${sep}guid"
-    )
+    def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[test.apidoc.apidoctest.v0.models.RegisteredUser] = parser(prefixOpt = Some(s"$prefix$sep"))
 
     def parser(
-      guid: String = "guid"
+      guid: String = "guid",
+      prefixOpt: Option[String] = None
     ): RowParser[test.apidoc.apidoctest.v0.models.RegisteredUser] = {
-      SqlParser.get[_root_.java.util.UUID](guid) map {
+      SqlParser.get[_root_.java.util.UUID](prefixOpt.getOrElse("") + guid) map {
         case guid => {
           test.apidoc.apidoctest.v0.models.RegisteredUser(
             guid = guid
@@ -53,8 +51,8 @@ package test.apidoc.apidoctest.v0.anorm.parsers {
   object User {
 
     def parserWithPrefix(prefix: String, sep: String = "_") = {
-      test.apidoc.apidoctest.v0.anorm.parsers.GuestUser.parserWithPrefix(prefix, sep) |
-      test.apidoc.apidoctest.v0.anorm.parsers.RegisteredUser.parserWithPrefix(prefix, sep)
+      test.apidoc.apidoctest.v0.anorm.parsers.GuestUser.parser(prefixOpt = Some(s"$prefix$sep")) |
+      test.apidoc.apidoctest.v0.anorm.parsers.RegisteredUser.parser(prefixOpt = Some(s"$prefix$sep"))
     }
 
     def parser() = {

--- a/lib/src/test/resources/generator/anorm/user.txt
+++ b/lib/src/test/resources/generator/anorm/user.txt
@@ -12,17 +12,15 @@ package test.apidoc.apidoctest.v0.anorm.parsers {
 
   object Name {
 
-    def parserWithPrefix(prefix: String, sep: String = "_") = parser(
-      first = s"$prefix${sep}first",
-      last = s"$prefix${sep}last"
-    )
+    def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[test.apidoc.apidoctest.v0.models.Name] = parser(prefixOpt = Some(s"$prefix$sep"))
 
     def parser(
       first: String = "first",
-      last: String = "last"
+      last: String = "last",
+      prefixOpt: Option[String] = None
     ): RowParser[test.apidoc.apidoctest.v0.models.Name] = {
-      SqlParser.str(first).? ~
-      SqlParser.str(last).? map {
+      SqlParser.str(prefixOpt.getOrElse("") + first).? ~
+      SqlParser.str(prefixOpt.getOrElse("") + last).? map {
         case first ~ last => {
           test.apidoc.apidoctest.v0.models.Name(
             first = first,
@@ -36,19 +34,16 @@ package test.apidoc.apidoctest.v0.anorm.parsers {
 
   object User {
 
-    def parserWithPrefix(prefix: String, sep: String = "_") = parser(
-      guid = s"$prefix${sep}guid",
-      email = s"$prefix${sep}email",
-      namePrefix = s"$prefix${sep}name"
-    )
+    def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[test.apidoc.apidoctest.v0.models.User] = parser(prefixOpt = Some(s"$prefix$sep"))
 
     def parser(
       guid: String = "guid",
       email: String = "email",
-      namePrefix: String = "name"
+      namePrefix: String = "name",
+      prefixOpt: Option[String] = None
     ): RowParser[test.apidoc.apidoctest.v0.models.User] = {
-      SqlParser.get[_root_.java.util.UUID](guid) ~
-      SqlParser.str(email) ~
+      SqlParser.get[_root_.java.util.UUID](prefixOpt.getOrElse("") + guid) ~
+      SqlParser.str(prefixOpt.getOrElse("") + email) ~
       test.apidoc.apidoctest.v0.anorm.parsers.Name.parserWithPrefix(namePrefix).? map {
         case guid ~ email ~ name => {
           test.apidoc.apidoctest.v0.models.User(

--- a/lib/src/test/resources/generator/anorm/user.txt
+++ b/lib/src/test/resources/generator/anorm/user.txt
@@ -44,7 +44,7 @@ package test.apidoc.apidoctest.v0.anorm.parsers {
     ): RowParser[test.apidoc.apidoctest.v0.models.User] = {
       SqlParser.get[_root_.java.util.UUID](prefixOpt.getOrElse("") + guid) ~
       SqlParser.str(prefixOpt.getOrElse("") + email) ~
-      test.apidoc.apidoctest.v0.anorm.parsers.Name.parserWithPrefix(namePrefix).? map {
+      test.apidoc.apidoctest.v0.anorm.parsers.Name.parserWithPrefix(prefixOpt.getOrElse("") + namePrefix).? map {
         case guid ~ email ~ name => {
           test.apidoc.apidoctest.v0.models.User(
             guid = guid,

--- a/scala-generator/src/main/scala/models/generator/PrimitiveWrapper.scala
+++ b/scala-generator/src/main/scala/models/generator/PrimitiveWrapper.scala
@@ -16,20 +16,34 @@ object PrimitiveWrapper {
       }
     }
   }
+
+  def isBasicType(primitive: ScalaPrimitive): Boolean = {
+    primitive match {
+      case ScalaPrimitive.Model(_, _) | ScalaPrimitive.Enum(_, _) | ScalaPrimitive.Union(_, _) => {
+        false
+      }
+      case ScalaPrimitive.Boolean | ScalaPrimitive.Double | ScalaPrimitive.Integer | ScalaPrimitive.Long | ScalaPrimitive.DateIso8601Joda | ScalaPrimitive.DateIso8601Java | ScalaPrimitive.DateTimeIso8601Joda | ScalaPrimitive.DateTimeIso8601Java | ScalaPrimitive.Decimal | ScalaPrimitive.ObjectAsPlay | ScalaPrimitive.ObjectAsCirce | ScalaPrimitive.String | ScalaPrimitive.Unit | ScalaPrimitive.Uuid => {
+
+        true
+      }
+    }
+  }
+
 }
 
 case class PrimitiveWrapper(ssd: ScalaService) {
+  import PrimitiveWrapper.isBasicType
 
   case class Wrapper(model: ScalaModel, union: ScalaUnion)
 
   private[this] val primitives = ssd.unions.flatMap(_.types).map(_.datatype).collect {
     case p: ScalaPrimitive => p
-  }.filter(isBasicType(_)).sortWith(_.shortName < _.shortName)
+  }.filter(isBasicType).sortWith(_.shortName < _.shortName)
 
   val wrappers: Seq[Wrapper] = ssd.unions.flatMap { union =>
     union.types.map(_.datatype).collect {
       case p: ScalaPrimitive => p
-    }.filter(isBasicType(_)).sortWith(_.shortName < _.shortName).map { p =>
+    }.filter(isBasicType).sortWith(_.shortName < _.shortName).map { p =>
       val name = PrimitiveWrapper.className(union, p)
       val model = Model(
         name = name,
@@ -47,18 +61,6 @@ case class PrimitiveWrapper(ssd: ScalaService) {
         new ScalaModel(ssd, model),
         union
       )
-    }
-  }
-
-  private def isBasicType(primitive: ScalaPrimitive): Boolean = {
-    primitive match {
-      case ScalaPrimitive.Model(_, _) | ScalaPrimitive.Enum(_, _) | ScalaPrimitive.Union(_, _) => {
-        false
-      }
-      case ScalaPrimitive.Boolean | ScalaPrimitive.Double | ScalaPrimitive.Integer | ScalaPrimitive.Long | ScalaPrimitive.DateIso8601Joda | ScalaPrimitive.DateIso8601Java | ScalaPrimitive.DateTimeIso8601Joda | ScalaPrimitive.DateTimeIso8601Java | ScalaPrimitive.Decimal | ScalaPrimitive.ObjectAsPlay | ScalaPrimitive.ObjectAsCirce | ScalaPrimitive.String | ScalaPrimitive.Unit | ScalaPrimitive.Uuid => {
-
-        true
-      }
     }
   }
 

--- a/scala-generator/src/main/scala/models/generator/ScalaService.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaService.scala
@@ -66,6 +66,8 @@ class ScalaService(
 
 class ScalaUnion(val ssd: ScalaService, val union: Union) {
 
+  val originalName: String = union.name
+
   val name: String = ScalaUtil.toClassName(union.name)
 
   val qualifiedName = ssd.unionClassName(name)

--- a/scala-generator/src/main/scala/models/generator/anorm/ParserGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/anorm/ParserGenerator.scala
@@ -231,12 +231,12 @@ object ParserGenerator extends CodeGenerator {
         case ScalaPrimitive.Model(ns, name) => {
           addImports(ns)
           val varName = ScalaUtil.toVariable(s"${originalName}Prefix")
-          s"${ns.anormParsers}.$name.parserWithPrefix($varName)"
+          s"""${ns.anormParsers}.$name.parserWithPrefix(prefixOpt.getOrElse("") + $varName)"""
         }
         case ScalaPrimitive.Union(ns, name) => {
           addImports(ns)
           val varName = ScalaUtil.toVariable(s"${originalName}Prefix")
-          s"${ns.anormParsers}.$name.parserWithPrefix($varName)"
+          s"""${ns.anormParsers}.$name.parserWithPrefix(prefixOpt.getOrElse("") + $varName)"""
         }
       }
     }

--- a/scala-generator/src/main/scala/models/generator/anorm/ParserGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/anorm/ParserGenerator.scala
@@ -249,7 +249,7 @@ object ParserGenerator extends CodeGenerator {
       Seq(
         s"object ${enum.name} {",
         Seq(
-          s"""def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[${enum.qualifiedName}] = parser(prefixOpt = Some("""" + "$prefix$sep" + """"))""",
+          s"""def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[${enum.qualifiedName}] = parser(prefixOpt = Some(s"""" + "$prefix$sep" + """"))""",
           Seq(
             s"""def parser(name: String = "${enum.originalName}", prefixOpt: Option[String] = None): RowParser[${enum.qualifiedName}] = {""",
             s"""  SqlParser.str(prefixOpt.getOrElse("") + name) map {""",

--- a/scala-generator/src/main/scala/models/generator/anorm/ParserGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/anorm/ParserGenerator.scala
@@ -1,8 +1,7 @@
 package scala.generator.anorm
 
-import scala.generator.{Namespaces, ScalaDatatype, ScalaEnum, ScalaField, ScalaModel, ScalaPrimitive, ScalaService, ScalaUnion, ScalaUtil}
+import scala.generator._
 import scala.models.ApidocComments
-import io.apibuilder.spec.v0.models.Service
 import io.apibuilder.generator.v0.models.{File, InvocationForm}
 import generator.ServiceFileNames
 import lib.generator.CodeGenerator
@@ -89,24 +88,17 @@ object ParserGenerator extends CodeGenerator {
 
     private[this] def generateModelParser(model: ScalaModel): String = {
       Seq(
-        Seq(
-          s"""def parserWithPrefix(prefix: String, sep: String = "_") = parser(""",
-          model.fields.map { f =>
-            val argName = parserFieldName(f.originalName, f.datatype)
-            s"""${ScalaUtil.quoteNameIfKeyword(argName)} = s"""" + "$prefix${sep}" + s"""${f.originalName}""""
-          }.mkString(",\n").indent(2),
-          ")"
-        ).mkString("\n"),
+        s"""def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[${model.qualifiedName}] = parser(prefixOpt = Some(s"""" + "$prefix$sep" + """"))""",
         "",
         s"def parser(",
-        model.fields.map { f =>
+        (model.fields.map { f =>
           parserFieldDeclaration(f.name, f.datatype, f.originalName)
-        }.mkString(",\n").indent(2),
+        } ++ List("prefixOpt: Option[String] = None")).mkString(",\n").indent(2),
         s"): RowParser[${model.qualifiedName}] = {",
         Seq(
-          model.fields.map { generateRowParser(_) }.mkString(" ~\n") + " map {",
+          model.fields.map { f => generateRowParser("""prefixOpt.getOrElse("") + """ + f.name, f.datatype, f.originalName) }.mkString(" ~\n") + " map {",
           Seq(
-            "case " + model.fields.map(parserName(_)).mkString(" ~ ") + " => {",
+            "case " + model.fields.map(parserName).mkString(" ~ ") + " => {",
             Seq(
               s"${model.qualifiedName}(",
               model.fields.map { f =>
@@ -257,10 +249,10 @@ object ParserGenerator extends CodeGenerator {
       Seq(
         s"object ${enum.name} {",
         Seq(
-          """def parserWithPrefix(prefix: String, sep: String = "_") = parser(s"""" + "$prefix${sep}name" + """")""",
+          s"""def parserWithPrefix(prefix: String, sep: String = "_"): RowParser[${enum.qualifiedName}] = parser(prefixOpt = Some("""" + "$prefix$sep" + """"))""",
           Seq(
-            s"""def parser(name: String = "${enum.originalName}"): RowParser[${enum.qualifiedName}] = {""",
-            s"  SqlParser.str(name) map {",
+            s"""def parser(name: String = "${enum.originalName}", prefixOpt: Option[String] = None): RowParser[${enum.qualifiedName}] = {""",
+            s"""  SqlParser.str(prefixOpt.getOrElse("") + name) map {""",
             s"    case value => ${enum.qualifiedName}(value)",
             s"  }",
             s"}"
@@ -282,13 +274,18 @@ object ParserGenerator extends CodeGenerator {
     }
 
     private[this] def generateUnion(union: ScalaUnion): String = {
+      import PrimitiveWrapper._
       Seq(
         s"object ${union.name} {",
 
         Seq(
           """def parserWithPrefix(prefix: String, sep: String = "_") = {""",
           union.types.map { t =>
-            s"${t.ssd.namespaces.anormParsers}.${t.name}.parserWithPrefix(prefix, sep)"
+            t.datatype match {
+              case _: ScalaPrimitive.Enum => s"""${t.ssd.namespaces.anormParsers}.${t.name}.parser("${union.originalName}", Some(s"""" + "$prefix$sep" + """"))"""
+              case p: ScalaPrimitive if isBasicType(p) => generateRowParser("""s"$prefix${sep}""" + s"""${union.originalName}"""", t.datatype, union.originalName) + s""".map(${t.ssd.namespaces.models}.${className(union, p)}.apply)"""
+              case _ => s"""${t.ssd.namespaces.anormParsers}.${t.name}.parser(prefixOpt = Some(s"""" + "$prefix$sep" + """"))"""
+            }
           }.mkString(" |\n").indent(2),
           "}"
         ).mkString("\n").indent(2),
@@ -296,7 +293,11 @@ object ParserGenerator extends CodeGenerator {
         Seq(
           "def parser() = {",
           union.types.map { t =>
-            s"${t.ssd.namespaces.anormParsers}.${t.name}.parser()"
+            t.datatype match {
+              case _: ScalaPrimitive.Enum => s"""${t.ssd.namespaces.anormParsers}.${t.name}.parser("${union.originalName}")"""
+              case p: ScalaPrimitive if isBasicType(p) => generateRowParser(s""""${union.originalName}"""", t.datatype, union.originalName) + s""".map(${t.ssd.namespaces.models}.${className(union, p)}.apply)"""
+              case _ => s"""${t.ssd.namespaces.anormParsers}.${t.name}.parser()"""
+            }
           }.mkString(" |\n").indent(2),
           "}"
         ).mkString("\n").indent(2),


### PR DESCRIPTION
An example of the produced code changes can be seen here:
https://github.com/apicollective/apibuilder/compare/add-filetype?expand=1

This commit captures a few things:
1. The implementation of parser() and parserWithPrefix() was broken for union
   types that mixed in primitive datatypes. It expected, say, Integer, to have
   an existing parser - which it did not. This commit fixes that by calling
   `SqlParser.___` for the type, then marshaling it into the model for that
   part of the union.
2. I _think_ union types should be using the union's name, *not* the sub-type's
   name - this commit uses the union name now.
3. There was a bug in parserWithPrefix for enums, where is was essentially using
   `"name"` instead of `s"$name"`.
4. #2 necessitated a move of the prefix logic down into the `parser()` methods.
   There is some logic here that makes a distinction between Enum and Model; in
   the former, we should be using the union's name (per #2 above); in the latter
   we should continue using the individual property names. As such, parserWithPrefix
   can't own the entire prefix logic.