### PR TITLE
Optional handler for UNDEFINED enum - Example: logging, alerting, etc. Details...

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -110,7 +110,10 @@ package io.apibuilder.example.union.types.v0.models {
     private[this]
     val byName: Map[String, Bar] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): Bar = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): Bar = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[Bar] = byName.get(value.toLowerCase)
 
@@ -143,7 +146,10 @@ package io.apibuilder.example.union.types.v0.models {
     private[this]
     val byName: Map[String, Foo] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): Foo = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): Foo = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[Foo] = byName.get(value.toLowerCase)
 

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -110,7 +110,10 @@ package io.apibuilder.example.union.types.v0.models {
     private[this]
     val byName: Map[String, Bar] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): Bar = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): Bar = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[Bar] = byName.get(value.toLowerCase)
 
@@ -143,7 +146,10 @@ package io.apibuilder.example.union.types.v0.models {
     private[this]
     val byName: Map[String, Foo] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): Foo = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): Foo = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[Foo] = byName.get(value.toLowerCase)
 

--- a/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
+++ b/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
@@ -370,7 +370,10 @@ package com.gilt.quality.v0.models {
     private[this]
     val byName: Map[String, ExternalServiceName] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): ExternalServiceName = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): ExternalServiceName = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[ExternalServiceName] = byName.get(value.toLowerCase)
 
@@ -430,7 +433,10 @@ package com.gilt.quality.v0.models {
     private[this]
     val byName: Map[String, Publication] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): Publication = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): Publication = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[Publication] = byName.get(value.toLowerCase)
 
@@ -465,7 +471,10 @@ package com.gilt.quality.v0.models {
     private[this]
     val byName: Map[String, Response] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): Response = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): Response = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[Response] = byName.get(value.toLowerCase)
 
@@ -499,7 +508,10 @@ package com.gilt.quality.v0.models {
     private[this]
     val byName: Map[String, Severity] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): Severity = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): Severity = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[Severity] = byName.get(value.toLowerCase)
 
@@ -543,7 +555,10 @@ package com.gilt.quality.v0.models {
     private[this]
     val byName: Map[String, Task] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): Task = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): Task = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[Task] = byName.get(value.toLowerCase)
 

--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -108,7 +108,10 @@ package io.apibuilder.reference.api.v0.models {
     private[this]
     val byName: Map[String, AgeGroup] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): AgeGroup = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): AgeGroup = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[AgeGroup] = byName.get(value.toLowerCase)
 

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -108,7 +108,10 @@ package io.apibuilder.reference.api.v0.models {
     private[this]
     val byName: Map[String, AgeGroup] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): AgeGroup = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): AgeGroup = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[AgeGroup] = byName.get(value.toLowerCase)
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -108,7 +108,10 @@ package io.apibuilder.reference.api.v0.models {
     private[this]
     val byName: Map[String, AgeGroup] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): AgeGroup = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): AgeGroup = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[AgeGroup] = byName.get(value.toLowerCase)
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -108,7 +108,10 @@ package io.apibuilder.reference.api.v0.models {
     private[this]
     val byName: Map[String, AgeGroup] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): AgeGroup = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): AgeGroup = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[AgeGroup] = byName.get(value.toLowerCase)
 

--- a/lib/src/test/resources/play2enums-example.txt
+++ b/lib/src/test/resources/play2enums-example.txt
@@ -26,7 +26,10 @@ object AgeGroup {
   private[this]
   val byName: Map[String, AgeGroup] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-  def apply(value: String): AgeGroup = fromString(value).getOrElse(UNDEFINED(value))
+  def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): AgeGroup = fromString(value).getOrElse {
+  	onUndefined(value)
+  	UNDEFINED(value)
+  }
 
   def fromString(value: String): _root_.scala.Option[AgeGroup] = byName.get(value.toLowerCase)
 
@@ -60,7 +63,10 @@ object Genre {
   private[this]
   val byName: Map[String, Genre] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-  def apply(value: String): Genre = fromString(value).getOrElse(UNDEFINED(value))
+  def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): Genre = fromString(value).getOrElse {
+  	onUndefined(value)
+  	UNDEFINED(value)
+  }
 
   def fromString(value: String): _root_.scala.Option[Genre] = byName.get(value.toLowerCase)
 

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -91,7 +91,10 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
     private[this]
     val byName: Map[String, SystemUser] = all.map(x => x.toString.toLowerCase -> x).toMap
 
-    def apply(value: String): SystemUser = fromString(value).getOrElse(UNDEFINED(value))
+    def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): SystemUser = fromString(value).getOrElse {
+    	onUndefined(value)
+    	UNDEFINED(value)
+    }
 
     def fromString(value: String): _root_.scala.Option[SystemUser] = byName.get(value.toLowerCase)
 

--- a/scala-generator/src/main/scala/models/generator/ScalaEnums.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaEnums.scala
@@ -46,7 +46,10 @@ case class UNDEFINED(override val toString: String) extends ${enum.name}
     s"val all: scala.List[${enum.name}] = scala.List(" + enum.values.map(_.name).mkString(", ") + ")\n\n" +
     s"private[this]\n" +
     s"val byName: Map[String, ${enum.name}] = all.map(x => x.toString.toLowerCase -> x).toMap\n\n" +
-    s"def apply(value: String): ${enum.name} = fromString(value).getOrElse(UNDEFINED(value))\n\n" +
+      s"def apply(value: String)(implicit onUndefined: String => Unit = _ => {}): ${enum.name} = fromString(value).getOrElse {\n" +
+      s"\tonUndefined(value)\n" +
+      s"\tUNDEFINED(value)\n" +
+      s"}\n\n" +
     s"def fromString(value: String): _root_.scala.Option[${enum.name}] = byName.get(value.toLowerCase)\n\n"
   }
 


### PR DESCRIPTION
Addresses the use case when persisting enum values as strings and then news up enum based on those values when enum was removed from API but persistence store was not updated to be in sync, which quietly results in UNDEFINED("removed_enum_string_here") that could potentially cause application errors or undesired behavior.