### PR TITLE
rm troublesome import in http4s-circe gen /f non discriminator unions

### DIFF
--- a/lib/src/test/scala/TestHelper.scala
+++ b/lib/src/test/scala/TestHelper.scala
@@ -19,7 +19,9 @@ object TestHelper extends Matchers {
   lazy val referenceWithImportsApiService = parseFile(s"/examples/reference-with-imports.json")
   lazy val generatorApiService = parseFile(s"/examples/apidoc-generator.json")
   lazy val apidocApiService = parseFile(s"/examples/apidoc-api.json")
+
   lazy val generatorApiServiceWithUnionAndDescriminator = parseFile(s"/examples/apidoc-example-union-types-discriminator.json")
+  lazy val generatorApiServiceWithUnionWithoutDescriminator = parseFile(s"/examples/apidoc-example-union-types.json")
 
   def buildJson(json: String): String = {
     val specVersion = io.apibuilder.spec.v0.Constants.Version

--- a/scala-generator/src/main/scala/models/http4s/CirceJson.scala
+++ b/scala-generator/src/main/scala/models/http4s/CirceJson.scala
@@ -87,7 +87,6 @@ ${Seq(generateEnums(), generateModels(), generateUnions()).filter(!_.isEmpty).mk
   private[this] def decodersWithoutDiscriminator(union: ScalaUnion): String = {
     Seq(
       s"${implicitDecoderDef(union.name)} = Decoder.instance { c =>",
-      s"  import cats.implicits._",
       unionTypesWithNames(union).map { case (t, typeName) =>
         s"""c.get[$typeName]("${t.discriminatorName}") orElse"""
       }.mkString("\n").indent(2),

--- a/scala-generator/src/test/scala/models/http4s/Http4sClientGeneratorSpec.scala
+++ b/scala-generator/src/test/scala/models/http4s/Http4sClientGeneratorSpec.scala
@@ -74,8 +74,19 @@ class Http4sClientGeneratorSpec extends FunSpec with Matchers {
       val json = CirceJson(ssd)
       val scalaSourceCode = json.generate()
       assertValidScalaSourceCode(scalaSourceCode)
+
       scalaSourceCode should include ("decodeApidocExampleUnionTypesDiscriminatorUserString")
       scalaSourceCode should include ("encodeApidocExampleUnionTypesDiscriminatorUserString")
+    }
+
+    it("Circe generator produces valid json decoder for unions without descriminator") {
+      val service = models.TestHelper.generatorApiServiceWithUnionWithoutDescriminator
+      val ssd = new ScalaService(service)
+      val json = CirceJson(ssd)
+      val scalaSourceCode = json.generate()
+      assertValidScalaSourceCode(scalaSourceCode)
+
+      scalaSourceCode should not include ("import cats.implicits._")
     }
   }
 }


### PR DESCRIPTION
unable to find the library combination where this works/worked

tried 0.16 and 0.18 variants of library and client with and without the scala compiler flag from the cats readme to no avail.  moreover, the generators build and work in this regard without the removed import.  (there is an additional issue with the non-discriminator example since it does not include an encoder for the "PrimitiveWrapper" which I can address separately)

if intentional with what versions was this required?

_http4s 0.18_

```
> cat build.sbt
// from cats readme (doesn't seem to help)
scalacOptions += "-Ypartial-unification"

libraryDependencies ++= Seq(
  "org.http4s" %% "http4s-circe" % "0.18.0-M5",
  "org.http4s" %% "http4s-blaze-client" % "0.18.0-M5"
)

```


compile
```
> sbt compile
[info] Loading settings from plugins.sbt ...
[info] Loading global plugins from /mnt/sdcard/jars/sbt/1.0/plugins
[info] Loading project definition from /home/michael/src/apibuilder-fix/0.18/project
[info] Loading settings from build.sbt ...
[info] Set current project to root-0-18 (in build file:/home/michael/src/apibuilder-fix/0.18/)
[info] Executing in batch mode. For better performance use sbt's shell
[info] Compiling 1 Scala source to /home/michael/src/apibuilder-fix/0.18/target/scala-2.12/classes ...
[error] /home/michael/src/apibuilder-fix/0.18/BryzekApidocExampleUnionTypesV0Client.scala:225:65: type mismatch;
[error]  found   : io.circe.Decoder.Result[com.bryzek.apidoc.example.union.types.v0.models.Foo]
[error]     (which expands to)  scala.util.Either[io.circe.DecodingFailure,com.bryzek.apidoc.example.union.types.v0.models.Foo]
[error]  required: ?{def orElse(x$1: ? >: io.circe.Decoder.Result[com.bryzek.apidoc.example.union.types.v0.models.Bar]): ?}
[error]     (which expands to)  ?{def orElse(x$1: ? >: scala.util.Either[io.circe.DecodingFailure,com.bryzek.apidoc.example.union.types.v0.models.Bar]): ?}
[error] Note that implicit conversions are not applicable because they are ambiguous:
[error]  both method eitherOps in package json of type [A, B](e: Either[A,B])cats.syntax.EitherOps[A,B]
[error]  and method catsSyntaxEither in trait EitherSyntax of type [A, B](eab: Either[A,B])cats.syntax.EitherOps[A,B]
[error]  are possible conversion functions from io.circe.Decoder.Result[com.bryzek.apidoc.example.union.types.v0.models.Foo] to ?{def orElse(x$1: ? >: io.circe.Decoder.Result[com.bryzek.apidoc.example.union.types.v0.models.Bar]): ?}
[error]       c.get[com.bryzek.apidoc.example.union.types.v0.models.Foo]("foo") orElse
[error]                                                                 ^
[error] /home/michael/src/apibuilder-fix/0.18/BryzekApidocExampleUnionTypesV0Client.scala:225:73: value orElse is not a member of io.circe.Decoder.Result[com.bryzek.apidoc.example.union.types.v0.models.Foo]
[error]       c.get[com.bryzek.apidoc.example.union.types.v0.models.Foo]("foo") orElse
[error]                                                                         ^
[error] /home/michael/src/apibuilder-fix/0.18/BryzekApidocExampleUnionTypesV0Client.scala:238:76: type mismatch;
[error]  found   : io.circe.Decoder.Result[com.bryzek.apidoc.example.union.types.v0.models.RegisteredUser]
[error]     (which expands to)  scala.util.Either[io.circe.DecodingFailure,com.bryzek.apidoc.example.union.types.v0.models.RegisteredUser]
[error]  required: ?{def orElse(x$1: ? >: io.circe.Decoder.Result[com.bryzek.apidoc.example.union.types.v0.models.GuestUser]): ?}
[error]     (which expands to)  ?{def orElse(x$1: ? >: scala.util.Either[io.circe.DecodingFailure,com.bryzek.apidoc.example.union.types.v0.models.GuestUser]): ?}
[error] Note that implicit conversions are not applicable because they are ambiguous:
[error]  both method eitherOps in package json of type [A, B](e: Either[A,B])cats.syntax.EitherOps[A,B]
[error]  and method catsSyntaxEither in trait EitherSyntax of type [A, B](eab: Either[A,B])cats.syntax.EitherOps[A,B]
[error]  are possible conversion functions from io.circe.Decoder.Result[com.bryzek.apidoc.example.union.types.v0.models.RegisteredUser] to ?{def orElse(x$1: ? >: io.circe.Decoder.Result[com.bryzek.apidoc.example.union.types.v0.models.GuestUser]): ?}
[error]       c.get[com.bryzek.apidoc.example.union.types.v0.models.RegisteredUser]("registered_user") orElse
[error]                                                                            ^
[error] /home/michael/src/apibuilder-fix/0.18/BryzekApidocExampleUnionTypesV0Client.scala:238:96: value orElse is not a member of io.circe.Decoder.Result[com.bryzek.apidoc.example.union.types.v0.models.RegisteredUser]
[error]       c.get[com.bryzek.apidoc.example.union.types.v0.models.RegisteredUser]("registered_user") orElse
[error]                                                                                                ^
[error] /home/michael/src/apibuilder-fix/0.18/BryzekApidocExampleUnionTypesV0Client.scala:247:126: could not find implicit value for parameter encoder: io.circe.Encoder[com.bryzek.apidoc.example.union.types.v0.models.UserUuid]
[error]       case t: com.bryzek.apidoc.example.union.types.v0.models.UserUuid => Json.fromJsonObject(JsonObject.singleton("uuid", t.asJson))
[error]                                                                                                                              ^
[error] 5 errors found
[error] (compile:compileIncremental) Compilation failed
[error] Total time: 4 s, completed 29-Nov-2017 13:49:36
```

changes to generated file for successful compilation (first block separate issue to be addressed in follow up)

```
diff BryzekApidocExampleUnionTypesV0Client.scala.broken BryzekApidocExampleUnionTypesV0Client.scala
222a223,228
>     implicit def encodeApidocExampleUnionTypesUserUuid: Encoder[UserUuid] = Encoder.instance { t =>
>       Json.fromFields(Seq(
>         Some("value" -> t.asJson)
>       ).flatten)
>     }
> 
224d229
<       import cats.implicits._
237d241
<       import cats.implicits._
```