### PR TITLE
Kotlin android generator: Added @JsonProperty so that Jackson can par…

### DIFF
--- a/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinGenerator.scala
+++ b/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinGenerator.scala
@@ -142,9 +142,15 @@ class KotlinGenerator
 
         val kotlinDataType = dataTypeFromField(field.`type`, modelsNameSpace)
 
+        val annotation = AnnotationSpec.builder(classOf[JsonProperty]).addMember("\"" + field.name + "\"")
         val constructorParameter = ParameterSpec.builder(fieldCamelCaseName, if(field.required) kotlinDataType.asNonNullable() else kotlinDataType.asNullable())
         constructorWithParams.addParameter(constructorParameter.build)
-        propSpecs.add(PropertySpec.builder(fieldCamelCaseName, if(field.required) kotlinDataType.asNonNullable() else kotlinDataType.asNullable()).initializer(fieldCamelCaseName).build())
+        propSpecs.add(
+          PropertySpec.builder(fieldCamelCaseName, if(field.required) kotlinDataType.asNonNullable() else kotlinDataType.asNullable())
+          .initializer(fieldCamelCaseName)
+          .addAnnotation(annotation.build())
+          .build()
+        )
       })
 
       builder.primaryConstructor(constructorWithParams.build).addProperties(propSpecs)


### PR DESCRIPTION
…se fields correctly

example model class:

data class TileImage(
        @JsonProperty("file_name")
        val fileName: String,
        @JsonProperty("base_url")
        val baseUrl: String,
        @JsonProperty("aspect_ratio")
        val aspectRatio: String
) : Serializable {
    ...
}