### PR TITLE
kotlin: using backport of java.time.Instant and java.time.LocalDate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,8 @@ lazy val kotlinGenerator = project
   .settings(
     libraryDependencies ++= Seq(
       "com.fasterxml.jackson.module" % "jackson-module-kotlin" % "2.9.3",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.9.3",
+      //"com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.9.3",
+      "org.threeten" % "threetenbp" % "1.3.6",
       "com.squareup" % "kotlinpoet" % "0.7.0",
       "com.squareup.retrofit2" % "retrofit" % "2.3.0",
       "org.jetbrains.kotlin" % "kotlin-compiler" % "1.2.30" % "test",

--- a/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinUtil.scala
+++ b/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinUtil.scala
@@ -144,8 +144,8 @@ trait KotlinUtil {
 
   val dataTypes = Map[String, TypeName](
     "boolean" -> new ClassName("kotlin", "Boolean"),
-    "date-iso8601" -> new ClassName("org.joda.time", "DateTime"),
-    "date-time-iso8601" -> new ClassName("org.joda.time", "DateTime"),
+    "date-iso8601" -> new ClassName("org.threeten.bp", "LocalDate"),
+    "date-time-iso8601" -> new ClassName("org.threeten.bp", "Instant"),
     "decimal" -> new ClassName("java.math","BigDecimal"),
     "double" -> new ClassName("kotlin","Double"),
     "integer" -> new ClassName("kotlin", "Int"),

--- a/kotlin-generator/src/test/scala/models/generator/kotlin/KotlinUtilTest.scala
+++ b/kotlin-generator/src/test/scala/models/generator/kotlin/KotlinUtilTest.scala
@@ -62,8 +62,8 @@ class KotlinUtilTest
     dataTypeFromField("boolean", "com.foobar.example").toString should be ("kotlin.Boolean")
     dataTypeFromField("long", "com.foobar.example").toString should be ("kotlin.Long")
     dataTypeFromField("uuid", "com.foobar.example").toString should be ("java.util.UUID")
-    dataTypeFromField("date-iso8601", "com.foobar.example").toString should be ("org.joda.time.DateTime")
-    dataTypeFromField("date-time-iso8601", "com.foobar.example").toString should be ("org.joda.time.DateTime")
+    dataTypeFromField("date-iso8601", "com.foobar.example").toString should be ("org.threeten.bp.LocalDate")
+    dataTypeFromField("date-time-iso8601", "com.foobar.example").toString should be ("org.threeten.bp.Instant")
   }
 
   "isModelNameWithPackage" should "return correctly" in {
@@ -83,7 +83,8 @@ class KotlinUtilTest
 
   it should "handle maps" in {
     dataTypeFromField("map[long]", "com.foobar.example").toString should be ("kotlin.collections.Map<kotlin.String, kotlin.Long>")
-    dataTypeFromField("map[date-time-iso8601]", "com.foobar.example").toString should be ("kotlin.collections.Map<kotlin.String, org.joda.time.DateTime>")
+    dataTypeFromField("map[date-time-iso8601]", "com.foobar.example").toString should be ("kotlin.collections.Map<kotlin.String, org.threeten.bp.Instant>")
+    dataTypeFromField("map[date-iso8601]", "com.foobar.example").toString should be ("kotlin.collections.Map<kotlin.String, org.threeten.bp.LocalDate>")
     dataTypeFromField("map[string]", "com.foobar.example").toString should be ("kotlin.collections.Map<kotlin.String, kotlin.String>")
     dataTypeFromField("map[CustomType]", "com.foobar.example").toString should be ("kotlin.collections.Map<kotlin.String, com.foobar.example.CustomType>")
   }


### PR DESCRIPTION
Seems that we're all switching from jodatime to java.time  

`java.time.Instant` and `java.time.LocalDate` work natively on Android 8+, but not on older versions.  It'll be a few years before we can use java.time natively, until then we'll use backport: `org.threeten.bp.Instant` and `org.threeten.bp.LocalDate`

