### PR TITLE
Fix http4s client error response class does not compile

### DIFF
--- a/scala-generator/src/main/scala/models/generator/ScalaClientMethodConfig.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientMethodConfig.scala
@@ -174,6 +174,8 @@ private lazy val defaultAsyncHttpClient = {
     override val responseClass = "org.http4s.Response"
     override val extraClientCtorArgs = Some(",\n  asyncHttpClient: org.http4s.client.Client = Client.defaultAsyncHttpClient")
     override val extraClientObjectMethods = Some("""
+implicit def circeJsonDecoder[A](implicit decoder: io.circe.Decoder[A]) = org.http4s.circe.jsonOf[A]
+
 private lazy val defaultAsyncHttpClient = PooledHttp1Client()
 """)
     override val canSerializeUuid = true

--- a/scala-generator/src/main/scala/models/http4s/Http4sClient.scala
+++ b/scala-generator/src/main/scala/models/http4s/Http4sClient.scala
@@ -28,8 +28,6 @@ ${headers.objectConstants.indent(2)}
 
 ${Http4sScalaClientCommon.clientSignature(config).indent(2)} {
     import org.http4s.Response
-    implicit def circeJsonDecoder[A](implicit decoder: io.circe.Decoder[A]) = org.http4s.circe.jsonOf[A]
-    implicit def circeJsonEncoder[A](implicit encoder: io.circe.Encoder[A]) = org.http4s.circe.jsonEncoderOf[A]
     import ${config.asyncType}
 ${JsonImports(form.service).mkString("\n").indent(4)}
 
@@ -49,6 +47,8 @@ ${headerString.indent(6)}
 
     def modifyRequest(request: Task[org.http4s.Request]): Task[org.http4s.Request] = request
 
+    implicit def circeJsonEncoder[A](implicit encoder: io.circe.Encoder[A]) = org.http4s.circe.jsonEncoderOf[A]
+
     def _executeRequest[T, U](
       method: String,
       path: Seq[String],
@@ -56,7 +56,7 @@ ${headerString.indent(6)}
       requestHeaders: Seq[(String, String)] = Nil,
       body: Option[T] = None
     )(handler: Response => Task[U]
-    )(implicit encoder: org.http4s.EntityEncoder[T]): Task[U] = {
+    )(implicit encoder: io.circe.Encoder[T]): Task[U] = {
       import org.http4s.QueryParamEncoder._
 
       val m = org.http4s.Method.fromString(method) match {

--- a/scala-generator/src/main/scala/models/http4s/Http4sScalaClientCommon.scala
+++ b/scala-generator/src/main/scala/models/http4s/Http4sScalaClientCommon.scala
@@ -23,7 +23,7 @@ object Http4sScalaClientCommon extends ScalaClientCommon {
         |  def parseJson[T](
         |    className: String,
         |    r: ${config.responseClass}
-        |  )(implicit decoder: org.http4s.EntityDecoder[T]): Task[T] = r.attemptAs[T].${http4sConfig.monadTransformerInvoke}.flatMap {
+        |  )(implicit decoder: io.circe.Decoder[T]): Task[T] = r.attemptAs[T].${http4sConfig.monadTransformerInvoke}.flatMap {
         |    case ${http4sConfig.rightType}(value) => Task.now(value)
         |    case ${http4sConfig.leftType}(error) => Task.fail(new ${Namespaces(config.namespace).errors}.FailedRequest(r.${config.responseStatusMethod}, s"Invalid json for class[" + className + "]", None, error))
         |  }


### PR DESCRIPTION
Push down conversion from circe en/decoder to http4s entityEn/Decode to inside _executeRequest and parseJson.