### PR TITLE
Http4s server returns 400 when X-Apidoc-Version-Major header is not p…

### DIFF
--- a/lib/src/test/resources/http4s/form-params-017.txt
+++ b/lib/src/test/resources/http4s/form-params-017.txt
@@ -108,7 +108,7 @@ trait ModelRoutes {
             responseOpt.getOrElse(BadRequest())
       }
     }
-    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+    case _req @ POST -> Root / "test" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/form-params-017.txt
+++ b/lib/src/test/resources/http4s/form-params-017.txt
@@ -108,5 +108,7 @@ trait ModelRoutes {
             responseOpt.getOrElse(BadRequest())
       }
     }
+    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/form-params-018.txt
+++ b/lib/src/test/resources/http4s/form-params-018.txt
@@ -107,5 +107,7 @@ trait ModelRoutes[F[_]] extends Matchers[F] {
             responseOpt.getOrElse(BadRequest())
       }
     }
+    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/form-params-018.txt
+++ b/lib/src/test/resources/http4s/form-params-018.txt
@@ -107,7 +107,7 @@ trait ModelRoutes[F[_]] extends Matchers[F] {
             responseOpt.getOrElse(BadRequest())
       }
     }
-    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+    case _req @ POST -> Root / "test" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/imported-types-017.txt
+++ b/lib/src/test/resources/http4s/imported-types-017.txt
@@ -133,32 +133,42 @@ trait ModelRoutes {
       getPathEnumLocalById(_req, id).flatMap {
         case GetPathEnumLocalByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "path-enum-local" / EnumVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "path-enum-imported" / IoApibuilderHttp4sImportedModelsEnumVal(id) if apiVersionMatch(_req) =>
       getPathEnumImportedById(_req, id).flatMap {
         case GetPathEnumImportedByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "path-enum-imported" / IoApibuilderHttp4sImportedModelsEnumVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "query-enum-local" :? IdEnumMatcher(id) if apiVersionMatch(_req) =>
       getQueryEnumLocal(_req, id).flatMap {
         case GetQueryEnumLocalResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "query-enum-local" :? IdEnumMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "query-enum-imported" :? IdIoApibuilderHttp4sImportedModelsEnumMatcher(id) if apiVersionMatch(_req) =>
       getQueryEnumImported(_req, id).flatMap {
         case GetQueryEnumImportedResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "query-enum-imported" :? IdIoApibuilderHttp4sImportedModelsEnumMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "query-model-local" :? IdModelMatcher(id) if apiVersionMatch(_req) =>
       getQueryModelLocal(_req, id).flatMap {
         case GetQueryModelLocalResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "query-model-local" :? IdModelMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "query-model-imported" :? IdIoApibuilderHttp4sImportedModelsModelMatcher(id) if apiVersionMatch(_req) =>
       getQueryModelImported(_req, id).flatMap {
         case GetQueryModelImportedResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
-    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+    case _req @ GET -> Root / "query-model-imported" :? IdIoApibuilderHttp4sImportedModelsModelMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/imported-types-017.txt
+++ b/lib/src/test/resources/http4s/imported-types-017.txt
@@ -158,5 +158,7 @@ trait ModelRoutes {
       getQueryModelImported(_req, id).flatMap {
         case GetQueryModelImportedResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/imported-types-018.txt
+++ b/lib/src/test/resources/http4s/imported-types-018.txt
@@ -157,5 +157,7 @@ trait ModelRoutes[F[_]] extends Matchers[F] {
       getQueryModelImported(_req, id).flatMap {
         case GetQueryModelImportedResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/imported-types-018.txt
+++ b/lib/src/test/resources/http4s/imported-types-018.txt
@@ -132,32 +132,42 @@ trait ModelRoutes[F[_]] extends Matchers[F] {
       getPathEnumLocalById(_req, id).flatMap {
         case GetPathEnumLocalByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "path-enum-local" / EnumVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "path-enum-imported" / IoApibuilderHttp4sImportedModelsEnumVal(id) if apiVersionMatch(_req) =>
       getPathEnumImportedById(_req, id).flatMap {
         case GetPathEnumImportedByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "path-enum-imported" / IoApibuilderHttp4sImportedModelsEnumVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "query-enum-local" :? IdEnumMatcher(id) if apiVersionMatch(_req) =>
       getQueryEnumLocal(_req, id).flatMap {
         case GetQueryEnumLocalResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "query-enum-local" :? IdEnumMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "query-enum-imported" :? IdIoApibuilderHttp4sImportedModelsEnumMatcher(id) if apiVersionMatch(_req) =>
       getQueryEnumImported(_req, id).flatMap {
         case GetQueryEnumImportedResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "query-enum-imported" :? IdIoApibuilderHttp4sImportedModelsEnumMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "query-model-local" :? IdModelMatcher(id) if apiVersionMatch(_req) =>
       getQueryModelLocal(_req, id).flatMap {
         case GetQueryModelLocalResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "query-model-local" :? IdModelMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "query-model-imported" :? IdIoApibuilderHttp4sImportedModelsModelMatcher(id) if apiVersionMatch(_req) =>
       getQueryModelImported(_req, id).flatMap {
         case GetQueryModelImportedResponse.HTTP200(headers) => Ok(headers: _*)
       }
-    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+    case _req @ GET -> Root / "query-model-imported" :? IdIoApibuilderHttp4sImportedModelsModelMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/path-params-015.txt
+++ b/lib/src/test/resources/http4s/path-params-015.txt
@@ -381,127 +381,175 @@ trait ModelRoutes {
       getStringById(_req, id).flatMap {
         case GetStringByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "string" / id if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "named_string" / named_id if apiVersionMatch(_req) =>
       getNamedStringByNamedId(_req, named_id).flatMap {
         case GetNamedStringByNamedIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "named_string" / named_id if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_min" / String10Val(id) if apiVersionMatch(_req) =>
       getStringWithMinById(_req, id).flatMap {
         case GetStringWithMinByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_min" / String10Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_max" / StringTo10Val(id) if apiVersionMatch(_req) =>
       getStringWithMaxById(_req, id).flatMap {
         case GetStringWithMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_max" / StringTo10Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_min_and_max" / String10To30Val(id) if apiVersionMatch(_req) =>
       getStringWithMinAndMaxById(_req, id).flatMap {
         case GetStringWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_min_and_max" / String10To30Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "int" / IntVal(id) if apiVersionMatch(_req) =>
       getIntById(_req, id).flatMap {
         case GetIntByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "int" / IntVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "int_with_min_and_max" / Int10To30Val(id) if apiVersionMatch(_req) =>
       getIntWithMinAndMaxById(_req, id).flatMap {
         case GetIntWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "int_with_min_and_max" / Int10To30Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "long" / LongVal(id) if apiVersionMatch(_req) =>
       getLongById(_req, id).flatMap {
         case GetLongByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "long" / LongVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "long_with_min_and_max" / Long10To30Val(id) if apiVersionMatch(_req) =>
       getLongWithMinAndMaxById(_req, id).flatMap {
         case GetLongWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "long_with_min_and_max" / Long10To30Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "boolean" / BooleanVal(id) if apiVersionMatch(_req) =>
       getBooleanById(_req, id).flatMap {
         case GetBooleanByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "boolean" / BooleanVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "boolean_with_min_and_max" / BooleanVal(id) if apiVersionMatch(_req) =>
       getBooleanWithMinAndMaxById(_req, id).flatMap {
         case GetBooleanWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "boolean_with_min_and_max" / BooleanVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "double" / DoubleVal(id) if apiVersionMatch(_req) =>
       getDoubleById(_req, id).flatMap {
         case GetDoubleByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "double" / DoubleVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "double_with_min_and_max" / DoubleVal(id) if apiVersionMatch(_req) =>
       getDoubleWithMinAndMaxById(_req, id).flatMap {
         case GetDoubleWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "double_with_min_and_max" / DoubleVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "decimal" / BigDecimalVal(id) if apiVersionMatch(_req) =>
       getDecimalById(_req, id).flatMap {
         case GetDecimalByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "decimal" / BigDecimalVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "decimal_with_min_and_max" / BigDecimalVal(id) if apiVersionMatch(_req) =>
       getDecimalWithMinAndMaxById(_req, id).flatMap {
         case GetDecimalWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "decimal_with_min_and_max" / BigDecimalVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "date" / LocalDateVal(id) if apiVersionMatch(_req) =>
       getDateById(_req, id).flatMap {
         case GetDateByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "date" / LocalDateVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "date_with_min_and_max" / LocalDateVal(id) if apiVersionMatch(_req) =>
       getDateWithMinAndMaxById(_req, id).flatMap {
         case GetDateWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "date_with_min_and_max" / LocalDateVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "datetime" / InstantVal(id) if apiVersionMatch(_req) =>
       getDatetimeById(_req, id).flatMap {
         case GetDatetimeByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "datetime" / InstantVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "datetime_with_min_and_max" / InstantVal(id) if apiVersionMatch(_req) =>
       getDatetimeWithMinAndMaxById(_req, id).flatMap {
         case GetDatetimeWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "datetime_with_min_and_max" / InstantVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "uuid" / UUIDVal(id) if apiVersionMatch(_req) =>
       getUuidById(_req, id).flatMap {
         case GetUuidByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "uuid" / UUIDVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "uuid_with_min_and_max" / UUIDVal(id) if apiVersionMatch(_req) =>
       getUuidWithMinAndMaxById(_req, id).flatMap {
         case GetUuidWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "uuid_with_min_and_max" / UUIDVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "enum" / EnumVal(id) if apiVersionMatch(_req) =>
       getEnumById(_req, id).flatMap {
         case GetEnumByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "enum" / EnumVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "named_enum" / EnumVal(named_id) if apiVersionMatch(_req) =>
       getNamedEnumByNamedId(_req, named_id).flatMap {
         case GetNamedEnumByNamedIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "named_enum" / EnumVal(named_id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "enum_with_min_and_max" / EnumVal(id) if apiVersionMatch(_req) =>
       getEnumWithMinAndMaxById(_req, id).flatMap {
         case GetEnumWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "enum_with_min_and_max" / EnumVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "invalid" / ModelVal(id) if apiVersionMatch(_req) =>
       getInvalidById(_req, id).flatMap {
         case GetInvalidByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
-    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+    case _req @ GET -> Root / "invalid" / ModelVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/path-params-015.txt
+++ b/lib/src/test/resources/http4s/path-params-015.txt
@@ -501,5 +501,7 @@ trait ModelRoutes {
       getInvalidById(_req, id).flatMap {
         case GetInvalidByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/path-params-017.txt
+++ b/lib/src/test/resources/http4s/path-params-017.txt
@@ -381,127 +381,175 @@ trait ModelRoutes {
       getStringById(_req, id).flatMap {
         case GetStringByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "string" / id if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "named_string" / named_id if apiVersionMatch(_req) =>
       getNamedStringByNamedId(_req, named_id).flatMap {
         case GetNamedStringByNamedIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "named_string" / named_id if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_min" / String10Val(id) if apiVersionMatch(_req) =>
       getStringWithMinById(_req, id).flatMap {
         case GetStringWithMinByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_min" / String10Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_max" / StringTo10Val(id) if apiVersionMatch(_req) =>
       getStringWithMaxById(_req, id).flatMap {
         case GetStringWithMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_max" / StringTo10Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_min_and_max" / String10To30Val(id) if apiVersionMatch(_req) =>
       getStringWithMinAndMaxById(_req, id).flatMap {
         case GetStringWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_min_and_max" / String10To30Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "int" / IntVal(id) if apiVersionMatch(_req) =>
       getIntById(_req, id).flatMap {
         case GetIntByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "int" / IntVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "int_with_min_and_max" / Int10To30Val(id) if apiVersionMatch(_req) =>
       getIntWithMinAndMaxById(_req, id).flatMap {
         case GetIntWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "int_with_min_and_max" / Int10To30Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "long" / LongVal(id) if apiVersionMatch(_req) =>
       getLongById(_req, id).flatMap {
         case GetLongByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "long" / LongVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "long_with_min_and_max" / Long10To30Val(id) if apiVersionMatch(_req) =>
       getLongWithMinAndMaxById(_req, id).flatMap {
         case GetLongWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "long_with_min_and_max" / Long10To30Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "boolean" / BooleanVal(id) if apiVersionMatch(_req) =>
       getBooleanById(_req, id).flatMap {
         case GetBooleanByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "boolean" / BooleanVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "boolean_with_min_and_max" / BooleanVal(id) if apiVersionMatch(_req) =>
       getBooleanWithMinAndMaxById(_req, id).flatMap {
         case GetBooleanWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "boolean_with_min_and_max" / BooleanVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "double" / DoubleVal(id) if apiVersionMatch(_req) =>
       getDoubleById(_req, id).flatMap {
         case GetDoubleByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "double" / DoubleVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "double_with_min_and_max" / DoubleVal(id) if apiVersionMatch(_req) =>
       getDoubleWithMinAndMaxById(_req, id).flatMap {
         case GetDoubleWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "double_with_min_and_max" / DoubleVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "decimal" / BigDecimalVal(id) if apiVersionMatch(_req) =>
       getDecimalById(_req, id).flatMap {
         case GetDecimalByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "decimal" / BigDecimalVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "decimal_with_min_and_max" / BigDecimalVal(id) if apiVersionMatch(_req) =>
       getDecimalWithMinAndMaxById(_req, id).flatMap {
         case GetDecimalWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "decimal_with_min_and_max" / BigDecimalVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "date" / LocalDateVal(id) if apiVersionMatch(_req) =>
       getDateById(_req, id).flatMap {
         case GetDateByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "date" / LocalDateVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "date_with_min_and_max" / LocalDateVal(id) if apiVersionMatch(_req) =>
       getDateWithMinAndMaxById(_req, id).flatMap {
         case GetDateWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "date_with_min_and_max" / LocalDateVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "datetime" / InstantVal(id) if apiVersionMatch(_req) =>
       getDatetimeById(_req, id).flatMap {
         case GetDatetimeByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "datetime" / InstantVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "datetime_with_min_and_max" / InstantVal(id) if apiVersionMatch(_req) =>
       getDatetimeWithMinAndMaxById(_req, id).flatMap {
         case GetDatetimeWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "datetime_with_min_and_max" / InstantVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "uuid" / UUIDVal(id) if apiVersionMatch(_req) =>
       getUuidById(_req, id).flatMap {
         case GetUuidByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "uuid" / UUIDVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "uuid_with_min_and_max" / UUIDVal(id) if apiVersionMatch(_req) =>
       getUuidWithMinAndMaxById(_req, id).flatMap {
         case GetUuidWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "uuid_with_min_and_max" / UUIDVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "enum" / EnumVal(id) if apiVersionMatch(_req) =>
       getEnumById(_req, id).flatMap {
         case GetEnumByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "enum" / EnumVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "named_enum" / EnumVal(named_id) if apiVersionMatch(_req) =>
       getNamedEnumByNamedId(_req, named_id).flatMap {
         case GetNamedEnumByNamedIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "named_enum" / EnumVal(named_id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "enum_with_min_and_max" / EnumVal(id) if apiVersionMatch(_req) =>
       getEnumWithMinAndMaxById(_req, id).flatMap {
         case GetEnumWithMinAndMaxByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "enum_with_min_and_max" / EnumVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "invalid" / ModelVal(id) if apiVersionMatch(_req) =>
       getInvalidById(_req, id).flatMap {
         case GetInvalidByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
-    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+    case _req @ GET -> Root / "invalid" / ModelVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/path-params-017.txt
+++ b/lib/src/test/resources/http4s/path-params-017.txt
@@ -501,5 +501,7 @@ trait ModelRoutes {
       getInvalidById(_req, id).flatMap {
         case GetInvalidByIdResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/path-params-018.txt
+++ b/lib/src/test/resources/http4s/path-params-018.txt
@@ -380,127 +380,175 @@ trait ModelRoutes[F[_]] extends Matchers[F] {
       getStringById(_req, id).flatMap {
         case GetStringByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "string" / id if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "named_string" / named_id if apiVersionMatch(_req) =>
       getNamedStringByNamedId(_req, named_id).flatMap {
         case GetNamedStringByNamedIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "named_string" / named_id if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_min" / String10Val(id) if apiVersionMatch(_req) =>
       getStringWithMinById(_req, id).flatMap {
         case GetStringWithMinByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_min" / String10Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_max" / StringTo10Val(id) if apiVersionMatch(_req) =>
       getStringWithMaxById(_req, id).flatMap {
         case GetStringWithMaxByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_max" / StringTo10Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_min_and_max" / String10To30Val(id) if apiVersionMatch(_req) =>
       getStringWithMinAndMaxById(_req, id).flatMap {
         case GetStringWithMinAndMaxByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_min_and_max" / String10To30Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "int" / IntVal(id) if apiVersionMatch(_req) =>
       getIntById(_req, id).flatMap {
         case GetIntByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "int" / IntVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "int_with_min_and_max" / Int10To30Val(id) if apiVersionMatch(_req) =>
       getIntWithMinAndMaxById(_req, id).flatMap {
         case GetIntWithMinAndMaxByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "int_with_min_and_max" / Int10To30Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "long" / LongVal(id) if apiVersionMatch(_req) =>
       getLongById(_req, id).flatMap {
         case GetLongByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "long" / LongVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "long_with_min_and_max" / Long10To30Val(id) if apiVersionMatch(_req) =>
       getLongWithMinAndMaxById(_req, id).flatMap {
         case GetLongWithMinAndMaxByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "long_with_min_and_max" / Long10To30Val(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "boolean" / BooleanVal(id) if apiVersionMatch(_req) =>
       getBooleanById(_req, id).flatMap {
         case GetBooleanByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "boolean" / BooleanVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "boolean_with_min_and_max" / BooleanVal(id) if apiVersionMatch(_req) =>
       getBooleanWithMinAndMaxById(_req, id).flatMap {
         case GetBooleanWithMinAndMaxByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "boolean_with_min_and_max" / BooleanVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "double" / DoubleVal(id) if apiVersionMatch(_req) =>
       getDoubleById(_req, id).flatMap {
         case GetDoubleByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "double" / DoubleVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "double_with_min_and_max" / DoubleVal(id) if apiVersionMatch(_req) =>
       getDoubleWithMinAndMaxById(_req, id).flatMap {
         case GetDoubleWithMinAndMaxByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "double_with_min_and_max" / DoubleVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "decimal" / BigDecimalVal(id) if apiVersionMatch(_req) =>
       getDecimalById(_req, id).flatMap {
         case GetDecimalByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "decimal" / BigDecimalVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "decimal_with_min_and_max" / BigDecimalVal(id) if apiVersionMatch(_req) =>
       getDecimalWithMinAndMaxById(_req, id).flatMap {
         case GetDecimalWithMinAndMaxByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "decimal_with_min_and_max" / BigDecimalVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "date" / LocalDateVal(id) if apiVersionMatch(_req) =>
       getDateById(_req, id).flatMap {
         case GetDateByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "date" / LocalDateVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "date_with_min_and_max" / LocalDateVal(id) if apiVersionMatch(_req) =>
       getDateWithMinAndMaxById(_req, id).flatMap {
         case GetDateWithMinAndMaxByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "date_with_min_and_max" / LocalDateVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "datetime" / InstantVal(id) if apiVersionMatch(_req) =>
       getDatetimeById(_req, id).flatMap {
         case GetDatetimeByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "datetime" / InstantVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "datetime_with_min_and_max" / InstantVal(id) if apiVersionMatch(_req) =>
       getDatetimeWithMinAndMaxById(_req, id).flatMap {
         case GetDatetimeWithMinAndMaxByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "datetime_with_min_and_max" / InstantVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "uuid" / UUIDVal(id) if apiVersionMatch(_req) =>
       getUuidById(_req, id).flatMap {
         case GetUuidByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "uuid" / UUIDVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "uuid_with_min_and_max" / UUIDVal(id) if apiVersionMatch(_req) =>
       getUuidWithMinAndMaxById(_req, id).flatMap {
         case GetUuidWithMinAndMaxByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "uuid_with_min_and_max" / UUIDVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "enum" / EnumVal(id) if apiVersionMatch(_req) =>
       getEnumById(_req, id).flatMap {
         case GetEnumByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "enum" / EnumVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "named_enum" / EnumVal(named_id) if apiVersionMatch(_req) =>
       getNamedEnumByNamedId(_req, named_id).flatMap {
         case GetNamedEnumByNamedIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "named_enum" / EnumVal(named_id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "enum_with_min_and_max" / EnumVal(id) if apiVersionMatch(_req) =>
       getEnumWithMinAndMaxById(_req, id).flatMap {
         case GetEnumWithMinAndMaxByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "enum_with_min_and_max" / EnumVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "invalid" / ModelVal(id) if apiVersionMatch(_req) =>
       getInvalidById(_req, id).flatMap {
         case GetInvalidByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
-    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+    case _req @ GET -> Root / "invalid" / ModelVal(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/path-params-018.txt
+++ b/lib/src/test/resources/http4s/path-params-018.txt
@@ -500,5 +500,7 @@ trait ModelRoutes[F[_]] extends Matchers[F] {
       getInvalidById(_req, id).flatMap {
         case GetInvalidByIdResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/query-params-017.txt
+++ b/lib/src/test/resources/http4s/query-params-017.txt
@@ -603,5 +603,7 @@ trait ModelRoutes {
       getEnumWithMinAndMax(_req, id).flatMap {
         case GetEnumWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/query-params-017.txt
+++ b/lib/src/test/resources/http4s/query-params-017.txt
@@ -458,152 +458,210 @@ trait ModelRoutes {
       getString(_req, id).flatMap {
         case GetStringResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "string" :? IdStringMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "named_string" :? NamedIdStringMatcher(named_id) if apiVersionMatch(_req) =>
       getNamedString(_req, named_id).flatMap {
         case GetNamedStringResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "named_string" :? NamedIdStringMatcher(named_id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_min" :? IdString10Matcher(id) if apiVersionMatch(_req) =>
       getStringWithMin(_req, id).flatMap {
         case GetStringWithMinResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_min" :? IdString10Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_max" :? IdStringTo10Matcher(id) if apiVersionMatch(_req) =>
       getStringWithMax(_req, id).flatMap {
         case GetStringWithMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_max" :? IdStringTo10Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_min_and_max" :? IdString10To30DefDefaultMatcher(id) if apiVersionMatch(_req) =>
       getStringWithMinAndMax(_req, id).flatMap {
         case GetStringWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_min_and_max" :? IdString10To30DefDefaultMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "optional_string" :? IdOptStringMatcher(id) if apiVersionMatch(_req) =>
       getOptionalString(_req, id).flatMap {
         case GetOptionalStringResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "optional_string" :? IdOptStringMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "optional_string_with_min_and_max" :? IdOptString10To30Matcher(id) if apiVersionMatch(_req) =>
       getOptionalStringWithMinAndMax(_req, id).flatMap {
         case GetOptionalStringWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "optional_string_with_min_and_max" :? IdOptString10To30Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "list_string" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if apiVersionMatch(_req) =>
       getListString(_req, id).flatMap {
         case GetListStringResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "list_string" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "list_string_with_min_and_max" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if apiVersionMatch(_req) =>
       getListStringWithMinAndMax(_req, id).flatMap {
         case GetListStringWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "list_string_with_min_and_max" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "optional_list_string" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if apiVersionMatch(_req) =>
       getOptionalListString(_req, id).flatMap {
         case GetOptionalListStringResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "optional_list_string" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "optional_list_string_with_min_and_max" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if apiVersionMatch(_req) =>
       getOptionalListStringWithMinAndMax(_req, id).flatMap {
         case GetOptionalListStringWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "optional_list_string_with_min_and_max" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "int" :? IdIntMatcher(id) if apiVersionMatch(_req) =>
       getInt(_req, id).flatMap {
         case GetIntResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "int" :? IdIntMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "int_with_min_and_max" :? IdInt10To30Def20Matcher(id) if apiVersionMatch(_req) =>
       getIntWithMinAndMax(_req, id).flatMap {
         case GetIntWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "int_with_min_and_max" :? IdInt10To30Def20Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "long" :? IdLongMatcher(id) if apiVersionMatch(_req) =>
       getLong(_req, id).flatMap {
         case GetLongResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "long" :? IdLongMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "long_with_min_and_max" :? IdLong10To30Def20Matcher(id) if apiVersionMatch(_req) =>
       getLongWithMinAndMax(_req, id).flatMap {
         case GetLongWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "long_with_min_and_max" :? IdLong10To30Def20Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "boolean" :? IdBooleanMatcher(id) if apiVersionMatch(_req) =>
       getBoolean(_req, id).flatMap {
         case GetBooleanResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "boolean" :? IdBooleanMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "boolean_with_min_and_max" :? IdBoolean10To30DefTrueMatcher(id) if apiVersionMatch(_req) =>
       getBooleanWithMinAndMax(_req, id).flatMap {
         case GetBooleanWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "boolean_with_min_and_max" :? IdBoolean10To30DefTrueMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "double" :? IdDoubleMatcher(id) if apiVersionMatch(_req) =>
       getDouble(_req, id).flatMap {
         case GetDoubleResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "double" :? IdDoubleMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "double_with_min_and_max" :? IdDouble10To30Def314Matcher(id) if apiVersionMatch(_req) =>
       getDoubleWithMinAndMax(_req, id).flatMap {
         case GetDoubleWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "double_with_min_and_max" :? IdDouble10To30Def314Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "decimal" :? IdBigDecimalMatcher(id) if apiVersionMatch(_req) =>
       getDecimal(_req, id).flatMap {
         case GetDecimalResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "decimal" :? IdBigDecimalMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "decimal_with_min_and_max" :? IdBigDecimal10To30Def314Matcher(id) if apiVersionMatch(_req) =>
       getDecimalWithMinAndMax(_req, id).flatMap {
         case GetDecimalWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "decimal_with_min_and_max" :? IdBigDecimal10To30Def314Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "date" :? IdLocalDateMatcher(id) if apiVersionMatch(_req) =>
       getDate(_req, id).flatMap {
         case GetDateResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "date" :? IdLocalDateMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "date_with_min_and_max" :? IdLocalDate10To30Def19991231Matcher(id) if apiVersionMatch(_req) =>
       getDateWithMinAndMax(_req, id).flatMap {
         case GetDateWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "date_with_min_and_max" :? IdLocalDate10To30Def19991231Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "datetime" :? IdInstantMatcher(id) if apiVersionMatch(_req) =>
       getDatetime(_req, id).flatMap {
         case GetDatetimeResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "datetime" :? IdInstantMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "datetime_with_min_and_max" :? IdInstant10To30Def19991231t235959zMatcher(id) if apiVersionMatch(_req) =>
       getDatetimeWithMinAndMax(_req, id).flatMap {
         case GetDatetimeWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "datetime_with_min_and_max" :? IdInstant10To30Def19991231t235959zMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "uuid" :? IdUUIDMatcher(id) if apiVersionMatch(_req) =>
       getUuid(_req, id).flatMap {
         case GetUuidResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "uuid" :? IdUUIDMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "uuid_with_min_and_max" :? IdUUID10To30DefE86bdef2B6a64c0aAb74594cdce3d86fMatcher(id) if apiVersionMatch(_req) =>
       getUuidWithMinAndMax(_req, id).flatMap {
         case GetUuidWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "uuid_with_min_and_max" :? IdUUID10To30DefE86bdef2B6a64c0aAb74594cdce3d86fMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "enum" :? IdEnumMatcher(id) if apiVersionMatch(_req) =>
       getEnum(_req, id).flatMap {
         case GetEnumResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "enum" :? IdEnumMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "named_enum" :? NamedIdEnumMatcher(named_id) if apiVersionMatch(_req) =>
       getNamedEnum(_req, named_id).flatMap {
         case GetNamedEnumResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "named_enum" :? NamedIdEnumMatcher(named_id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "enum_with_min_and_max" :? IdEnum10To30DefValueMatcher(id) if apiVersionMatch(_req) =>
       getEnumWithMinAndMax(_req, id).flatMap {
         case GetEnumWithMinAndMaxResponse.HTTP200(headers) => Ok().putHeaders(headers: _*)
       }
-    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+    case _req @ GET -> Root / "enum_with_min_and_max" :? IdEnum10To30DefValueMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/query-params-018.txt
+++ b/lib/src/test/resources/http4s/query-params-018.txt
@@ -457,152 +457,210 @@ trait ModelRoutes[F[_]] extends Matchers[F] {
       getString(_req, id).flatMap {
         case GetStringResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "string" :? IdStringMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "named_string" :? NamedIdStringMatcher(named_id) if apiVersionMatch(_req) =>
       getNamedString(_req, named_id).flatMap {
         case GetNamedStringResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "named_string" :? NamedIdStringMatcher(named_id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_min" :? IdString10Matcher(id) if apiVersionMatch(_req) =>
       getStringWithMin(_req, id).flatMap {
         case GetStringWithMinResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_min" :? IdString10Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_max" :? IdStringTo10Matcher(id) if apiVersionMatch(_req) =>
       getStringWithMax(_req, id).flatMap {
         case GetStringWithMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_max" :? IdStringTo10Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "string_with_min_and_max" :? IdString10To30DefDefaultMatcher(id) if apiVersionMatch(_req) =>
       getStringWithMinAndMax(_req, id).flatMap {
         case GetStringWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "string_with_min_and_max" :? IdString10To30DefDefaultMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "optional_string" :? IdOptStringMatcher(id) if apiVersionMatch(_req) =>
       getOptionalString(_req, id).flatMap {
         case GetOptionalStringResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "optional_string" :? IdOptStringMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "optional_string_with_min_and_max" :? IdOptString10To30Matcher(id) if apiVersionMatch(_req) =>
       getOptionalStringWithMinAndMax(_req, id).flatMap {
         case GetOptionalStringWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "optional_string_with_min_and_max" :? IdOptString10To30Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "list_string" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if apiVersionMatch(_req) =>
       getListString(_req, id).flatMap {
         case GetListStringResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "list_string" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "list_string_with_min_and_max" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if apiVersionMatch(_req) =>
       getListStringWithMinAndMax(_req, id).flatMap {
         case GetListStringWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "list_string_with_min_and_max" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "optional_list_string" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if apiVersionMatch(_req) =>
       getOptionalListString(_req, id).flatMap {
         case GetOptionalListStringResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "optional_list_string" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "optional_list_string_with_min_and_max" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if apiVersionMatch(_req) =>
       getOptionalListStringWithMinAndMax(_req, id).flatMap {
         case GetOptionalListStringWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "optional_list_string_with_min_and_max" :? IdListStringMatcher(cats.data.Validated.Valid(id)) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "int" :? IdIntMatcher(id) if apiVersionMatch(_req) =>
       getInt(_req, id).flatMap {
         case GetIntResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "int" :? IdIntMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "int_with_min_and_max" :? IdInt10To30Def20Matcher(id) if apiVersionMatch(_req) =>
       getIntWithMinAndMax(_req, id).flatMap {
         case GetIntWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "int_with_min_and_max" :? IdInt10To30Def20Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "long" :? IdLongMatcher(id) if apiVersionMatch(_req) =>
       getLong(_req, id).flatMap {
         case GetLongResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "long" :? IdLongMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "long_with_min_and_max" :? IdLong10To30Def20Matcher(id) if apiVersionMatch(_req) =>
       getLongWithMinAndMax(_req, id).flatMap {
         case GetLongWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "long_with_min_and_max" :? IdLong10To30Def20Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "boolean" :? IdBooleanMatcher(id) if apiVersionMatch(_req) =>
       getBoolean(_req, id).flatMap {
         case GetBooleanResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "boolean" :? IdBooleanMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "boolean_with_min_and_max" :? IdBoolean10To30DefTrueMatcher(id) if apiVersionMatch(_req) =>
       getBooleanWithMinAndMax(_req, id).flatMap {
         case GetBooleanWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "boolean_with_min_and_max" :? IdBoolean10To30DefTrueMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "double" :? IdDoubleMatcher(id) if apiVersionMatch(_req) =>
       getDouble(_req, id).flatMap {
         case GetDoubleResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "double" :? IdDoubleMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "double_with_min_and_max" :? IdDouble10To30Def314Matcher(id) if apiVersionMatch(_req) =>
       getDoubleWithMinAndMax(_req, id).flatMap {
         case GetDoubleWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "double_with_min_and_max" :? IdDouble10To30Def314Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "decimal" :? IdBigDecimalMatcher(id) if apiVersionMatch(_req) =>
       getDecimal(_req, id).flatMap {
         case GetDecimalResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "decimal" :? IdBigDecimalMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "decimal_with_min_and_max" :? IdBigDecimal10To30Def314Matcher(id) if apiVersionMatch(_req) =>
       getDecimalWithMinAndMax(_req, id).flatMap {
         case GetDecimalWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "decimal_with_min_and_max" :? IdBigDecimal10To30Def314Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "date" :? IdLocalDateMatcher(id) if apiVersionMatch(_req) =>
       getDate(_req, id).flatMap {
         case GetDateResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "date" :? IdLocalDateMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "date_with_min_and_max" :? IdLocalDate10To30Def19991231Matcher(id) if apiVersionMatch(_req) =>
       getDateWithMinAndMax(_req, id).flatMap {
         case GetDateWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "date_with_min_and_max" :? IdLocalDate10To30Def19991231Matcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "datetime" :? IdInstantMatcher(id) if apiVersionMatch(_req) =>
       getDatetime(_req, id).flatMap {
         case GetDatetimeResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "datetime" :? IdInstantMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "datetime_with_min_and_max" :? IdInstant10To30Def19991231t235959zMatcher(id) if apiVersionMatch(_req) =>
       getDatetimeWithMinAndMax(_req, id).flatMap {
         case GetDatetimeWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "datetime_with_min_and_max" :? IdInstant10To30Def19991231t235959zMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "uuid" :? IdUUIDMatcher(id) if apiVersionMatch(_req) =>
       getUuid(_req, id).flatMap {
         case GetUuidResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "uuid" :? IdUUIDMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "uuid_with_min_and_max" :? IdUUID10To30DefE86bdef2B6a64c0aAb74594cdce3d86fMatcher(id) if apiVersionMatch(_req) =>
       getUuidWithMinAndMax(_req, id).flatMap {
         case GetUuidWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "uuid_with_min_and_max" :? IdUUID10To30DefE86bdef2B6a64c0aAb74594cdce3d86fMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "enum" :? IdEnumMatcher(id) if apiVersionMatch(_req) =>
       getEnum(_req, id).flatMap {
         case GetEnumResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "enum" :? IdEnumMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "named_enum" :? NamedIdEnumMatcher(named_id) if apiVersionMatch(_req) =>
       getNamedEnum(_req, named_id).flatMap {
         case GetNamedEnumResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req @ GET -> Root / "named_enum" :? NamedIdEnumMatcher(named_id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "enum_with_min_and_max" :? IdEnum10To30DefValueMatcher(id) if apiVersionMatch(_req) =>
       getEnumWithMinAndMax(_req, id).flatMap {
         case GetEnumWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
-    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+    case _req @ GET -> Root / "enum_with_min_and_max" :? IdEnum10To30DefValueMatcher(id) if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/query-params-018.txt
+++ b/lib/src/test/resources/http4s/query-params-018.txt
@@ -602,5 +602,7 @@ trait ModelRoutes[F[_]] extends Matchers[F] {
       getEnumWithMinAndMax(_req, id).flatMap {
         case GetEnumWithMinAndMaxResponse.HTTP200(headers) => Ok(headers: _*)
       }
+    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/response-types-017.txt
+++ b/lib/src/test/resources/http4s/response-types-017.txt
@@ -111,26 +111,36 @@ trait ModelRoutes {
       getString(_req).flatMap {
         case GetStringResponse.HTTP200(value, headers) => Ok(value).putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "string" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "enum" if apiVersionMatch(_req) =>
       getEnum(_req).flatMap {
         case GetEnumResponse.HTTP200(value, headers) => Ok(value).putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "enum" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "model" if apiVersionMatch(_req) =>
       getModel(_req).flatMap {
         case GetModelResponse.HTTP200(value, headers) => Ok(value).putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "model" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "list" if apiVersionMatch(_req) =>
       getList(_req).flatMap {
         case GetListResponse.HTTP200(value, headers) => Ok(value).putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "list" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "map" if apiVersionMatch(_req) =>
       getMap(_req).flatMap {
         case GetMapResponse.HTTP200(value, headers) => Ok(value).putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "map" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "multiple" if apiVersionMatch(_req) =>
       getMultiple(_req).flatMap {
@@ -140,7 +150,7 @@ trait ModelRoutes {
         case GetMultipleResponse.HTTP204(headers) => NoContent().putHeaders(headers: _*)
         case GetMultipleResponse.HTTP206(value, headers) => PartialContent(value).putHeaders(headers: _*)
       }
-    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+    case _req @ GET -> Root / "multiple" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/response-types-017.txt
+++ b/lib/src/test/resources/http4s/response-types-017.txt
@@ -140,5 +140,7 @@ trait ModelRoutes {
         case GetMultipleResponse.HTTP204(headers) => NoContent().putHeaders(headers: _*)
         case GetMultipleResponse.HTTP206(value, headers) => PartialContent(value).putHeaders(headers: _*)
       }
+    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/response-types-018.txt
+++ b/lib/src/test/resources/http4s/response-types-018.txt
@@ -139,5 +139,7 @@ trait ModelRoutes[F[_]] extends Matchers[F] {
         case GetMultipleResponse.HTTP204(headers) => NoContent(headers: _*)
         case GetMultipleResponse.HTTP206(value, headers) => PartialContent(value, headers: _*)
       }
+    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/response-types-018.txt
+++ b/lib/src/test/resources/http4s/response-types-018.txt
@@ -110,26 +110,36 @@ trait ModelRoutes[F[_]] extends Matchers[F] {
       getString(_req).flatMap {
         case GetStringResponse.HTTP200(value, headers) => Ok(value, headers: _*)
       }
+    case _req @ GET -> Root / "string" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "enum" if apiVersionMatch(_req) =>
       getEnum(_req).flatMap {
         case GetEnumResponse.HTTP200(value, headers) => Ok(value, headers: _*)
       }
+    case _req @ GET -> Root / "enum" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "model" if apiVersionMatch(_req) =>
       getModel(_req).flatMap {
         case GetModelResponse.HTTP200(value, headers) => Ok(value, headers: _*)
       }
+    case _req @ GET -> Root / "model" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "list" if apiVersionMatch(_req) =>
       getList(_req).flatMap {
         case GetListResponse.HTTP200(value, headers) => Ok(value, headers: _*)
       }
+    case _req @ GET -> Root / "list" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "map" if apiVersionMatch(_req) =>
       getMap(_req).flatMap {
         case GetMapResponse.HTTP200(value, headers) => Ok(value, headers: _*)
       }
+    case _req @ GET -> Root / "map" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "multiple" if apiVersionMatch(_req) =>
       getMultiple(_req).flatMap {
@@ -139,7 +149,7 @@ trait ModelRoutes[F[_]] extends Matchers[F] {
         case GetMultipleResponse.HTTP204(headers) => NoContent(headers: _*)
         case GetMultipleResponse.HTTP206(value, headers) => PartialContent(value, headers: _*)
       }
-    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+    case _req @ GET -> Root / "multiple" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/status-codes-017.txt
+++ b/lib/src/test/resources/http4s/status-codes-017.txt
@@ -104,5 +104,7 @@ trait FooRoutes {
       get401(_req).flatMap {
         case Get401Response.HTTP401(value, challenge, challenges, headers) => Unauthorized(challenge, challenges: _*).putHeaders(headers: _*)
       }
+    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/status-codes-017.txt
+++ b/lib/src/test/resources/http4s/status-codes-017.txt
@@ -89,22 +89,28 @@ trait FooRoutes {
         case Get200Response.HTTP200(value, headers) => Ok(value).putHeaders(headers: _*)
         case Get200Response.HTTP401(challenge, challenges, headers) => Unauthorized(challenge, challenges: _*).putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "foos" / "200" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "foos" / "205" if apiVersionMatch(_req) =>
       get205(_req).flatMap {
         case Get205Response.HTTP205(headers) => ResetContent().putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "foos" / "205" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "foos" / "300" if apiVersionMatch(_req) =>
       get300(_req).flatMap {
         case Get300Response.HTTP300(location, headers) => MultipleChoices(location).putHeaders(headers: _*)
       }
+    case _req @ GET -> Root / "foos" / "300" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "foos" / "401" if apiVersionMatch(_req) =>
       get401(_req).flatMap {
         case Get401Response.HTTP401(value, challenge, challenges, headers) => Unauthorized(challenge, challenges: _*).putHeaders(headers: _*)
       }
-    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+    case _req @ GET -> Root / "foos" / "401" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/status-codes-018.txt
+++ b/lib/src/test/resources/http4s/status-codes-018.txt
@@ -88,22 +88,28 @@ trait FooRoutes[F[_]] extends Matchers[F] {
         case Get200Response.HTTP200(value, headers) => Ok(value, headers: _*)
         case Get200Response.HTTP401(authenticate, headers) => Unauthorized(authenticate, headers: _*)
       }
+    case _req @ GET -> Root / "foos" / "200" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "foos" / "205" if apiVersionMatch(_req) =>
       get205(_req).flatMap {
         case Get205Response.HTTP205(headers) => ResetContent(headers: _*)
       }
+    case _req @ GET -> Root / "foos" / "205" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "foos" / "300" if apiVersionMatch(_req) =>
       get300(_req).flatMap {
         case Get300Response.HTTP300(location, headers) => MultipleChoices(location, headers: _*)
       }
+    case _req @ GET -> Root / "foos" / "300" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "foos" / "401" if apiVersionMatch(_req) =>
       get401(_req).flatMap {
         case Get401Response.HTTP401(value, authenticate, headers) => Unauthorized(authenticate, value, headers: _*)
       }
-    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+    case _req @ GET -> Root / "foos" / "401" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/lib/src/test/resources/http4s/status-codes-018.txt
+++ b/lib/src/test/resources/http4s/status-codes-018.txt
@@ -103,5 +103,7 @@ trait FooRoutes[F[_]] extends Matchers[F] {
       get401(_req).flatMap {
         case Get401Response.HTTP401(value, authenticate, headers) => Unauthorized(authenticate, value, headers: _*)
       }
+    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
   }
 }

--- a/scala-generator/src/main/scala/models/http4s/server/Http4sServer.scala
+++ b/scala-generator/src/main/scala/models/http4s/server/Http4sServer.scala
@@ -112,8 +112,6 @@ case class Http4sServer(form: InvocationForm,
          |
          |  def service()${config.asyncTypeParam().map(p => s"(implicit sync: Sync[F])").getOrElse("")} = ${config.httpServiceClass} {
          |${routes.map(_.route(version).mkString("\n")).mkString("\n\n").indent(4)}
-         |    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
-         |      BadRequest(s"Missing required request header: $${ApiVersion.ApiVersionMajor}.")
          |  }
          |}
          |""".stripMargin

--- a/scala-generator/src/main/scala/models/http4s/server/Http4sServer.scala
+++ b/scala-generator/src/main/scala/models/http4s/server/Http4sServer.scala
@@ -112,6 +112,8 @@ case class Http4sServer(form: InvocationForm,
          |
          |  def service()${config.asyncTypeParam().map(p => s"(implicit sync: Sync[F])").getOrElse("")} = ${config.httpServiceClass} {
          |${routes.map(_.route(version).mkString("\n")).mkString("\n\n").indent(4)}
+         |    case _req if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+         |      BadRequest(s"Missing required request header: $${ApiVersion.ApiVersionMajor}.")
          |  }
          |}
          |""".stripMargin

--- a/scala-generator/src/main/scala/models/http4s/server/Route.scala
+++ b/scala-generator/src/main/scala/models/http4s/server/Route.scala
@@ -137,7 +137,9 @@ case class Route(ssd: ScalaService, resource: ScalaResource, op: ScalaOperation,
       Seq(s"  }")
     }
 
-    val prefix = Seq(s"case _req @ ${op.method} -> $path$queryStart$query$verFilter =>")
+    def prefix(filter: String) = s"case _req @ ${op.method} -> $path$queryStart$query$filter =>"
+
+    val verFilterPrefix = Seq(prefix(verFilter))
 
     val decodingParameters:Seq[String] = {
       op.nonHeaderParameters.map { field =>
@@ -183,7 +185,11 @@ case class Route(ssd: ScalaService, resource: ScalaResource, op: ScalaOperation,
       route("")
     }
 
-    prefix ++ decoding
+    val missingVersionHeaderCase = version.fold(Seq(""))(_ =>
+                                                  Seq(prefix(s" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined") ++ "\n" ++
+                                                    s"""  BadRequest(s"Missing required request header: $${ApiVersion.ApiVersionMajor}.")"""))
+
+    verFilterPrefix ++ decoding ++ missingVersionHeaderCase
 
   }
 


### PR DESCRIPTION
…resent (instead of 404). Closes #277

This implementation:
* still allows for multiple server versions to co-exist in the same code base;
* still allows to override `apiVersionMatch` to always return `true` (when running only one version) and is backward compatible with the services currently doing so.