### PR TITLE
Removed unused imports

### DIFF
--- a/scala-generator/src/main/scala/models/http4s/CirceJson.scala
+++ b/scala-generator/src/main/scala/models/http4s/CirceJson.scala
@@ -14,9 +14,8 @@ case class CirceJson(
     import io.circe.Decoder._
     import io.circe.Encoder._
     import scala.util.Try
-    import io.circe.{Json, JsonObject, Encoder, Decoder, DecodingFailure}
+    import io.circe._
     import io.circe.syntax._
-${JsonImports(ssd.service).mkString("\n").indent(4)}
 
     // Make Scala 2.11 Either monadic
     private[${ssd.namespaces.last}] implicit def eitherOps[A,B](e: Either[A,B]) = cats.implicits.catsSyntaxEither(e)


### PR DESCRIPTION
Fixes my wart expressed in #398. Should be safe because:
- `import io.circe._` actually can import more stuff,
- `import io.apibuider.generator.v0.models.json._` in the package object itself is redundant 