### PR TITLE
[Ruby] Fix serialization of union types with primitives

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -77,7 +77,7 @@ package io.apibuilder.example.union.types.v0.models {
    * Wrapper class to support the union types containing the datatype[uuid]
    */
   case class UserUuid(
-    value: _root_.java.util.UUID
+    uuid: _root_.java.util.UUID
   ) extends User
 
   sealed trait Bar extends Foobar
@@ -267,7 +267,7 @@ package io.apibuilder.example.union.types.v0.models {
     }
 
     implicit def jsonReadsApidocExampleUnionTypesUserUuid: play.api.libs.json.Reads[UserUuid] = {
-      (__ \ "value").read[_root_.java.util.UUID].map { x => new UserUuid(value = x) }
+      (__ \ "uuid").read[_root_.java.util.UUID].map { x => new UserUuid(uuid = x) }
     }
 
     implicit def jsonReadsApidocExampleUnionTypesFoobar: play.api.libs.json.Reads[Foobar] = {

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -77,7 +77,7 @@ package io.apibuilder.example.union.types.v0.models {
    * Wrapper class to support the union types containing the datatype[uuid]
    */
   case class UserUuid(
-    value: _root_.java.util.UUID
+    uuid: _root_.java.util.UUID
   ) extends User
 
   sealed trait Bar extends Foobar
@@ -267,7 +267,7 @@ package io.apibuilder.example.union.types.v0.models {
     }
 
     implicit def jsonReadsApidocExampleUnionTypesUserUuid: play.api.libs.json.Reads[UserUuid] = {
-      (__ \ "value").read[_root_.java.util.UUID].map { x => new UserUuid(value = x) }
+      (__ \ "uuid").read[_root_.java.util.UUID].map { x => new UserUuid(uuid = x) }
     }
 
     implicit def jsonReadsApidocExampleUnionTypesFoobar: play.api.libs.json.Reads[Foobar] = {

--- a/lib/src/test/resources/example-union-types-ruby-client.txt
+++ b/lib/src/test/resources/example-union-types-ruby-client.txt
@@ -113,9 +113,7 @@ module Io
                 end
 
                 def to_hash
-                  case @__discriminator__
-                  else { @__discriminator__ => subtype_to_hash }
-                  end
+                  { @__discriminator__ => subtype_to_hash }
                 end
 
                 def Foobar.from_json(hash)
@@ -378,7 +376,7 @@ module Io
 
                 def subtype_to_hash
                   {
-                    :uuid => value
+                    :value => value
                   }
                 end
 

--- a/lib/src/test/resources/example-union-types-ruby-client.txt
+++ b/lib/src/test/resources/example-union-types-ruby-client.txt
@@ -105,7 +105,7 @@ module Io
 
                 def initialize(incoming={})
                   opts = HttpClient::Helper.symbolize_keys(incoming)
-                  @__discriminator__ = 'foobar'
+                  @__discriminator__ = opts[:__discriminator__] ||'foobar'
                 end
 
                 def subtype_to_hash
@@ -113,7 +113,9 @@ module Io
                 end
 
                 def to_hash
-                  { @__discriminator__ => subtype_to_hash }
+                  case @__discriminator__
+                  else { @__discriminator__ => subtype_to_hash }
+                  end
                 end
 
                 def Foobar.from_json(hash)
@@ -221,7 +223,7 @@ module Io
                 attr_reader :value
 
                 def initialize(value)
-                  super(:name => Foobar::Types::BAR)
+                  super(:name => Foobar::Types::BAR, :__discriminator__ => 'bar')
                   @value = HttpClient::Preconditions.assert_class('value', value, String)
                 end
 
@@ -260,7 +262,7 @@ module Io
                 attr_reader :value
 
                 def initialize(value)
-                  super(:name => Foobar::Types::FOO)
+                  super(:name => Foobar::Types::FOO, :__discriminator__ => 'foo')
                   @value = HttpClient::Preconditions.assert_class('value', value, String)
                 end
 
@@ -376,7 +378,7 @@ module Io
 
                 def subtype_to_hash
                   {
-                    :value => value
+                    :uuid => value
                   }
                 end
 

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -60,7 +60,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
    * Wrapper class to support the union types containing the datatype[string]
    */
   case class UserString(
-    value: String
+    string: String
   ) extends User
 
   sealed trait SystemUser extends User
@@ -188,7 +188,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
     }
 
     implicit def jsonReadsApidocExampleUnionTypesDiscriminatorUserString: play.api.libs.json.Reads[UserString] = {
-      (__ \ "value").read[String].map { x => new UserString(value = x) }
+      (__ \ "string").read[String].map { x => new UserString(string = x) }
     }
 
     implicit def jsonReadsApidocExampleUnionTypesDiscriminatorUser: play.api.libs.json.Reads[User] = new play.api.libs.json.Reads[User] {

--- a/lib/src/test/scala/TestHelper.scala
+++ b/lib/src/test/scala/TestHelper.scala
@@ -108,7 +108,7 @@ object TestHelper extends Matchers {
 
       val expectedPath = "/tmp/apidoc.tmp.expected." + Text.safeName(filename)
       TestHelper.writeToFile(expectedPath, contents.trim)
-      TestHelper.writeToFile(actualPath, contents.trim)
+      // TestHelper.writeToFile(actualPath, contents.trim)
       
       val cmd = s"diff $expectedPath $actualPath"
       println(cmd)

--- a/lib/src/test/scala/TestHelper.scala
+++ b/lib/src/test/scala/TestHelper.scala
@@ -108,7 +108,7 @@ object TestHelper extends Matchers {
 
       val expectedPath = "/tmp/apidoc.tmp.expected." + Text.safeName(filename)
       TestHelper.writeToFile(expectedPath, contents.trim)
-      // TestHelper.writeToFile(actualPath, contents.trim)
+      TestHelper.writeToFile(actualPath, contents.trim)
       
       val cmd = s"diff $expectedPath $actualPath"
       println(cmd)

--- a/ruby-generator/src/main/scala/models/RubyClientGenerator.scala
+++ b/ruby-generator/src/main/scala/models/RubyClientGenerator.scala
@@ -698,13 +698,13 @@ ${headers.rubyModuleConstants.indent(2)}
       "def to_hash",
       union.discriminator match {
         case None => {
-          (
+          Seq(
             Seq(
               s"case $discName"
             ) ++ union.types.flatMap { ut =>
               Datatype.Primitive(ut.`type`) match {
-                case Failure(_) => Some(s"when Types::${RubyUtil.toUnionConstant(union, ut.`type`)}; subtype_to_hash")
-                case Success(_) => None
+                case Failure(_) => None
+                case Success(_) => Some(s"  when Types::${RubyUtil.toUnionConstant(union, ut.`type`)}; subtype_to_hash")
               }
             } ++ Seq(
               s"  else { @$discName => subtype_to_hash }",

--- a/ruby-generator/src/main/scala/models/RubyClientGenerator.scala
+++ b/ruby-generator/src/main/scala/models/RubyClientGenerator.scala
@@ -31,9 +31,9 @@ object RubyUtil {
     name: String
   ) {
 
-    val parts = name.split("\\.").map(toClassName(_))
+    val parts: Array[String] = name.split("\\.").map(toClassName(_))
 
-    val fullName = "::" + (parts.toList match {
+    val fullName: String = "::" + (parts.toList match {
       case Nil => sys.error(s"Invalid module name[$name]")
       case one :: Nil => parts.mkString("::")
       case one :: two :: Nil => parts.mkString("::")
@@ -1094,12 +1094,6 @@ ${headers.rubyModuleConstants.indent(2)}
       parseArgument(varName, varName, dt, None, false)
     }
 
-    val (assertStub, assertClass) = dt match {
-      case Datatype.Container.List(inner) => ("assert_collection_of_class", qualifiedClassName(inner.name))
-      case Datatype.Container.Map(inner) => ("assert_hash_of_class", qualifiedClassName(inner.name))
-      case _ => ("assert_class", klass)
-    }
-
     RubyTypeInfo(
       varName = varName,
       klass = klass,
@@ -1134,9 +1128,9 @@ ${headers.rubyModuleConstants.indent(2)}
         }
       }
       case t @ (UserDefined.Model(_) | UserDefined.Enum(_)) =>
-        s"${qualifiedClassName(t.name)}.new(${varName})"
+        s"${qualifiedClassName(t.name)}.new($varName)"
       case UserDefined.Union(name) =>
-        s"${qualifiedClassName(name)}.from_json(${varName})"
+        s"${qualifiedClassName(name)}.from_json($varName)"
       case Container.List(inner) =>
         s"$varName.map { |x| ${generateResponse(inner, "x")} }"
       case Container.Map(inner) =>

--- a/ruby-generator/src/main/scala/models/RubyClientGenerator.scala
+++ b/ruby-generator/src/main/scala/models/RubyClientGenerator.scala
@@ -700,7 +700,7 @@ ${headers.rubyModuleConstants.indent(2)}
         case None => {
           Seq(
             Seq(
-              s"case $discName"
+              s"  case @$discName"
             ) ++ union.types.flatMap { ut =>
               Datatype.Primitive(ut.`type`) match {
                 case Failure(_) => None
@@ -708,7 +708,7 @@ ${headers.rubyModuleConstants.indent(2)}
               }
             } ++ Seq(
               s"  else { @$discName => subtype_to_hash }",
-              "end"
+              "  end"
             )
           ).flatten.mkString("\n")
         }

--- a/scala-generator/src/main/scala/models/generator/PrimitiveWrapper.scala
+++ b/scala-generator/src/main/scala/models/generator/PrimitiveWrapper.scala
@@ -51,13 +51,13 @@ case class PrimitiveWrapper(ssd: ScalaService) {
         description = Some(s"Wrapper class to support the union types containing the datatype[${p.apidocType}]"),
         fields = Seq(
           Field(
-            name = PrimitiveWrapper.FieldName,
+            name = p.apidocType.toString,
             `type` = p.apidocType,
             required = true
           )
         )
       )
-      new Wrapper(
+      Wrapper(
         new ScalaModel(ssd, model),
         union
       )


### PR DESCRIPTION
{
     "code": {
       "integer": {
         "value": 200
       }
     }
    }