### PR TITLE
Moved error models to client class and removed effect

### DIFF
--- a/scala-generator/src/main/scala/models/generator/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientMethodGenerator.scala
@@ -94,7 +94,7 @@ class ScalaClientMethodGenerator(
     * all error return types. e.g. a 409 that returns Seq[Error] is
     * handled via these classes.
     */
-  private def modelErrorClasses(): Seq[String] = {
+  protected def modelErrorClasses(): Seq[String] = {
     ssd.resources.flatMap(_.operations).flatMap(_.responses).filter(r => !r.isSuccess).map { response =>
       errorTypeClass(response)
     }.distinct.sorted
@@ -126,7 +126,7 @@ class ScalaClientMethodGenerator(
     }
 
     Seq(
-      s"case class $className${config.asyncTypeParam(Some("Sync")).map(p =>s"[$p]").getOrElse("")}(",
+      s"case class $className(",
       s"  response: ${config.responseClass},",
       s"  message: Option[String] = None",
       s""") extends Exception(message.getOrElse(response.${config.responseStatusMethod} + ": " + response.${config.responseBodyMethod}))$bodyString"""

--- a/scala-generator/src/main/scala/models/http4s/Http4sClient.scala
+++ b/scala-generator/src/main/scala/models/http4s/Http4sClient.scala
@@ -85,7 +85,7 @@ ${headerString.indent(6)}
       val authBody = body.fold(${config.wrappedAsyncType("Sync").getOrElse(config.asyncType)}.${config.asyncSuccess}(authReq))(authReq.withBody)
 
       ${config.httpClient}.fetch(modifyRequest(authBody))(handler)
-    }
+    }${methodGenerator.modelErrors().indent(4)}
   }
 
 ${Http4sScalaClientCommon(config).indent(2)}

--- a/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
@@ -178,7 +178,7 @@ class ScalaClientMethodGenerator (
   def modelErrors(): String =
     config match {
       case _ @ (_:ScalaClientMethodConfigs.Http4s017 | _:ScalaClientMethodConfigs.Http4s015) => ""
-      case _ => s"\n\n${super.modelErrorClasses().mkString("\n\n")}"
+      case _ => s"\n\nobject errors{\n\n${super.modelErrorClasses().mkString("\n\n")}\n}"
     }
 
 }

--- a/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
@@ -3,6 +3,7 @@ package scala.models.http4s
 import io.apibuilder.spec.v0.models.{ResponseCodeInt, ResponseCodeOption, ResponseCodeUndefinedType}
 
 import scala.generator._
+import scala.models.JsonImports
 
 class ScalaClientMethodGenerator (
   config: ScalaClientMethodConfig,
@@ -167,6 +168,19 @@ class ScalaClientMethodGenerator (
 
     }
   }
+
+  override protected def modelErrorClasses(): Seq[String] =
+    config match {
+      case _ @ (_:ScalaClientMethodConfigs.Http4s017 | _:ScalaClientMethodConfigs.Http4s015) => super.modelErrorClasses()
+      case _ => Seq()
+    }
+
+  def modelErrors(): String =
+    config match {
+      case _ @ (_:ScalaClientMethodConfigs.Http4s017 | _:ScalaClientMethodConfigs.Http4s015) => ""
+      case _ => s"\n\n${super.modelErrorClasses().mkString("\n\n")}"
+    }
+
 }
 
 class ScalaClientMethod(

--- a/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
@@ -178,7 +178,7 @@ class ScalaClientMethodGenerator (
   def modelErrors(): String =
     config match {
       case _ @ (_:ScalaClientMethodConfigs.Http4s017 | _:ScalaClientMethodConfigs.Http4s015) => ""
-      case _ => s"\n\nobject errors{\n\n${super.modelErrorClasses().mkString("\n\n")}\n}"
+      case _ => s"\n\nobject errors {\n\n${super.modelErrorClasses().mkString("\n\n")}\n}"
     }
 
 }


### PR DESCRIPTION
As discussed in #353, it's better to move the error classes into the client in order to not have to specify the effect type when we do pattern matching.

This change breaks only the  **Http4s v0.18+** api