### PR TITLE
Remove : from default headers

### DIFF
--- a/go-generator/src/main/scala/models/Headers.scala
+++ b/go-generator/src/main/scala/models/Headers.scala
@@ -17,7 +17,7 @@ case class Headers(
 
   private[this] val constants = Seq(
     form.service.baseUrl.map { url => ("BaseUrl" -> url) },
-    Some("UserAgent", form.userAgent.getOrElse("apidoc:go_1_5_client:unknown")),
+    Some("UserAgent", form.userAgent.getOrElse("apibuilder-go_1_5_client-unknown")),
     Some("Version", form.service.version),
     versionMajor.map { major => (VersionMajorName, major.toString) }
   ).flatten

--- a/lib/src/test/resources/example-response-with-unit-type.txt
+++ b/lib/src/test/resources/example-response-with-unit-type.txt
@@ -21,7 +21,7 @@ module Io
         module Constants
 
           NAMESPACE = 'io.apibuilder.test' unless defined?(Constants::NAMESPACE)
-          USER_AGENT = 'apidoc:play_2x_client:unknown' unless defined?(Constants::USER_AGENT)
+          USER_AGENT = 'apibuilder-play_2x_client-unknown' unless defined?(Constants::USER_AGENT)
           VERSION = '0.0.1-dev' unless defined?(Constants::VERSION)
           VERSION_MAJOR = 0 unless defined?(VERSION_MAJOR)
 

--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -352,7 +352,7 @@ package io.apibuilder.example.union.types.v0 {
   object Constants {
 
     val Namespace = "io.apibuilder.example.union.types.v0"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.3.46"
     val VersionMajor = 0
 

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -403,7 +403,7 @@ package io.apibuilder.example.union.types.v0 {
   object Constants {
 
     val Namespace = "io.apibuilder.example.union.types.v0"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.3.46"
     val VersionMajor = 0
 

--- a/lib/src/test/resources/example-union-types-ruby-client.txt
+++ b/lib/src/test/resources/example-union-types-ruby-client.txt
@@ -24,7 +24,7 @@ module Io
               module Constants
 
                 NAMESPACE = 'io.apibuilder.example.union.types.v0' unless defined?(Constants::NAMESPACE)
-                USER_AGENT = 'apidoc:play_2x_client:unknown' unless defined?(Constants::USER_AGENT)
+                USER_AGENT = 'apibuilder-play_2x_client-unknown' unless defined?(Constants::USER_AGENT)
                 VERSION = '0.3.46' unless defined?(Constants::VERSION)
                 VERSION_MAJOR = 0 unless defined?(VERSION_MAJOR)
 

--- a/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
@@ -123,7 +123,7 @@ package com.gilt.test.v0 {
   object Constants {
 
     val Namespace = "com.gilt.test.v0"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.0.1-dev"
     val VersionMajor = 0
 

--- a/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
@@ -154,7 +154,7 @@ package com.gilt.test.v0 {
   object Constants {
 
     val Namespace = "com.gilt.test.v0"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.0.1-dev"
     val VersionMajor = 0
 

--- a/lib/src/test/resources/generators/play-22-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-22-built-in-types.txt
@@ -366,7 +366,7 @@ package apibuilder {
   object Constants {
 
     val Namespace = "apibuilder"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.0.1-dev"
     val VersionMajor = 0
 

--- a/lib/src/test/resources/generators/play-23-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-23-built-in-types.txt
@@ -366,7 +366,7 @@ package apibuilder {
   object Constants {
 
     val Namespace = "apibuilder"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.0.1-dev"
     val VersionMajor = 0
 

--- a/lib/src/test/resources/generators/play-24-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-24-built-in-types.txt
@@ -366,7 +366,7 @@ package apibuilder {
   object Constants {
 
     val Namespace = "apibuilder"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.0.1-dev"
     val VersionMajor = 0
 

--- a/lib/src/test/resources/generators/play-25-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-25-built-in-types.txt
@@ -366,7 +366,7 @@ package apibuilder {
   object Constants {
 
     val Namespace = "apibuilder"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.0.1-dev"
     val VersionMajor = 0
 

--- a/lib/src/test/resources/generators/play-26-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-26-built-in-types.txt
@@ -366,7 +366,7 @@ package apibuilder {
   object Constants {
 
     val Namespace = "apibuilder"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.0.1-dev"
     val VersionMajor = 0
 

--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -412,7 +412,7 @@ package io.apibuilder.reference.api.v0 {
 
     val BaseUrl = "http://localhost:9000"
     val Namespace = "io.apibuilder.reference.api.v0"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.3.47"
     val VersionMajor = 0
 

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -452,7 +452,7 @@ package io.apibuilder.reference.api.v0 {
 
     val BaseUrl = "http://localhost:9000"
     val Namespace = "io.apibuilder.reference.api.v0"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.3.47"
     val VersionMajor = 0
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -413,7 +413,7 @@ package io.apibuilder.reference.api.v0 {
 
     val BaseUrl = "http://localhost:9000"
     val Namespace = "io.apibuilder.reference.api.v0"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.3.47"
     val VersionMajor = 0
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -453,7 +453,7 @@ package io.apibuilder.reference.api.v0 {
 
     val BaseUrl = "http://localhost:9000"
     val Namespace = "io.apibuilder.reference.api.v0"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.3.47"
     val VersionMajor = 0
 

--- a/lib/src/test/resources/generators/ruby-built-in-types.txt
+++ b/lib/src/test/resources/generators/ruby-built-in-types.txt
@@ -19,7 +19,7 @@ module Apibuilder
     module Constants
 
       NAMESPACE = 'apibuilder' unless defined?(Constants::NAMESPACE)
-      USER_AGENT = 'apidoc:play_2x_client:unknown' unless defined?(Constants::USER_AGENT)
+      USER_AGENT = 'apibuilder-play_2x_client-unknown' unless defined?(Constants::USER_AGENT)
       VERSION = '0.0.1-dev' unless defined?(Constants::VERSION)
       VERSION_MAJOR = 0 unless defined?(VERSION_MAJOR)
 

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -286,7 +286,7 @@ package io.apibuilder.example.union.types.discriminator.v0 {
   object Constants {
 
     val Namespace = "io.apibuilder.example.union.types.discriminator.v0"
-    val UserAgent = "apidoc:play_2x_client:unknown"
+    val UserAgent = "apibuilder-play_2x_client-unknown"
     val Version = "0.3.46"
     val VersionMajor = 0
 

--- a/lib/src/test/scala/TestHelper.scala
+++ b/lib/src/test/scala/TestHelper.scala
@@ -111,7 +111,7 @@ object TestHelper extends Matchers {
 
       val expectedPath = "/tmp/apidoc.tmp.expected." + Text.safeName(filename)
       TestHelper.writeToFile(expectedPath, contents.trim)
-      // TestHelper.writeToFile(actualPath, contents.trim)
+      TestHelper.writeToFile(actualPath, contents.trim)
       
       val cmd = s"diff $expectedPath $actualPath"
       println(cmd)

--- a/lib/src/test/scala/TestHelper.scala
+++ b/lib/src/test/scala/TestHelper.scala
@@ -111,7 +111,7 @@ object TestHelper extends Matchers {
 
       val expectedPath = "/tmp/apidoc.tmp.expected." + Text.safeName(filename)
       TestHelper.writeToFile(expectedPath, contents.trim)
-      TestHelper.writeToFile(actualPath, contents.trim)
+      // TestHelper.writeToFile(actualPath, contents.trim)
       
       val cmd = s"diff $expectedPath $actualPath"
       println(cmd)

--- a/ruby-generator/src/main/scala/models/Headers.scala
+++ b/ruby-generator/src/main/scala/models/Headers.scala
@@ -16,7 +16,7 @@ case class Headers(
   private[this] val constants = Seq(
     form.service.baseUrl.map { url => ("BaseUrl", url) },
     Some("Namespace", form.service.namespace),
-    Some("UserAgent", form.userAgent.getOrElse("apidoc:play_2x_client:unknown")),
+    Some("UserAgent", form.userAgent.getOrElse("apibuilder-play_2x_client-unknown")),
     Some("Version", form.service.version),
     versionMajor.map { major => (VersionMajorName, major.toString) }
   ).flatten

--- a/scala-generator/src/main/scala/models/Headers.scala
+++ b/scala-generator/src/main/scala/models/Headers.scala
@@ -18,7 +18,7 @@ case class Headers(
   private[this] val constants = Seq(
     form.service.baseUrl.map { url => ("BaseUrl", url) },
     Some("Namespace", form.service.namespace),
-    Some("UserAgent", form.userAgent.getOrElse("apidoc:play_2x_client:unknown")),
+    Some("UserAgent", form.userAgent.getOrElse("apibuilder-play_2x_client-unknown")),
     Some("Version", form.service.version),
     versionMajor.map { major => (VersionMajorName, major.toString) }
   ).flatten


### PR DESCRIPTION
Fixes:
```
     Illegal header: Illegal 'user-agent' header: Invalid input ':', expected
    OWS, 'EOI', tchar, product-or-comment, comment or ws (line 1, column 11):
    apibuilder:0.12.87
    https://app.apibuilder.io/flow/api/0.4.14/ning_1_9_client
```