### PR TITLE
Fix query string bindables are missing the field key

### DIFF
--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -439,7 +439,7 @@ package io.apibuilder.example.union.types.v0 {
       }
 
       override def unbind(key: String, value: T): String = {
-        converters.convert(value)
+        s"$key=${converters.convert(value)}"
       }
     }
 

--- a/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
@@ -187,7 +187,7 @@ package com.gilt.test.v0 {
       }
 
       override def unbind(key: String, value: T): String = {
-        converters.convert(value)
+        s"$key=${converters.convert(value)}"
       }
     }
 

--- a/lib/src/test/resources/generators/play-2-bindable-reference-api-object.txt
+++ b/lib/src/test/resources/generators/play-2-bindable-reference-api-object.txt
@@ -82,7 +82,7 @@ object Bindables {
     }
 
     override def unbind(key: String, value: T): String = {
-      converters.convert(value)
+      s"$key=${converters.convert(value)}"
     }
   }
 

--- a/lib/src/test/resources/generators/play-22-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-22-built-in-types.txt
@@ -399,7 +399,7 @@ package apibuilder {
       }
 
       override def unbind(key: String, value: T): String = {
-        converters.convert(value)
+        s"$key=${converters.convert(value)}"
       }
     }
 

--- a/lib/src/test/resources/generators/play-23-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-23-built-in-types.txt
@@ -399,7 +399,7 @@ package apibuilder {
       }
 
       override def unbind(key: String, value: T): String = {
-        converters.convert(value)
+        s"$key=${converters.convert(value)}"
       }
     }
 

--- a/lib/src/test/resources/generators/play-24-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-24-built-in-types.txt
@@ -399,7 +399,7 @@ package apibuilder {
       }
 
       override def unbind(key: String, value: T): String = {
-        converters.convert(value)
+        s"$key=${converters.convert(value)}"
       }
     }
 

--- a/lib/src/test/resources/generators/play-25-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-25-built-in-types.txt
@@ -399,7 +399,7 @@ package apibuilder {
       }
 
       override def unbind(key: String, value: T): String = {
-        converters.convert(value)
+        s"$key=${converters.convert(value)}"
       }
     }
 

--- a/lib/src/test/resources/generators/play-26-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-26-built-in-types.txt
@@ -399,7 +399,7 @@ package apibuilder {
       }
 
       override def unbind(key: String, value: T): String = {
-        converters.convert(value)
+        s"$key=${converters.convert(value)}"
       }
     }
 

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -489,7 +489,7 @@ package io.apibuilder.reference.api.v0 {
       }
 
       override def unbind(key: String, value: T): String = {
-        converters.convert(value)
+        s"$key=${converters.convert(value)}"
       }
     }
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -490,7 +490,7 @@ package io.apibuilder.reference.api.v0 {
       }
 
       override def unbind(key: String, value: T): String = {
-        converters.convert(value)
+        s"$key=${converters.convert(value)}"
       }
     }
 

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -324,7 +324,7 @@ package io.apibuilder.example.union.types.discriminator.v0 {
       }
 
       override def unbind(key: String, value: T): String = {
-        converters.convert(value)
+        s"$key=${converters.convert(value)}"
       }
     }
 

--- a/scala-generator/src/main/scala/models/Play2Bindables.scala
+++ b/scala-generator/src/main/scala/models/Play2Bindables.scala
@@ -119,7 +119,7 @@ case class ApibuilderQueryStringBindable[T](
   }
 
   override def unbind(key: String, value: T): String = {
-    converters.convert(value)
+    s"$key=${converters.convert(value)}"
   }
 }
 


### PR DESCRIPTION
Currently a query parameter "foo" with value "bar" is query-string encoded as http://host?bar
instead of the correct http://host?foo=bar