### PR TITLE
[Scala] Remove discriminator

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -7,11 +7,7 @@ package io.apibuilder.example.union.types.v0.models {
   sealed trait Foobar extends _root_.scala.Product with _root_.scala.Serializable
 
   @deprecated("to be removed")
-  sealed trait User extends _root_.scala.Product with _root_.scala.Serializable {
-
-    def discriminator: io.apibuilder.example.union.types.v0.models.UserDiscriminator
-
-  }
+  sealed trait User extends _root_.scala.Product with _root_.scala.Serializable
 
   /**
    * Defines the valid discriminator values for the type User
@@ -44,11 +40,7 @@ package io.apibuilder.example.union.types.v0.models {
   case class GuestUser(
     guid: _root_.java.util.UUID,
     email: String
-  ) extends User {
-
-    override val discriminator: io.apibuilder.example.union.types.v0.models.UserDiscriminator = io.apibuilder.example.union.types.v0.models.UserDiscriminator.GuestUser
-
-  }
+  ) extends User
 
   /**
    * @param guid Internal unique identifier for this user.
@@ -57,11 +49,7 @@ package io.apibuilder.example.union.types.v0.models {
     guid: _root_.java.util.UUID,
     email: String,
     preference: io.apibuilder.example.union.types.v0.models.Foobar
-  ) extends User {
-
-    override val discriminator: io.apibuilder.example.union.types.v0.models.UserDiscriminator = io.apibuilder.example.union.types.v0.models.UserDiscriminator.RegisteredUser
-
-  }
+  ) extends User
 
   /**
    * Provides future compatibility in clients - in the future, when a type is added
@@ -85,11 +73,7 @@ package io.apibuilder.example.union.types.v0.models {
    */
   case class UserUndefinedType(
     description: String
-  ) extends User {
-
-    override def discriminator: io.apibuilder.example.union.types.v0.models.UserDiscriminator = sys.error("Undefined type[UserUndefinedType]")
-
-  }
+  ) extends User
 
 
   /**
@@ -97,11 +81,7 @@ package io.apibuilder.example.union.types.v0.models {
    */
   case class UserUuid(
     value: _root_.java.util.UUID
-  ) extends User {
-
-    override val discriminator: io.apibuilder.example.union.types.v0.models.UserDiscriminator = io.apibuilder.example.union.types.v0.models.UserDiscriminator.UserUuid
-
-  }
+  ) extends User
 
   sealed trait Bar extends Foobar
 

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -7,11 +7,7 @@ package io.apibuilder.example.union.types.v0.models {
   sealed trait Foobar extends _root_.scala.Product with _root_.scala.Serializable
 
   @deprecated("to be removed")
-  sealed trait User extends _root_.scala.Product with _root_.scala.Serializable {
-
-    def discriminator: io.apibuilder.example.union.types.v0.models.UserDiscriminator
-
-  }
+  sealed trait User extends _root_.scala.Product with _root_.scala.Serializable
 
   /**
    * Defines the valid discriminator values for the type User
@@ -44,11 +40,7 @@ package io.apibuilder.example.union.types.v0.models {
   case class GuestUser(
     guid: _root_.java.util.UUID,
     email: String
-  ) extends User {
-
-    override val discriminator: io.apibuilder.example.union.types.v0.models.UserDiscriminator = io.apibuilder.example.union.types.v0.models.UserDiscriminator.GuestUser
-
-  }
+  ) extends User
 
   /**
    * @param guid Internal unique identifier for this user.
@@ -57,11 +49,7 @@ package io.apibuilder.example.union.types.v0.models {
     guid: _root_.java.util.UUID,
     email: String,
     preference: io.apibuilder.example.union.types.v0.models.Foobar
-  ) extends User {
-
-    override val discriminator: io.apibuilder.example.union.types.v0.models.UserDiscriminator = io.apibuilder.example.union.types.v0.models.UserDiscriminator.RegisteredUser
-
-  }
+  ) extends User
 
   /**
    * Provides future compatibility in clients - in the future, when a type is added
@@ -85,11 +73,7 @@ package io.apibuilder.example.union.types.v0.models {
    */
   case class UserUndefinedType(
     description: String
-  ) extends User {
-
-    override def discriminator: io.apibuilder.example.union.types.v0.models.UserDiscriminator = sys.error("Undefined type[UserUndefinedType]")
-
-  }
+  ) extends User
 
 
   /**
@@ -97,11 +81,7 @@ package io.apibuilder.example.union.types.v0.models {
    */
   case class UserUuid(
     value: _root_.java.util.UUID
-  ) extends User {
-
-    override val discriminator: io.apibuilder.example.union.types.v0.models.UserDiscriminator = io.apibuilder.example.union.types.v0.models.UserDiscriminator.UserUuid
-
-  }
+  ) extends User
 
   sealed trait Bar extends Foobar
 

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -4,11 +4,7 @@
  */
 package io.apibuilder.example.union.types.discriminator.v0.models {
 
-  sealed trait User extends _root_.scala.Product with _root_.scala.Serializable {
-
-    def discriminator: io.apibuilder.example.union.types.discriminator.v0.models.UserDiscriminator
-
-  }
+  sealed trait User extends _root_.scala.Product with _root_.scala.Serializable
 
   /**
    * Defines the valid discriminator values for the type User
@@ -40,20 +36,12 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
   case class GuestUser(
     id: String,
     email: _root_.scala.Option[String] = None
-  ) extends User {
-
-    override val discriminator: io.apibuilder.example.union.types.discriminator.v0.models.UserDiscriminator = io.apibuilder.example.union.types.discriminator.v0.models.UserDiscriminator.GuestUser
-
-  }
+  ) extends User
 
   case class RegisteredUser(
     id: String,
     email: String
-  ) extends User {
-
-    override val discriminator: io.apibuilder.example.union.types.discriminator.v0.models.UserDiscriminator = io.apibuilder.example.union.types.discriminator.v0.models.UserDiscriminator.RegisteredUser
-
-  }
+  ) extends User
 
   /**
    * Provides future compatibility in clients - in the future, when a type is added
@@ -65,11 +53,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
    */
   case class UserUndefinedType(
     description: String
-  ) extends User {
-
-    override def discriminator: io.apibuilder.example.union.types.discriminator.v0.models.UserDiscriminator = sys.error("Undefined type[UserUndefinedType]")
-
-  }
+  ) extends User
 
 
   /**
@@ -77,11 +61,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
    */
   case class UserString(
     value: String
-  ) extends User {
-
-    override val discriminator: io.apibuilder.example.union.types.discriminator.v0.models.UserDiscriminator = io.apibuilder.example.union.types.discriminator.v0.models.UserDiscriminator.UserString
-
-  }
+  ) extends User
 
   sealed trait SystemUser extends User
 

--- a/scala-generator/src/main/scala/models/generator/ScalaCaseClasses.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaCaseClasses.scala
@@ -78,24 +78,12 @@ trait ScalaCaseClasses extends CodeGenerator {
   def generateUnionTrait(union: ScalaUnion): String = {
     // TODO: handle primitive types
 
-    val declaration = s"sealed trait ${union.name} extends _root_.scala.Product with _root_.scala.Serializable"
-    val code = union.discriminator match {
-      case None => declaration
-      case Some(disc) => {
-        Seq(
-          s"$declaration {",
-          s"  def ${discriminatorMethodName(disc)}: ${union.ssd.namespaces.models}.${ScalaUnionDiscriminator(union).className}",
-          "}"
-        ).mkString("\n\n")
-      }
-    }
-
     Seq(
       ScalaUtil.deprecationString(union.deprecation).trim match {
         case "" => None
         case v => Some(v)
       },
-      Some(code)
+      Some(s"sealed trait ${union.name} extends _root_.scala.Product with _root_.scala.Serializable")
     ).flatten.mkString("\n")
   }
 
@@ -111,36 +99,14 @@ trait ScalaCaseClasses extends CodeGenerator {
   }
 
   def generateCaseClass(model: ScalaModel, unions: Seq[ScalaUnion]): String = {
-    val body = defineDiscriminators(model, unions).map { code => s" {\n\n$code\n\n}" }
     Seq(
       Some(ScalaUtil.deprecationString(model.deprecation).trim).filter(_.nonEmpty),
-      Some(s"case class ${model.name}(${model.argList.getOrElse("")})" + ScalaUtil.extendsClause(unions.map(_.name)).map(s => s" $s").getOrElse("") + body.getOrElse(""))
+      Some(s"case class ${model.name}(${model.argList.getOrElse("")})" + ScalaUtil.extendsClause(unions.map(_.name)).map(s => s" $s").getOrElse(""))
     ).flatten.mkString("\n")
-  }
-
-  private[this] def defineDiscriminators(model: ScalaModel, unions: Seq[ScalaUnion]): Option[String] = {
-    unions.flatMap { union =>
-      union.discriminator.map { disc =>
-        val base = s"${union.ssd.namespaces.models}.${ScalaUnionDiscriminator(union).className}"
-        if (union.undefinedType.shortName == model.name) {
-          s"""  override def ${discriminatorMethodName(disc)}: $base = sys.error("Undefined type[${model.name}]")"""
-        } else {
-          s"  override val ${discriminatorMethodName(disc)}: $base = $base.${model.name}"
-        }
-      }
-    }.toList match {
-      case Nil => None
-      case functions => {
-        Some(functions.mkString("\n\n"))
-      }
-    }
   }
 
   def generateEnum(ssd: ScalaService, enum: ScalaEnum): String = {
     ScalaEnums(ssd, enum).build()
   }
 
-  private[this] def discriminatorMethodName(disc: String): String = {
-    ScalaUtil.quoteNameIfKeyword(ScalaUtil.toVariable(disc))
-  }
 }


### PR DESCRIPTION
- Adding the discriminator creates a conflict for types that extend multiple
    unions with discriminators that have the same name
  - Consider re-adding once interfaces themselves are first class