### PR TITLE
_executeRequest and http headers

### DIFF
--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -491,10 +491,7 @@ package io.apibuilder.example.union.types.v0 {
         case "DELETE" => loggedRequest.delete()
         case "HEAD" => loggedRequest.head()
         case "OPTIONS" => loggedRequest.options()
-        case _ => {
-          loggedRequest
-          sys.error("Unsupported method[%s]".format(method))
-        }
+        case _ => sys.error("Unsupported method[%s]".format(method))
       }
     }
 

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -478,30 +478,21 @@ package io.apibuilder.example.union.types.v0 {
       requestHeaders: Seq[(String, String)] = Nil,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
+      val requestHolder = _requestHolder(path)
+      val requestHolderHeaders = requestHolder.headers.keys.flatMap(key => requestHolder.headers(key).map(value => (key, value))).toSeq
+      val distinctHeaders = (requestHolderHeaders ++ requestHeaders).distinct
+      val loggedRequest = _logRequest(method.toUpperCase, requestHolder.withHeaders(_withJsonContentType(distinctHeaders): _*).withQueryString(queryParameters: _*)
+      )
       method.toUpperCase match {
-        case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
-        }
-        case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
-        }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
-        }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
-        }
+        case "GET" => loggedRequest.get()
+        case "POST" => loggedRequest.post(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PUT" => loggedRequest.put(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PATCH" => loggedRequest.patch(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "DELETE" => loggedRequest.delete()
+        case "HEAD" => loggedRequest.head()
+        case "OPTIONS" => loggedRequest.options()
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          loggedRequest
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
@@ -246,10 +246,7 @@ package com.gilt.test.v0 {
         case "DELETE" => loggedRequest.delete()
         case "HEAD" => loggedRequest.head()
         case "OPTIONS" => loggedRequest.options()
-        case _ => {
-          loggedRequest
-          sys.error("Unsupported method[%s]".format(method))
-        }
+        case _ => sys.error("Unsupported method[%s]".format(method))
       }
     }
 

--- a/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
@@ -233,30 +233,21 @@ package com.gilt.test.v0 {
       requestHeaders: Seq[(String, String)] = Nil,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
+      val requestHolder = _requestHolder(path)
+      val requestHolderHeaders = requestHolder.headers.keys.flatMap(key => requestHolder.headers(key).map(value => (key, value))).toSeq
+      val distinctHeaders = (requestHolderHeaders ++ requestHeaders).distinct
+      val loggedRequest = _logRequest(method.toUpperCase, requestHolder.withHeaders(_withJsonContentType(distinctHeaders): _*).withQueryString(queryParameters: _*)
+      )
       method.toUpperCase match {
-        case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
-        }
-        case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
-        }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
-        }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
-        }
+        case "GET" => loggedRequest.get()
+        case "POST" => loggedRequest.post(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PUT" => loggedRequest.put(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PATCH" => loggedRequest.patch(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "DELETE" => loggedRequest.delete()
+        case "HEAD" => loggedRequest.head()
+        case "OPTIONS" => loggedRequest.options()
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          loggedRequest
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/lib/src/test/resources/generators/play-22-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-22-built-in-types.txt
@@ -470,10 +470,7 @@ package apibuilder {
         case "DELETE" => loggedRequest.delete()
         case "HEAD" => loggedRequest.head()
         case "OPTIONS" => loggedRequest.options()
-        case _ => {
-          loggedRequest
-          sys.error("Unsupported method[%s]".format(method))
-        }
+        case _ => sys.error("Unsupported method[%s]".format(method))
       }
     }
 

--- a/lib/src/test/resources/generators/play-22-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-22-built-in-types.txt
@@ -457,30 +457,21 @@ package apibuilder {
       requestHeaders: Seq[(String, String)] = Nil,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.Response] = {
+      val requestHolder = _requestHolder(path)
+      val requestHolderHeaders = requestHolder.headers.keys.flatMap(key => requestHolder.headers(key).map(value => (key, value))).toSeq
+      val distinctHeaders = (requestHolderHeaders ++ requestHeaders).distinct
+      val loggedRequest = _logRequest(method.toUpperCase, requestHolder.withHeaders(_withJsonContentType(distinctHeaders): _*).withQueryString(queryParameters: _*)
+      )
       method.toUpperCase match {
-        case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
-        }
-        case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PATCH" => {
-          sys.error("PATCH method is not supported in Play Framework Version 2.2.x")
-        }
-        case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
-        }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
-        }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
-        }
+        case "GET" => loggedRequest.get()
+        case "POST" => loggedRequest.post(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PUT" => loggedRequest.put(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PATCH" => sys.error("PATCH method is not supported in Play Framework Version 2.2.x")
+        case "DELETE" => loggedRequest.delete()
+        case "HEAD" => loggedRequest.head()
+        case "OPTIONS" => loggedRequest.options()
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          loggedRequest
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/lib/src/test/resources/generators/play-23-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-23-built-in-types.txt
@@ -470,10 +470,7 @@ package apibuilder {
         case "DELETE" => loggedRequest.delete()
         case "HEAD" => loggedRequest.head()
         case "OPTIONS" => loggedRequest.options()
-        case _ => {
-          loggedRequest
-          sys.error("Unsupported method[%s]".format(method))
-        }
+        case _ => sys.error("Unsupported method[%s]".format(method))
       }
     }
 

--- a/lib/src/test/resources/generators/play-23-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-23-built-in-types.txt
@@ -457,30 +457,21 @@ package apibuilder {
       requestHeaders: Seq[(String, String)] = Nil,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
+      val requestHolder = _requestHolder(path)
+      val requestHolderHeaders = requestHolder.headers.keys.flatMap(key => requestHolder.headers(key).map(value => (key, value))).toSeq
+      val distinctHeaders = (requestHolderHeaders ++ requestHeaders).distinct
+      val loggedRequest = _logRequest(method.toUpperCase, requestHolder.withHeaders(_withJsonContentType(distinctHeaders): _*).withQueryString(queryParameters: _*)
+      )
       method.toUpperCase match {
-        case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
-        }
-        case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
-        }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
-        }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
-        }
+        case "GET" => loggedRequest.get()
+        case "POST" => loggedRequest.post(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PUT" => loggedRequest.put(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PATCH" => loggedRequest.patch(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "DELETE" => loggedRequest.delete()
+        case "HEAD" => loggedRequest.head()
+        case "OPTIONS" => loggedRequest.options()
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          loggedRequest
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/lib/src/test/resources/generators/play-24-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-24-built-in-types.txt
@@ -470,10 +470,7 @@ package apibuilder {
         case "DELETE" => loggedRequest.delete()
         case "HEAD" => loggedRequest.head()
         case "OPTIONS" => loggedRequest.options()
-        case _ => {
-          loggedRequest
-          sys.error("Unsupported method[%s]".format(method))
-        }
+        case _ => sys.error("Unsupported method[%s]".format(method))
       }
     }
 

--- a/lib/src/test/resources/generators/play-24-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-24-built-in-types.txt
@@ -457,30 +457,21 @@ package apibuilder {
       requestHeaders: Seq[(String, String)] = Nil,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
+      val requestHolder = _requestHolder(path)
+      val requestHolderHeaders = requestHolder.headers.keys.flatMap(key => requestHolder.headers(key).map(value => (key, value))).toSeq
+      val distinctHeaders = (requestHolderHeaders ++ requestHeaders).distinct
+      val loggedRequest = _logRequest(method.toUpperCase, requestHolder.withHeaders(_withJsonContentType(distinctHeaders): _*).withQueryString(queryParameters: _*)
+      )
       method.toUpperCase match {
-        case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
-        }
-        case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
-        }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
-        }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
-        }
+        case "GET" => loggedRequest.get()
+        case "POST" => loggedRequest.post(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PUT" => loggedRequest.put(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PATCH" => loggedRequest.patch(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "DELETE" => loggedRequest.delete()
+        case "HEAD" => loggedRequest.head()
+        case "OPTIONS" => loggedRequest.options()
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          loggedRequest
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/lib/src/test/resources/generators/play-25-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-25-built-in-types.txt
@@ -470,10 +470,7 @@ package apibuilder {
         case "DELETE" => loggedRequest.delete()
         case "HEAD" => loggedRequest.head()
         case "OPTIONS" => loggedRequest.options()
-        case _ => {
-          loggedRequest
-          sys.error("Unsupported method[%s]".format(method))
-        }
+        case _ => sys.error("Unsupported method[%s]".format(method))
       }
     }
 

--- a/lib/src/test/resources/generators/play-25-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-25-built-in-types.txt
@@ -457,30 +457,21 @@ package apibuilder {
       requestHeaders: Seq[(String, String)] = Nil,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
+      val requestHolder = _requestHolder(path)
+      val requestHolderHeaders = requestHolder.headers.keys.flatMap(key => requestHolder.headers(key).map(value => (key, value))).toSeq
+      val distinctHeaders = (requestHolderHeaders ++ requestHeaders).distinct
+      val loggedRequest = _logRequest(method.toUpperCase, requestHolder.withHeaders(_withJsonContentType(distinctHeaders): _*).withQueryString(queryParameters: _*)
+      )
       method.toUpperCase match {
-        case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
-        }
-        case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
-        }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
-        }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
-        }
+        case "GET" => loggedRequest.get()
+        case "POST" => loggedRequest.post(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PUT" => loggedRequest.put(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PATCH" => loggedRequest.patch(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "DELETE" => loggedRequest.delete()
+        case "HEAD" => loggedRequest.head()
+        case "OPTIONS" => loggedRequest.options()
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          loggedRequest
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/lib/src/test/resources/generators/play-26-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-26-built-in-types.txt
@@ -457,30 +457,21 @@ package apibuilder {
       requestHeaders: Seq[(String, String)] = Nil,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
+      val requestHolder = _requestHolder(path)
+      val requestHolderHeaders = requestHolder.headers.keys.flatMap(key => requestHolder.headers(key).map(value => (key, value))).toSeq
+      val distinctHeaders = (requestHolderHeaders ++ requestHeaders).distinct
+      val loggedRequest = _logRequest(method.toUpperCase, requestHolder.withHttpHeaders(_withJsonContentType(distinctHeaders): _*).withQueryStringParameters(queryParameters: _*)
+      )
       method.toUpperCase match {
-        case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHttpHeaders(requestHeaders:_*).withQueryStringParameters(queryParameters:_*)).get()
-        }
-        case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHttpHeaders(_withJsonContentType(requestHeaders):_*).withQueryStringParameters(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHttpHeaders(_withJsonContentType(requestHeaders):_*).withQueryStringParameters(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHttpHeaders(requestHeaders:_*).withQueryStringParameters(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHttpHeaders(requestHeaders:_*).withQueryStringParameters(queryParameters:_*)).delete()
-        }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHttpHeaders(requestHeaders:_*).withQueryStringParameters(queryParameters:_*)).head()
-        }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHttpHeaders(requestHeaders:_*).withQueryStringParameters(queryParameters:_*)).options()
-        }
+        case "GET" => loggedRequest.get()
+        case "POST" => loggedRequest.post(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PUT" => loggedRequest.put(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PATCH" => loggedRequest.patch(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "DELETE" => loggedRequest.delete()
+        case "HEAD" => loggedRequest.head()
+        case "OPTIONS" => loggedRequest.options()
         case _ => {
-          _logRequest(method, _requestHolder(path).withHttpHeaders(requestHeaders:_*).withQueryStringParameters(queryParameters:_*))
+          loggedRequest
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/lib/src/test/resources/generators/play-26-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-26-built-in-types.txt
@@ -470,10 +470,7 @@ package apibuilder {
         case "DELETE" => loggedRequest.delete()
         case "HEAD" => loggedRequest.head()
         case "OPTIONS" => loggedRequest.options()
-        case _ => {
-          loggedRequest
-          sys.error("Unsupported method[%s]".format(method))
-        }
+        case _ => sys.error("Unsupported method[%s]".format(method))
       }
     }
 

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -731,10 +731,7 @@ package io.apibuilder.reference.api.v0 {
         case "DELETE" => loggedRequest.delete()
         case "HEAD" => loggedRequest.head()
         case "OPTIONS" => loggedRequest.options()
-        case _ => {
-          loggedRequest
-          sys.error("Unsupported method[%s]".format(method))
-        }
+        case _ => sys.error("Unsupported method[%s]".format(method))
       }
     }
 

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -718,30 +718,21 @@ package io.apibuilder.reference.api.v0 {
       requestHeaders: Seq[(String, String)] = Nil,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
+      val requestHolder = _requestHolder(path)
+      val requestHolderHeaders = requestHolder.headers.keys.flatMap(key => requestHolder.headers(key).map(value => (key, value))).toSeq
+      val distinctHeaders = (requestHolderHeaders ++ requestHeaders).distinct
+      val loggedRequest = _logRequest(method.toUpperCase, requestHolder.withHeaders(_withJsonContentType(distinctHeaders): _*).withQueryString(queryParameters: _*)
+      )
       method.toUpperCase match {
-        case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
-        }
-        case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
-        }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
-        }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
-        }
+        case "GET" => loggedRequest.get()
+        case "POST" => loggedRequest.post(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PUT" => loggedRequest.put(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PATCH" => loggedRequest.patch(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "DELETE" => loggedRequest.delete()
+        case "HEAD" => loggedRequest.head()
+        case "OPTIONS" => loggedRequest.options()
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          loggedRequest
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -733,10 +733,7 @@ package io.apibuilder.reference.api.v0 {
         case "DELETE" => loggedRequest.delete()
         case "HEAD" => loggedRequest.head()
         case "OPTIONS" => loggedRequest.options()
-        case _ => {
-          loggedRequest
-          sys.error("Unsupported method[%s]".format(method))
-        }
+        case _ => sys.error("Unsupported method[%s]".format(method))
       }
     }
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -720,30 +720,21 @@ package io.apibuilder.reference.api.v0 {
       requestHeaders: Seq[(String, String)] = Nil,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
+      val requestHolder = _requestHolder(path)
+      val requestHolderHeaders = requestHolder.headers.keys.flatMap(key => requestHolder.headers(key).map(value => (key, value))).toSeq
+      val distinctHeaders = (requestHolderHeaders ++ requestHeaders).distinct
+      val loggedRequest = _logRequest(method.toUpperCase, requestHolder.withHeaders(_withJsonContentType(distinctHeaders): _*).withQueryString(queryParameters: _*)
+      )
       method.toUpperCase match {
-        case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
-        }
-        case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
-        }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
-        }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
-        }
+        case "GET" => loggedRequest.get()
+        case "POST" => loggedRequest.post(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PUT" => loggedRequest.put(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PATCH" => loggedRequest.patch(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "DELETE" => loggedRequest.delete()
+        case "HEAD" => loggedRequest.head()
+        case "OPTIONS" => loggedRequest.options()
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          loggedRequest
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -374,10 +374,7 @@ package io.apibuilder.example.union.types.discriminator.v0 {
         case "DELETE" => loggedRequest.delete()
         case "HEAD" => loggedRequest.head()
         case "OPTIONS" => loggedRequest.options()
-        case _ => {
-          loggedRequest
-          sys.error("Unsupported method[%s]".format(method))
-        }
+        case _ => sys.error("Unsupported method[%s]".format(method))
       }
     }
 

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -361,30 +361,21 @@ package io.apibuilder.example.union.types.discriminator.v0 {
       requestHeaders: Seq[(String, String)] = Nil,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
+      val requestHolder = _requestHolder(path)
+      val requestHolderHeaders = requestHolder.headers.keys.flatMap(key => requestHolder.headers(key).map(value => (key, value))).toSeq
+      val distinctHeaders = (requestHolderHeaders ++ requestHeaders).distinct
+      val loggedRequest = _logRequest(method.toUpperCase, requestHolder.withHeaders(_withJsonContentType(distinctHeaders): _*).withQueryString(queryParameters: _*)
+      )
       method.toUpperCase match {
-        case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
-        }
-        case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
-        }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
-        }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
-        }
+        case "GET" => loggedRequest.get()
+        case "POST" => loggedRequest.post(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PUT" => loggedRequest.put(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PATCH" => loggedRequest.patch(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "DELETE" => loggedRequest.delete()
+        case "HEAD" => loggedRequest.head()
+        case "OPTIONS" => loggedRequest.options()
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          loggedRequest
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/scala-generator/src/main/scala/models/Play2ClientGenerator.scala
+++ b/scala-generator/src/main/scala/models/Play2ClientGenerator.scala
@@ -209,10 +209,7 @@ ${if (version.config.expectsInjectedWsClient) "" else "      import play.api.Pla
         case "DELETE" => loggedRequest.delete()
         case "HEAD" => loggedRequest.head()
         case "OPTIONS" => loggedRequest.options()
-        case _ => {
-          loggedRequest
-          sys.error("Unsupported method[%s]".format(method))
-        }
+        case _ => sys.error("Unsupported method[%s]".format(method))
       }
     }
 

--- a/scala-generator/src/main/scala/models/Play2ClientGenerator.scala
+++ b/scala-generator/src/main/scala/models/Play2ClientGenerator.scala
@@ -142,7 +142,7 @@ case class Play2ClientGenerator(
     }
 
     val patchMethod = version.supportsHttpPatch match {
-      case true => s"""_logRequest("PATCH", _requestHolder(path).$withHeadersMethod(requestHeaders:_*).$withQueryStringMethod(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))"""
+      case true => s"""loggedRequest.patch(body.getOrElse(play.api.libs.json.Json.obj()))"""
       case false => s"""sys.error("PATCH method is not supported in Play Framework Version ${version.name}")"""
     }
 
@@ -196,30 +196,21 @@ ${if (version.config.expectsInjectedWsClient) "" else "      import play.api.Pla
       requestHeaders: Seq[(String, String)] = Nil,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[${version.config.responseClass}] = {
+      val requestHolder = _requestHolder(path)
+      val requestHolderHeaders = requestHolder.headers.keys.flatMap(key => requestHolder.headers(key).map(value => (key, value))).toSeq
+      val distinctHeaders = (requestHolderHeaders ++ requestHeaders).distinct
+      val loggedRequest = _logRequest(method.toUpperCase, requestHolder.$withHeadersMethod(_withJsonContentType(distinctHeaders): _*).$withQueryStringMethod(queryParameters: _*)
+      )
       method.toUpperCase match {
-        case "GET" => {
-          _logRequest("GET", _requestHolder(path).$withHeadersMethod(requestHeaders:_*).$withQueryStringMethod(queryParameters:_*)).get()
-        }
-        case "POST" => {
-          _logRequest("POST", _requestHolder(path).$withHeadersMethod(_withJsonContentType(requestHeaders):_*).$withQueryStringMethod(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).$withHeadersMethod(_withJsonContentType(requestHeaders):_*).$withQueryStringMethod(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
-        }
-        case "PATCH" => {
-          $patchMethod
-        }
-        case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).$withHeadersMethod(requestHeaders:_*).$withQueryStringMethod(queryParameters:_*)).delete()
-        }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).$withHeadersMethod(requestHeaders:_*).$withQueryStringMethod(queryParameters:_*)).head()
-        }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).$withHeadersMethod(requestHeaders:_*).$withQueryStringMethod(queryParameters:_*)).options()
-        }
+        case "GET" => loggedRequest.get()
+        case "POST" => loggedRequest.post(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PUT" => loggedRequest.put(body.getOrElse(play.api.libs.json.Json.obj()))
+        case "PATCH" => $patchMethod
+        case "DELETE" => loggedRequest.delete()
+        case "HEAD" => loggedRequest.head()
+        case "OPTIONS" => loggedRequest.options()
         case _ => {
-          _logRequest(method, _requestHolder(path).$withHeadersMethod(requestHeaders:_*).$withQueryStringMethod(queryParameters:_*))
+          loggedRequest
           sys.error("Unsupported method[%s]".format(method))
         }
       }


### PR DESCRIPTION
StandaloneAhcWSRequest.withHttpHeaders method overrides headers. 
This fix is to 
1) preserve both **requestHeaders** and **_reguestHolder's defaultHeaders**, which are set on Client creation 
2) remove duplicate code from _executeRequest method