### PR TITLE
fix for http4s-circe clients with primitive union types

### DIFF
--- a/lib/src/test/scala/TestHelper.scala
+++ b/lib/src/test/scala/TestHelper.scala
@@ -19,6 +19,7 @@ object TestHelper extends Matchers {
   lazy val referenceWithImportsApiService = parseFile(s"/examples/reference-with-imports.json")
   lazy val generatorApiService = parseFile(s"/examples/apidoc-generator.json")
   lazy val apidocApiService = parseFile(s"/examples/apidoc-api.json")
+  lazy val generatorApiServiceWithUnionAndDescriminator = parseFile(s"/examples/apidoc-example-union-types-discriminator.json")
 
   def buildJson(json: String): String = {
     val specVersion = io.apibuilder.spec.v0.Constants.Version

--- a/scala-generator/src/main/scala/models/http4s/CirceJson.scala
+++ b/scala-generator/src/main/scala/models/http4s/CirceJson.scala
@@ -47,7 +47,7 @@ ${Seq(generateEnums(), generateModels(), generateUnions()).filter(!_.isEmpty).mk
   def generateModels(): String = {
     Seq(
       ssd.models.map(decodersAndEncoders(_)).mkString("\n\n"),
-      PrimitiveWrapper(ssd).wrappers.map(w => decoders(w.model)).mkString("\n\n")
+      PrimitiveWrapper(ssd).wrappers.map(w => decodersAndEncoders(w.model)).mkString("\n\n")
     ).filter(!_.trim.isEmpty).mkString("\n\n")
   }
 

--- a/scala-generator/src/test/scala/models/http4s/Http4sClientGeneratorSpec.scala
+++ b/scala-generator/src/test/scala/models/http4s/Http4sClientGeneratorSpec.scala
@@ -67,5 +67,15 @@ class Http4sClientGeneratorSpec extends FunSpec with Matchers {
       scalaSourceCode should include (".raiseError")
       scalaSourceCode should include (".pure")
     }
+
+    it("Circe generator handles primitive union types") {
+      val service = models.TestHelper.generatorApiServiceWithUnionAndDescriminator
+      val ssd = new ScalaService(service)
+      val json = CirceJson(ssd)
+      val scalaSourceCode = json.generate()
+      assertValidScalaSourceCode(scalaSourceCode)
+      scalaSourceCode should include ("decodeApidocExampleUnionTypesDiscriminatorUserString")
+      scalaSourceCode should include ("encodeApidocExampleUnionTypesDiscriminatorUserString")
+    }
   }
 }


### PR DESCRIPTION
by adding the encoder for these types.  the play json models
generator takes a bit of a different approach in general but
this seems to work okay.

this is a followup to #310.  here is the diff from that PR - the first block pertains to this fix.

```
diff BryzekApidocExampleUnionTypesV0Client.scala.broken BryzekApidocExampleUnionTypesV0Client.scala
222a223,228
>     implicit def encodeApidocExampleUnionTypesUserUuid: Encoder[UserUuid] = Encoder.instance { t =>
>       Json.fromFields(Seq(
>         Some("value" -> t.asJson)
>       ).flatten)
>     }
> 
224d229
<       import cats.implicits._
237d241
<       import cats.implicits._
```
