### PR TITLE
Converted procedures to methods

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -351,7 +351,7 @@ package io.apibuilder.example.union.types.v0 {
     import org.slf4j.{Logger, LoggerFactory}
     import io.apibuilder.example.union.types.v0.models.json._
 
-    def closeAsyncHttpClient() {
+    def closeAsyncHttpClient(): Unit = {
       asyncHttpClient.close()
     }
 
@@ -393,7 +393,7 @@ package io.apibuilder.example.union.types.v0 {
       }
     }
 
-    def _logRequest(request: Request) {
+    def _logRequest(request: Request): Unit = {
       logger.info("_logRequest: " + request)
     }
 

--- a/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
@@ -124,7 +124,7 @@ package com.gilt.test.v0 {
     import org.slf4j.{Logger, LoggerFactory}
     import com.gilt.test.v0.models.json._
 
-    def closeAsyncHttpClient() {
+    def closeAsyncHttpClient(): Unit = {
       asyncHttpClient.close()
     }
 
@@ -168,7 +168,7 @@ package com.gilt.test.v0 {
       }
     }
 
-    def _logRequest(request: Request) {
+    def _logRequest(request: Request): Unit = {
       logger.info("_logRequest: " + request)
     }
 

--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -414,7 +414,7 @@ package io.apibuilder.reference.api.v0 {
     import org.slf4j.{Logger, LoggerFactory}
     import io.apibuilder.reference.api.v0.models.json._
 
-    def closeAsyncHttpClient() {
+    def closeAsyncHttpClient(): Unit = {
       asyncHttpClient.close()
     }
 
@@ -647,7 +647,7 @@ package io.apibuilder.reference.api.v0 {
       }
     }
 
-    def _logRequest(request: Request) {
+    def _logRequest(request: Request): Unit = {
       logger.info("_logRequest: " + request)
     }
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -416,7 +416,7 @@ package io.apibuilder.reference.api.v0 {
     import io.apibuilder.reference.api.v0.models.json._
     import io.apibuilder.spec.v0.models.json._
 
-    def closeAsyncHttpClient() {
+    def closeAsyncHttpClient(): Unit = {
       asyncHttpClient.close()
     }
 
@@ -649,7 +649,7 @@ package io.apibuilder.reference.api.v0 {
       }
     }
 
-    def _logRequest(request: Request) {
+    def _logRequest(request: Request): Unit = {
       logger.info("_logRequest: " + request)
     }
 

--- a/lib/src/test/scala/TestHelper.scala
+++ b/lib/src/test/scala/TestHelper.scala
@@ -38,7 +38,7 @@ object TestHelper extends Matchers {
     }
   }
 
-  def writeToFile(path: String, contents: String) {
+  def writeToFile(path: String, contents: String): Unit = {
     val outputPath = Paths.get(path)
     val bytes = contents.getBytes(StandardCharsets.UTF_8)
     Files.write(outputPath, bytes)
@@ -100,7 +100,7 @@ object TestHelper extends Matchers {
     reporter.errorCount shouldBe 0
   }
 
-  def assertEqualsFile(filename: String, contents: String) {
+  def assertEqualsFile(filename: String, contents: String): Unit = {
     val actualPath = resolvePath(filename)
     val current = readFile(actualPath).trim
     if (current != contents.trim) {

--- a/lib/src/test/scala/VersionTagSpec.scala
+++ b/lib/src/test/scala/VersionTagSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.{FunSpec, Matchers}
 
 class VersionTagSpec extends FunSpec with Matchers {
 
-  def assertSorted(versions: Seq[String], target: String) {
+  def assertSorted(versions: Seq[String], target: String): Unit = {
     val versionObjects = versions.map( VersionTag(_) )
     versionObjects.sorted.map(_.version).mkString(" ") should be(target)
   }

--- a/scala-generator/src/main/scala/models/generator/anorm/ParserGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/anorm/ParserGenerator.scala
@@ -170,7 +170,7 @@ object ParserGenerator extends CodeGenerator {
       generateRowParser(field.name, field.datatype, field.originalName)
     }
 
-    private[this] def addImports(ns: Namespaces) {
+    private[this] def addImports(ns: Namespaces): Unit = {
       requiredImports += s"import ${ns.anormConversions}.Types._"
     }
 
@@ -178,7 +178,7 @@ object ParserGenerator extends CodeGenerator {
       * Recursively adds anorm parser imports for any
       * datatype that is from an imported application.
       */
-    private[this] def addImports(datatype: ScalaDatatype) {
+    private[this] def addImports(datatype: ScalaDatatype): Unit = {
       datatype match {
         case ScalaPrimitive.Boolean | ScalaPrimitive.Double | ScalaPrimitive.Integer | ScalaPrimitive.Long | ScalaPrimitive.DateIso8601Joda | ScalaPrimitive.DateIso8601Java | ScalaPrimitive.DateTimeIso8601Joda | ScalaPrimitive.DateTimeIso8601Java | ScalaPrimitive.Decimal | ScalaPrimitive.ObjectAsPlay | ScalaPrimitive.ObjectAsCirce | ScalaPrimitive.String | ScalaPrimitive.Unit | ScalaPrimitive.Uuid => {
           // no-op

--- a/scala-generator/src/main/scala/models/http4s/Http4sClient.scala
+++ b/scala-generator/src/main/scala/models/http4s/Http4sClient.scala
@@ -33,7 +33,7 @@ ${Http4sScalaClientCommon.clientSignature(config).indent(2)} {
     import ${config.asyncType}
 ${JsonImports(form.service).mkString("\n").indent(4)}
 
-    def closeAsyncHttpClient() {
+    def closeAsyncHttpClient(): Unit = {
       asyncHttpClient.shutdownNow()
     }
 

--- a/scala-generator/src/main/scala/models/ning/NingClientGenerator.scala
+++ b/scala-generator/src/main/scala/models/ning/NingClientGenerator.scala
@@ -77,7 +77,7 @@ ${PlayScalaClientCommon.clientSignature(config).indent(2)} {
     import org.slf4j.{Logger, LoggerFactory}
 ${JsonImports(form.service).mkString("\n").indent(4)}
 
-    def closeAsyncHttpClient() {
+    def closeAsyncHttpClient(): Unit = {
       asyncHttpClient.close()
     }
 
@@ -87,7 +87,7 @@ ${methodGenerator.accessors().indent(4)}
 
 ${methodGenerator.objects().indent(4)}
 
-    def _logRequest(request: Request) {
+    def _logRequest(request: Request): Unit = {
       logger.info("_logRequest: " + request)
     }
 


### PR DESCRIPTION
`scalac` flag `-deprecation` highlights the following error in the generated code:
```
Procedure syntax is deprecated. Convert procedure `XXX` to method by adding `: Unit =`.
```