### PR TITLE
kotlin-generator: Fixes by HBC mobile team

### DIFF
--- a/android-generator/src/main/scala/models/generator/android/AndroidJavaUtil.scala
+++ b/android-generator/src/main/scala/models/generator/android/AndroidJavaUtil.scala
@@ -95,7 +95,7 @@ trait AndroidJavaUtil {
     "double" -> ClassName.get("java.lang","Double"),
     "integer" -> ClassName.get("java.lang", "Integer"),
     "long" -> ClassName.get("java.lang", "Long"),
-    "object" -> ClassName.get("java.util","Map"),
+    "object" -> ClassName.get("java.lang","Object"),
     "string" -> ClassName.get("java.lang","String"),
     "unit" -> ClassName.get("java.lang", "Void"),
     "uuid" -> ClassName.get("java.util","UUID")

--- a/android-generator/src/main/scala/models/generator/android/AndroidJavaUtil.scala
+++ b/android-generator/src/main/scala/models/generator/android/AndroidJavaUtil.scala
@@ -95,7 +95,7 @@ trait AndroidJavaUtil {
     "double" -> ClassName.get("java.lang","Double"),
     "integer" -> ClassName.get("java.lang", "Integer"),
     "long" -> ClassName.get("java.lang", "Long"),
-    "object" -> ClassName.get("java.lang","Object"),
+    "object" -> ClassName.get("java.util","Map"),
     "string" -> ClassName.get("java.lang","String"),
     "unit" -> ClassName.get("java.lang", "Void"),
     "uuid" -> ClassName.get("java.util","UUID")

--- a/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinGenerator.scala
+++ b/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinGenerator.scala
@@ -1,6 +1,6 @@
 package models.generator.kotlin
 
-import java.io.{IOException, StringWriter}
+import java.io.StringWriter
 
 import com.fasterxml.jackson.annotation._
 import com.fasterxml.jackson.databind.DeserializationFeature

--- a/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinGenerator.scala
+++ b/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinGenerator.scala
@@ -48,7 +48,7 @@ class KotlinGenerator
 
       allEnumValues.foreach(value => {
         val annotation = AnnotationSpec.builder(classOf[JsonProperty]).addMember("\"" + value.name + "\"")
-        builder.addEnumConstant(toEnumName(value.name), TypeSpec.anonymousClassBuilder(""""""" +  s"${value.name}" + """"""").addAnnotation(annotation.build()).build())
+        builder.addEnumConstant(toEnumName(value.name), TypeSpec.anonymousClassBuilder("\"" + value.name + "\"").addAnnotation(annotation.build()).build())
       })
 
       val nameField = "jsonProperty"

--- a/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinUtil.scala
+++ b/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinUtil.scala
@@ -150,7 +150,7 @@ trait KotlinUtil {
     "double" -> new ClassName("kotlin","Double"),
     "integer" -> new ClassName("kotlin", "Int"),
     "long" -> new ClassName("kotlin", "Long"),
-    "object" -> new ClassName("kotlin.collections","Map"),
+    "object" -> new ClassName("kotlin","Any"),
     "string" -> new ClassName("kotlin","String"),
     "unit" -> new ClassName("kotlin", "Unit"),
     "uuid" -> new ClassName("java.util","UUID")
@@ -195,7 +195,7 @@ trait KotlinUtil {
     if (input == undefinedEnumName) {
       input
     } else {
-      Text.snakeToCamelCase(Text.safeName(input.replaceAll("\\.", "_"))).capitalize
+      Text.safeName(input.replaceAll("\\.", "_")).toUpperCase
     }
   }
 


### PR DESCRIPTION
- bug fixes (object must serialize to Object, string to kotlin.String)
- Enums as all caps
- Enums need a toString so that Retrofit can serialize properly
- Added Kotlin nullability to resource params and model fields
- Models implement Serializable
- Models now have toJsonStirng() and fromJsonString()