### PR TITLE
Overcome limit of 22 fields for json readers

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -253,10 +253,10 @@ package io.apibuilder.example.union.types.v0.models {
     }
 
     implicit def jsonReadsApidocExampleUnionTypesGuestUser: play.api.libs.json.Reads[GuestUser] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "email").read[String]
-      )(GuestUser.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        email <- (__ \ "email").read[String]
+      } yield GuestUser(guid, email)
     }
 
     def jsObjectGuestUser(obj: io.apibuilder.example.union.types.v0.models.GuestUser): play.api.libs.json.JsObject = {
@@ -267,11 +267,11 @@ package io.apibuilder.example.union.types.v0.models {
     }
 
     implicit def jsonReadsApidocExampleUnionTypesRegisteredUser: play.api.libs.json.Reads[RegisteredUser] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "email").read[String] and
-        (__ \ "preference").read[io.apibuilder.example.union.types.v0.models.Foobar]
-      )(RegisteredUser.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        email <- (__ \ "email").read[String]
+        preference <- (__ \ "preference").read[io.apibuilder.example.union.types.v0.models.Foobar]
+      } yield RegisteredUser(guid, email, preference)
     }
 
     def jsObjectRegisteredUser(obj: io.apibuilder.example.union.types.v0.models.RegisteredUser): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -253,10 +253,10 @@ package io.apibuilder.example.union.types.v0.models {
     }
 
     implicit def jsonReadsApidocExampleUnionTypesGuestUser: play.api.libs.json.Reads[GuestUser] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "email").read[String]
-      )(GuestUser.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        email <- (__ \ "email").read[String]
+      } yield GuestUser(guid, email)
     }
 
     def jsObjectGuestUser(obj: io.apibuilder.example.union.types.v0.models.GuestUser): play.api.libs.json.JsObject = {
@@ -267,11 +267,11 @@ package io.apibuilder.example.union.types.v0.models {
     }
 
     implicit def jsonReadsApidocExampleUnionTypesRegisteredUser: play.api.libs.json.Reads[RegisteredUser] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "email").read[String] and
-        (__ \ "preference").read[io.apibuilder.example.union.types.v0.models.Foobar]
-      )(RegisteredUser.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        email <- (__ \ "email").read[String]
+        preference <- (__ \ "preference").read[io.apibuilder.example.union.types.v0.models.Foobar]
+      } yield RegisteredUser(guid, email, preference)
     }
 
     def jsObjectRegisteredUser(obj: io.apibuilder.example.union.types.v0.models.RegisteredUser): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/examples/reference-service.json
+++ b/lib/src/test/resources/examples/reference-service.json
@@ -164,6 +164,30 @@
           "type": "string",
           "required": true,
           "attributes": []
+        },
+        {
+          "name": "f22",
+          "type": "string",
+          "required": true,
+          "attributes": []
+        },
+        {
+          "name": "f23",
+          "type": "string",
+          "required": true,
+          "attributes": []
+        },
+        {
+          "name": "f24",
+          "type": "string",
+          "required": true,
+          "attributes": []
+        },
+        {
+          "name": "f25",
+          "type": "string",
+          "required": true,
+          "attributes": []
         }
       ],
       "attributes": [],

--- a/lib/src/test/resources/examples/reference-with-imports.json
+++ b/lib/src/test/resources/examples/reference-with-imports.json
@@ -204,6 +204,30 @@
           "type": "string",
           "required": true,
           "attributes": []
+        },
+        {
+          "name": "f22",
+          "type": "string",
+          "required": true,
+          "attributes": []
+        },
+        {
+          "name": "f23",
+          "type": "string",
+          "required": true,
+          "attributes": []
+        },
+        {
+          "name": "f24",
+          "type": "string",
+          "required": true,
+          "attributes": []
+        },
+        {
+          "name": "f25",
+          "type": "string",
+          "required": true,
+          "attributes": []
         }
       ],
       "attributes": [],

--- a/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
@@ -62,12 +62,12 @@ package com.gilt.test.v0.models {
     }
 
     implicit def jsonReadsTestUser: play.api.libs.json.Reads[User] = {
-      (
-        (__ \ "email").read[String] and
-        (__ \ "role").read[String] and
-        (__ \ "groups").read[Seq[String]] and
-        (__ \ "permissions").read[Seq[String]]
-      )(User.apply _)
+      for {
+        email <- (__ \ "email").read[String]
+        role <- (__ \ "role").read[String]
+        groups <- (__ \ "groups").read[Seq[String]]
+        permissions <- (__ \ "permissions").read[Seq[String]]
+      } yield User(email, role, groups, permissions)
     }
 
     def jsObjectUser(obj: com.gilt.test.v0.models.User): play.api.libs.json.JsObject = {
@@ -88,11 +88,11 @@ package com.gilt.test.v0.models {
     }
 
     implicit def jsonReadsTestUserPatch: play.api.libs.json.Reads[UserPatch] = {
-      (
-        (__ \ "groups").readNullable[Seq[String]] and
-        (__ \ "permissions").read[Seq[String]] and
-        (__ \ "preferences").read[Seq[String]]
-      )(UserPatch.apply _)
+      for {
+        groups <- (__ \ "groups").readNullable[Seq[String]]
+        permissions <- (__ \ "permissions").read[Seq[String]]
+        preferences <- (__ \ "preferences").read[Seq[String]]
+      } yield UserPatch(groups, permissions, preferences)
     }
 
     def jsObjectUserPatch(obj: com.gilt.test.v0.models.UserPatch): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
@@ -62,12 +62,12 @@ package com.gilt.test.v0.models {
     }
 
     implicit def jsonReadsTestUser: play.api.libs.json.Reads[User] = {
-      (
-        (__ \ "email").read[String] and
-        (__ \ "role").read[String] and
-        (__ \ "groups").read[Seq[String]] and
-        (__ \ "permissions").read[Seq[String]]
-      )(User.apply _)
+      for {
+        email <- (__ \ "email").read[String]
+        role <- (__ \ "role").read[String]
+        groups <- (__ \ "groups").read[Seq[String]]
+        permissions <- (__ \ "permissions").read[Seq[String]]
+      } yield User(email, role, groups, permissions)
     }
 
     def jsObjectUser(obj: com.gilt.test.v0.models.User): play.api.libs.json.JsObject = {
@@ -88,11 +88,11 @@ package com.gilt.test.v0.models {
     }
 
     implicit def jsonReadsTestUserPatch: play.api.libs.json.Reads[UserPatch] = {
-      (
-        (__ \ "groups").readNullable[Seq[String]] and
-        (__ \ "permissions").read[Seq[String]] and
-        (__ \ "preferences").read[Seq[String]]
-      )(UserPatch.apply _)
+      for {
+        groups <- (__ \ "groups").readNullable[Seq[String]]
+        permissions <- (__ \ "permissions").read[Seq[String]]
+        preferences <- (__ \ "preferences").read[Seq[String]]
+      } yield UserPatch(groups, permissions, preferences)
     }
 
     def jsObjectUserPatch(obj: com.gilt.test.v0.models.UserPatch): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/generators/play-2-json-spec-quality-plan-readers.txt
+++ b/lib/src/test/resources/generators/play-2-json-spec-quality-plan-readers.txt
@@ -1,9 +1,9 @@
 implicit def jsonReadsQualityPlan: play.api.libs.json.Reads[Plan] = {
-  (
-    (__ \ "id").read[Long] and
-    (__ \ "incident_id").read[Long] and
-    (__ \ "body").read[String] and
-    (__ \ "grade").readNullable[Int] and
-    (__ \ "created_at").read[_root_.org.joda.time.DateTime]
-  )(Plan.apply _)
+  for {
+    id <- (__ \ "id").read[Long]
+    incidentId <- (__ \ "incident_id").read[Long]
+    body <- (__ \ "body").read[String]
+    grade <- (__ \ "grade").readNullable[Int]
+    createdAt <- (__ \ "created_at").read[_root_.org.joda.time.DateTime]
+  } yield Plan(id, incidentId, body, grade, createdAt)
 }

--- a/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
+++ b/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
@@ -762,12 +762,12 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityAgendaItem: play.api.libs.json.Reads[AgendaItem] = {
-      (
-        (__ \ "id").read[Long] and
-        (__ \ "meeting").read[com.gilt.quality.v0.models.Meeting] and
-        (__ \ "incident").read[com.gilt.quality.v0.models.Incident] and
-        (__ \ "task").read[com.gilt.quality.v0.models.Task]
-      )(AgendaItem.apply _)
+      for {
+        id <- (__ \ "id").read[Long]
+        meeting <- (__ \ "meeting").read[com.gilt.quality.v0.models.Meeting]
+        incident <- (__ \ "incident").read[com.gilt.quality.v0.models.Incident]
+        task <- (__ \ "task").read[com.gilt.quality.v0.models.Task]
+      } yield AgendaItem(id, meeting, incident, task)
     }
 
     def jsObjectAgendaItem(obj: com.gilt.quality.v0.models.AgendaItem): play.api.libs.json.JsObject = {
@@ -788,11 +788,11 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityAgendaItemForm: play.api.libs.json.Reads[AgendaItemForm] = {
-      (
-        (__ \ "meeting_id").read[Long] and
-        (__ \ "incident_id").read[Long] and
-        (__ \ "task").read[com.gilt.quality.v0.models.Task]
-      )(AgendaItemForm.apply _)
+      for {
+        meetingId <- (__ \ "meeting_id").read[Long]
+        incidentId <- (__ \ "incident_id").read[Long]
+        task <- (__ \ "task").read[com.gilt.quality.v0.models.Task]
+      } yield AgendaItemForm(meetingId, incidentId, task)
     }
 
     def jsObjectAgendaItemForm(obj: com.gilt.quality.v0.models.AgendaItemForm): play.api.libs.json.JsObject = {
@@ -830,10 +830,10 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityEmailMessage: play.api.libs.json.Reads[EmailMessage] = {
-      (
-        (__ \ "subject").read[String] and
-        (__ \ "body").read[String]
-      )(EmailMessage.apply _)
+      for {
+        subject <- (__ \ "subject").read[String]
+        body <- (__ \ "body").read[String]
+      } yield EmailMessage(subject, body)
     }
 
     def jsObjectEmailMessage(obj: com.gilt.quality.v0.models.EmailMessage): play.api.libs.json.JsObject = {
@@ -852,10 +852,10 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityError: play.api.libs.json.Reads[Error] = {
-      (
-        (__ \ "code").read[String] and
-        (__ \ "message").read[String]
-      )(Error.apply _)
+      for {
+        code <- (__ \ "code").read[String]
+        message <- (__ \ "message").read[String]
+      } yield Error(code, message)
     }
 
     def jsObjectError(obj: com.gilt.quality.v0.models.Error): play.api.libs.json.JsObject = {
@@ -874,13 +874,13 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityExternalService: play.api.libs.json.Reads[ExternalService] = {
-      (
-        (__ \ "id").read[Long] and
-        (__ \ "organization").read[com.gilt.quality.v0.models.Organization] and
-        (__ \ "name").read[com.gilt.quality.v0.models.ExternalServiceName] and
-        (__ \ "url").read[String] and
-        (__ \ "username").read[String]
-      )(ExternalService.apply _)
+      for {
+        id <- (__ \ "id").read[Long]
+        organization <- (__ \ "organization").read[com.gilt.quality.v0.models.Organization]
+        name <- (__ \ "name").read[com.gilt.quality.v0.models.ExternalServiceName]
+        url <- (__ \ "url").read[String]
+        username <- (__ \ "username").read[String]
+      } yield ExternalService(id, organization, name, url, username)
     }
 
     def jsObjectExternalService(obj: com.gilt.quality.v0.models.ExternalService): play.api.libs.json.JsObject = {
@@ -902,12 +902,12 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityExternalServiceForm: play.api.libs.json.Reads[ExternalServiceForm] = {
-      (
-        (__ \ "name").read[com.gilt.quality.v0.models.ExternalServiceName] and
-        (__ \ "url").read[String] and
-        (__ \ "username").read[String] and
-        (__ \ "password").read[String]
-      )(ExternalServiceForm.apply _)
+      for {
+        name <- (__ \ "name").read[com.gilt.quality.v0.models.ExternalServiceName]
+        url <- (__ \ "url").read[String]
+        username <- (__ \ "username").read[String]
+        password <- (__ \ "password").read[String]
+      } yield ExternalServiceForm(name, url, username, password)
     }
 
     def jsObjectExternalServiceForm(obj: com.gilt.quality.v0.models.ExternalServiceForm): play.api.libs.json.JsObject = {
@@ -928,11 +928,11 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityFollowup: play.api.libs.json.Reads[Followup] = {
-      (
-        (__ \ "key").read[String] and
-        (__ \ "plan").read[com.gilt.quality.v0.models.Plan] and
-        (__ \ "sent_at").read[_root_.org.joda.time.DateTime]
-      )(Followup.apply _)
+      for {
+        key <- (__ \ "key").read[String]
+        plan <- (__ \ "plan").read[com.gilt.quality.v0.models.Plan]
+        sentAt <- (__ \ "sent_at").read[_root_.org.joda.time.DateTime]
+      } yield Followup(key, plan, sentAt)
     }
 
     def jsObjectFollowup(obj: com.gilt.quality.v0.models.Followup): play.api.libs.json.JsObject = {
@@ -952,12 +952,12 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityFollowupResponse: play.api.libs.json.Reads[FollowupResponse] = {
-      (
-        (__ \ "followup").read[com.gilt.quality.v0.models.Followup] and
-        (__ \ "response").read[com.gilt.quality.v0.models.Response] and
-        (__ \ "created_at").read[_root_.org.joda.time.DateTime] and
-        (__ \ "created_by").read[com.gilt.quality.v0.models.User]
-      )(FollowupResponse.apply _)
+      for {
+        followup <- (__ \ "followup").read[com.gilt.quality.v0.models.Followup]
+        response <- (__ \ "response").read[com.gilt.quality.v0.models.Response]
+        createdAt <- (__ \ "created_at").read[_root_.org.joda.time.DateTime]
+        createdBy <- (__ \ "created_by").read[com.gilt.quality.v0.models.User]
+      } yield FollowupResponse(followup, response, createdAt, createdBy)
     }
 
     def jsObjectFollowupResponse(obj: com.gilt.quality.v0.models.FollowupResponse): play.api.libs.json.JsObject = {
@@ -996,10 +996,10 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityIcons: play.api.libs.json.Reads[Icons] = {
-      (
-        (__ \ "smiley_url").read[String] and
-        (__ \ "frowny_url").read[String]
-      )(Icons.apply _)
+      for {
+        smileyUrl <- (__ \ "smiley_url").read[String]
+        frownyUrl <- (__ \ "frowny_url").read[String]
+      } yield Icons(smileyUrl, frownyUrl)
     }
 
     def jsObjectIcons(obj: com.gilt.quality.v0.models.Icons): play.api.libs.json.JsObject = {
@@ -1018,17 +1018,17 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityIncident: play.api.libs.json.Reads[Incident] = {
-      (
-        (__ \ "id").read[Long] and
-        (__ \ "organization").read[com.gilt.quality.v0.models.Organization] and
-        (__ \ "summary").read[String] and
-        (__ \ "description").readNullable[String] and
-        (__ \ "team").readNullable[com.gilt.quality.v0.models.Team] and
-        (__ \ "severity").read[com.gilt.quality.v0.models.Severity] and
-        (__ \ "tags").readNullable[Seq[String]] and
-        (__ \ "plan").readNullable[com.gilt.quality.v0.models.Plan] and
-        (__ \ "created_at").read[_root_.org.joda.time.DateTime]
-      )(Incident.apply _)
+      for {
+        id <- (__ \ "id").read[Long]
+        organization <- (__ \ "organization").read[com.gilt.quality.v0.models.Organization]
+        summary <- (__ \ "summary").read[String]
+        description <- (__ \ "description").readNullable[String]
+        team <- (__ \ "team").readNullable[com.gilt.quality.v0.models.Team]
+        severity <- (__ \ "severity").read[com.gilt.quality.v0.models.Severity]
+        tags <- (__ \ "tags").readNullable[Seq[String]]
+        plan <- (__ \ "plan").readNullable[com.gilt.quality.v0.models.Plan]
+        createdAt <- (__ \ "created_at").read[_root_.org.joda.time.DateTime]
+      } yield Incident(id, organization, summary, description, team, severity, tags, plan, createdAt)
     }
 
     def jsObjectIncident(obj: com.gilt.quality.v0.models.Incident): play.api.libs.json.JsObject = {
@@ -1065,13 +1065,13 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityIncidentForm: play.api.libs.json.Reads[IncidentForm] = {
-      (
-        (__ \ "team_key").readNullable[String] and
-        (__ \ "severity").read[com.gilt.quality.v0.models.Severity] and
-        (__ \ "summary").read[String] and
-        (__ \ "description").readNullable[String] and
-        (__ \ "tags").readNullable[Seq[String]]
-      )(IncidentForm.apply _)
+      for {
+        teamKey <- (__ \ "team_key").readNullable[String]
+        severity <- (__ \ "severity").read[com.gilt.quality.v0.models.Severity]
+        summary <- (__ \ "summary").read[String]
+        description <- (__ \ "description").readNullable[String]
+        tags <- (__ \ "tags").readNullable[Seq[String]]
+      } yield IncidentForm(teamKey, severity, summary, description, tags)
     }
 
     def jsObjectIncidentForm(obj: com.gilt.quality.v0.models.IncidentForm): play.api.libs.json.JsObject = {
@@ -1101,10 +1101,10 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityIncidentOrganizationChange: play.api.libs.json.Reads[IncidentOrganizationChange] = {
-      (
-        (__ \ "incident_id").read[Long] and
-        (__ \ "organization_key").read[String]
-      )(IncidentOrganizationChange.apply _)
+      for {
+        incidentId <- (__ \ "incident_id").read[Long]
+        organizationKey <- (__ \ "organization_key").read[String]
+      } yield IncidentOrganizationChange(incidentId, organizationKey)
     }
 
     def jsObjectIncidentOrganizationChange(obj: com.gilt.quality.v0.models.IncidentOrganizationChange): play.api.libs.json.JsObject = {
@@ -1123,11 +1123,11 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityIncidentSummary: play.api.libs.json.Reads[IncidentSummary] = {
-      (
-        (__ \ "id").read[Long] and
-        (__ \ "severity").read[com.gilt.quality.v0.models.Severity] and
-        (__ \ "summary").read[String]
-      )(IncidentSummary.apply _)
+      for {
+        id <- (__ \ "id").read[Long]
+        severity <- (__ \ "severity").read[com.gilt.quality.v0.models.Severity]
+        summary <- (__ \ "summary").read[String]
+      } yield IncidentSummary(id, severity, summary)
     }
 
     def jsObjectIncidentSummary(obj: com.gilt.quality.v0.models.IncidentSummary): play.api.libs.json.JsObject = {
@@ -1147,12 +1147,12 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityMeeting: play.api.libs.json.Reads[Meeting] = {
-      (
-        (__ \ "id").read[Long] and
-        (__ \ "organization").read[com.gilt.quality.v0.models.Organization] and
-        (__ \ "scheduled_at").read[_root_.org.joda.time.DateTime] and
-        (__ \ "adjourned_at").readNullable[_root_.org.joda.time.DateTime]
-      )(Meeting.apply _)
+      for {
+        id <- (__ \ "id").read[Long]
+        organization <- (__ \ "organization").read[com.gilt.quality.v0.models.Organization]
+        scheduledAt <- (__ \ "scheduled_at").read[_root_.org.joda.time.DateTime]
+        adjournedAt <- (__ \ "adjourned_at").readNullable[_root_.org.joda.time.DateTime]
+      } yield Meeting(id, organization, scheduledAt, adjournedAt)
     }
 
     def jsObjectMeeting(obj: com.gilt.quality.v0.models.Meeting): play.api.libs.json.JsObject = {
@@ -1193,11 +1193,11 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityMeetingPager: play.api.libs.json.Reads[MeetingPager] = {
-      (
-        (__ \ "meeting").read[com.gilt.quality.v0.models.Meeting] and
-        (__ \ "prior_incident").readNullable[com.gilt.quality.v0.models.Incident] and
-        (__ \ "next_incident").readNullable[com.gilt.quality.v0.models.Incident]
-      )(MeetingPager.apply _)
+      for {
+        meeting <- (__ \ "meeting").read[com.gilt.quality.v0.models.Meeting]
+        priorIncident <- (__ \ "prior_incident").readNullable[com.gilt.quality.v0.models.Incident]
+        nextIncident <- (__ \ "next_incident").readNullable[com.gilt.quality.v0.models.Incident]
+      } yield MeetingPager(meeting, priorIncident, nextIncident)
     }
 
     def jsObjectMeetingPager(obj: com.gilt.quality.v0.models.MeetingPager): play.api.libs.json.JsObject = {
@@ -1222,10 +1222,10 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityOrganization: play.api.libs.json.Reads[Organization] = {
-      (
-        (__ \ "key").read[String] and
-        (__ \ "name").read[String]
-      )(Organization.apply _)
+      for {
+        key <- (__ \ "key").read[String]
+        name <- (__ \ "name").read[String]
+      } yield Organization(key, name)
     }
 
     def jsObjectOrganization(obj: com.gilt.quality.v0.models.Organization): play.api.libs.json.JsObject = {
@@ -1244,10 +1244,10 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityOrganizationForm: play.api.libs.json.Reads[OrganizationForm] = {
-      (
-        (__ \ "name").read[String] and
-        (__ \ "key").readNullable[String]
-      )(OrganizationForm.apply _)
+      for {
+        name <- (__ \ "name").read[String]
+        key <- (__ \ "key").readNullable[String]
+      } yield OrganizationForm(name, key)
     }
 
     def jsObjectOrganizationForm(obj: com.gilt.quality.v0.models.OrganizationForm): play.api.libs.json.JsObject = {
@@ -1268,13 +1268,13 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityPlan: play.api.libs.json.Reads[Plan] = {
-      (
-        (__ \ "id").read[Long] and
-        (__ \ "incident_id").read[Long] and
-        (__ \ "body").read[String] and
-        (__ \ "grade").readNullable[Int] and
-        (__ \ "created_at").read[_root_.org.joda.time.DateTime]
-      )(Plan.apply _)
+      for {
+        id <- (__ \ "id").read[Long]
+        incidentId <- (__ \ "incident_id").read[Long]
+        body <- (__ \ "body").read[String]
+        grade <- (__ \ "grade").readNullable[Int]
+        createdAt <- (__ \ "created_at").read[_root_.org.joda.time.DateTime]
+      } yield Plan(id, incidentId, body, grade, createdAt)
     }
 
     def jsObjectPlan(obj: com.gilt.quality.v0.models.Plan): play.api.libs.json.JsObject = {
@@ -1298,10 +1298,10 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityPlanForm: play.api.libs.json.Reads[PlanForm] = {
-      (
-        (__ \ "incident_id").read[Long] and
-        (__ \ "body").read[String]
-      )(PlanForm.apply _)
+      for {
+        incidentId <- (__ \ "incident_id").read[Long]
+        body <- (__ \ "body").read[String]
+      } yield PlanForm(incidentId, body)
     }
 
     def jsObjectPlanForm(obj: com.gilt.quality.v0.models.PlanForm): play.api.libs.json.JsObject = {
@@ -1320,15 +1320,15 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityStatistic: play.api.libs.json.Reads[Statistic] = {
-      (
-        (__ \ "team").read[com.gilt.quality.v0.models.Team] and
-        (__ \ "total_grades").read[Long] and
-        (__ \ "average_grade").readNullable[Int] and
-        (__ \ "total_open_incidents").read[Long] and
-        (__ \ "total_incidents").read[Long] and
-        (__ \ "total_plans").read[Long] and
-        (__ \ "plans").readNullable[Seq[com.gilt.quality.v0.models.Plan]]
-      )(Statistic.apply _)
+      for {
+        team <- (__ \ "team").read[com.gilt.quality.v0.models.Team]
+        totalGrades <- (__ \ "total_grades").read[Long]
+        averageGrade <- (__ \ "average_grade").readNullable[Int]
+        totalOpenIncidents <- (__ \ "total_open_incidents").read[Long]
+        totalIncidents <- (__ \ "total_incidents").read[Long]
+        totalPlans <- (__ \ "total_plans").read[Long]
+        plans <- (__ \ "plans").readNullable[Seq[com.gilt.quality.v0.models.Plan]]
+      } yield Statistic(team, totalGrades, averageGrade, totalOpenIncidents, totalIncidents, totalPlans, plans)
     }
 
     def jsObjectStatistic(obj: com.gilt.quality.v0.models.Statistic): play.api.libs.json.JsObject = {
@@ -1357,12 +1357,12 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualitySubscription: play.api.libs.json.Reads[Subscription] = {
-      (
-        (__ \ "id").read[Long] and
-        (__ \ "organization").read[com.gilt.quality.v0.models.Organization] and
-        (__ \ "user").read[com.gilt.quality.v0.models.User] and
-        (__ \ "publication").read[com.gilt.quality.v0.models.Publication]
-      )(Subscription.apply _)
+      for {
+        id <- (__ \ "id").read[Long]
+        organization <- (__ \ "organization").read[com.gilt.quality.v0.models.Organization]
+        user <- (__ \ "user").read[com.gilt.quality.v0.models.User]
+        publication <- (__ \ "publication").read[com.gilt.quality.v0.models.Publication]
+      } yield Subscription(id, organization, user, publication)
     }
 
     def jsObjectSubscription(obj: com.gilt.quality.v0.models.Subscription): play.api.libs.json.JsObject = {
@@ -1383,11 +1383,11 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualitySubscriptionForm: play.api.libs.json.Reads[SubscriptionForm] = {
-      (
-        (__ \ "organization_key").read[String] and
-        (__ \ "user_guid").read[_root_.java.util.UUID] and
-        (__ \ "publication").read[com.gilt.quality.v0.models.Publication]
-      )(SubscriptionForm.apply _)
+      for {
+        organizationKey <- (__ \ "organization_key").read[String]
+        userGuid <- (__ \ "user_guid").read[_root_.java.util.UUID]
+        publication <- (__ \ "publication").read[com.gilt.quality.v0.models.Publication]
+      } yield SubscriptionForm(organizationKey, userGuid, publication)
     }
 
     def jsObjectSubscriptionForm(obj: com.gilt.quality.v0.models.SubscriptionForm): play.api.libs.json.JsObject = {
@@ -1407,12 +1407,12 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityTeam: play.api.libs.json.Reads[Team] = {
-      (
-        (__ \ "organization").read[com.gilt.quality.v0.models.Organization] and
-        (__ \ "key").read[String] and
-        (__ \ "email").readNullable[String] and
-        (__ \ "icons").read[com.gilt.quality.v0.models.Icons]
-      )(Team.apply _)
+      for {
+        organization <- (__ \ "organization").read[com.gilt.quality.v0.models.Organization]
+        key <- (__ \ "key").read[String]
+        email <- (__ \ "email").readNullable[String]
+        icons <- (__ \ "icons").read[com.gilt.quality.v0.models.Icons]
+      } yield Team(organization, key, email, icons)
     }
 
     def jsObjectTeam(obj: com.gilt.quality.v0.models.Team): play.api.libs.json.JsObject = {
@@ -1435,12 +1435,12 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityTeamForm: play.api.libs.json.Reads[TeamForm] = {
-      (
-        (__ \ "key").read[String] and
-        (__ \ "email").readNullable[String] and
-        (__ \ "smiley_url").readNullable[String] and
-        (__ \ "frowny_url").readNullable[String]
-      )(TeamForm.apply _)
+      for {
+        key <- (__ \ "key").read[String]
+        email <- (__ \ "email").readNullable[String]
+        smileyUrl <- (__ \ "smiley_url").readNullable[String]
+        frownyUrl <- (__ \ "frowny_url").readNullable[String]
+      } yield TeamForm(key, email, smileyUrl, frownyUrl)
     }
 
     def jsObjectTeamForm(obj: com.gilt.quality.v0.models.TeamForm): play.api.libs.json.JsObject = {
@@ -1469,10 +1469,10 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityTeamMember: play.api.libs.json.Reads[TeamMember] = {
-      (
-        (__ \ "team").read[com.gilt.quality.v0.models.Team] and
-        (__ \ "user").read[com.gilt.quality.v0.models.User]
-      )(TeamMember.apply _)
+      for {
+        team <- (__ \ "team").read[com.gilt.quality.v0.models.Team]
+        user <- (__ \ "user").read[com.gilt.quality.v0.models.User]
+      } yield TeamMember(team, user)
     }
 
     def jsObjectTeamMember(obj: com.gilt.quality.v0.models.TeamMember): play.api.libs.json.JsObject = {
@@ -1491,10 +1491,10 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityTeamMemberSummary: play.api.libs.json.Reads[TeamMemberSummary] = {
-      (
-        (__ \ "team").read[com.gilt.quality.v0.models.Team] and
-        (__ \ "number_members").read[Long]
-      )(TeamMemberSummary.apply _)
+      for {
+        team <- (__ \ "team").read[com.gilt.quality.v0.models.Team]
+        numberMembers <- (__ \ "number_members").read[Long]
+      } yield TeamMemberSummary(team, numberMembers)
     }
 
     def jsObjectTeamMemberSummary(obj: com.gilt.quality.v0.models.TeamMemberSummary): play.api.libs.json.JsObject = {
@@ -1513,11 +1513,11 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityUpdateTeamForm: play.api.libs.json.Reads[UpdateTeamForm] = {
-      (
-        (__ \ "email").readNullable[String] and
-        (__ \ "smiley_url").readNullable[String] and
-        (__ \ "frowny_url").readNullable[String]
-      )(UpdateTeamForm.apply _)
+      for {
+        email <- (__ \ "email").readNullable[String]
+        smileyUrl <- (__ \ "smiley_url").readNullable[String]
+        frownyUrl <- (__ \ "frowny_url").readNullable[String]
+      } yield UpdateTeamForm(email, smileyUrl, frownyUrl)
     }
 
     def jsObjectUpdateTeamForm(obj: com.gilt.quality.v0.models.UpdateTeamForm): play.api.libs.json.JsObject = {
@@ -1544,10 +1544,10 @@ package com.gilt.quality.v0.models {
     }
 
     implicit def jsonReadsQualityUser: play.api.libs.json.Reads[User] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "email").read[String]
-      )(User.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        email <- (__ \ "email").read[String]
+      } yield User(guid, email)
     }
 
     def jsObjectUser(obj: com.gilt.quality.v0.models.User): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/generators/play-22-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-22-built-in-types.txt
@@ -104,19 +104,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesArray: play.api.libs.json.Reads[Array] = {
-      (
-        (__ \ "boolean").read[Seq[Boolean]] and
-        (__ \ "dateiso8601").read[Seq[_root_.org.joda.time.LocalDate]] and
-        (__ \ "datetimeiso8601").read[Seq[_root_.org.joda.time.DateTime]] and
-        (__ \ "decimal").read[Seq[BigDecimal]] and
-        (__ \ "double").read[Seq[Double]] and
-        (__ \ "integer").read[Seq[Int]] and
-        (__ \ "json").read[Seq[_root_.play.api.libs.json.JsValue]] and
-        (__ \ "long").read[Seq[Long]] and
-        (__ \ "object").read[Seq[_root_.play.api.libs.json.JsObject]] and
-        (__ \ "string").read[Seq[String]] and
-        (__ \ "uuid").read[Seq[_root_.java.util.UUID]]
-      )(Array.apply _)
+      for {
+        boolean <- (__ \ "boolean").read[Seq[Boolean]]
+        dateiso8601 <- (__ \ "dateiso8601").read[Seq[_root_.org.joda.time.LocalDate]]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").read[Seq[_root_.org.joda.time.DateTime]]
+        decimal <- (__ \ "decimal").read[Seq[BigDecimal]]
+        double <- (__ \ "double").read[Seq[Double]]
+        integer <- (__ \ "integer").read[Seq[Int]]
+        json <- (__ \ "json").read[Seq[_root_.play.api.libs.json.JsValue]]
+        long <- (__ \ "long").read[Seq[Long]]
+        `object` <- (__ \ "object").read[Seq[_root_.play.api.libs.json.JsObject]]
+        string <- (__ \ "string").read[Seq[String]]
+        uuid <- (__ \ "uuid").read[Seq[_root_.java.util.UUID]]
+      } yield Array(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectArray(obj: apibuilder.models.Array): play.api.libs.json.JsObject = {
@@ -144,19 +144,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesOptarray: play.api.libs.json.Reads[Optarray] = {
-      (
-        (__ \ "boolean").readNullable[Seq[Boolean]] and
-        (__ \ "dateiso8601").readNullable[Seq[_root_.org.joda.time.LocalDate]] and
-        (__ \ "datetimeiso8601").readNullable[Seq[_root_.org.joda.time.DateTime]] and
-        (__ \ "decimal").readNullable[Seq[BigDecimal]] and
-        (__ \ "double").readNullable[Seq[Double]] and
-        (__ \ "integer").readNullable[Seq[Int]] and
-        (__ \ "json").readNullable[Seq[_root_.play.api.libs.json.JsValue]] and
-        (__ \ "long").readNullable[Seq[Long]] and
-        (__ \ "object").readNullable[Seq[_root_.play.api.libs.json.JsObject]] and
-        (__ \ "string").readNullable[Seq[String]] and
-        (__ \ "uuid").readNullable[Seq[_root_.java.util.UUID]]
-      )(Optarray.apply _)
+      for {
+        boolean <- (__ \ "boolean").readNullable[Seq[Boolean]]
+        dateiso8601 <- (__ \ "dateiso8601").readNullable[Seq[_root_.org.joda.time.LocalDate]]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").readNullable[Seq[_root_.org.joda.time.DateTime]]
+        decimal <- (__ \ "decimal").readNullable[Seq[BigDecimal]]
+        double <- (__ \ "double").readNullable[Seq[Double]]
+        integer <- (__ \ "integer").readNullable[Seq[Int]]
+        json <- (__ \ "json").readNullable[Seq[_root_.play.api.libs.json.JsValue]]
+        long <- (__ \ "long").readNullable[Seq[Long]]
+        `object` <- (__ \ "object").readNullable[Seq[_root_.play.api.libs.json.JsObject]]
+        string <- (__ \ "string").readNullable[Seq[String]]
+        uuid <- (__ \ "uuid").readNullable[Seq[_root_.java.util.UUID]]
+      } yield Optarray(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectOptarray(obj: apibuilder.models.Optarray): play.api.libs.json.JsObject = {
@@ -215,19 +215,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesOptional: play.api.libs.json.Reads[Optional] = {
-      (
-        (__ \ "boolean").readNullable[Boolean] and
-        (__ \ "dateiso8601").readNullable[_root_.org.joda.time.LocalDate] and
-        (__ \ "datetimeiso8601").readNullable[_root_.org.joda.time.DateTime] and
-        (__ \ "decimal").readNullable[BigDecimal] and
-        (__ \ "double").readNullable[Double] and
-        (__ \ "integer").readNullable[Int] and
-        (__ \ "json").readNullable[_root_.play.api.libs.json.JsValue] and
-        (__ \ "long").readNullable[Long] and
-        (__ \ "object").readNullable[_root_.play.api.libs.json.JsObject] and
-        (__ \ "string").readNullable[String] and
-        (__ \ "uuid").readNullable[_root_.java.util.UUID]
-      )(Optional.apply _)
+      for {
+        boolean <- (__ \ "boolean").readNullable[Boolean]
+        dateiso8601 <- (__ \ "dateiso8601").readNullable[_root_.org.joda.time.LocalDate]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").readNullable[_root_.org.joda.time.DateTime]
+        decimal <- (__ \ "decimal").readNullable[BigDecimal]
+        double <- (__ \ "double").readNullable[Double]
+        integer <- (__ \ "integer").readNullable[Int]
+        json <- (__ \ "json").readNullable[_root_.play.api.libs.json.JsValue]
+        long <- (__ \ "long").readNullable[Long]
+        `object` <- (__ \ "object").readNullable[_root_.play.api.libs.json.JsObject]
+        string <- (__ \ "string").readNullable[String]
+        uuid <- (__ \ "uuid").readNullable[_root_.java.util.UUID]
+      } yield Optional(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectOptional(obj: apibuilder.models.Optional): play.api.libs.json.JsObject = {
@@ -286,19 +286,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesRequired: play.api.libs.json.Reads[Required] = {
-      (
-        (__ \ "boolean").read[Boolean] and
-        (__ \ "dateiso8601").read[_root_.org.joda.time.LocalDate] and
-        (__ \ "datetimeiso8601").read[_root_.org.joda.time.DateTime] and
-        (__ \ "decimal").read[BigDecimal] and
-        (__ \ "double").read[Double] and
-        (__ \ "integer").read[Int] and
-        (__ \ "json").read[_root_.play.api.libs.json.JsValue] and
-        (__ \ "long").read[Long] and
-        (__ \ "object").read[_root_.play.api.libs.json.JsObject] and
-        (__ \ "string").read[String] and
-        (__ \ "uuid").read[_root_.java.util.UUID]
-      )(Required.apply _)
+      for {
+        boolean <- (__ \ "boolean").read[Boolean]
+        dateiso8601 <- (__ \ "dateiso8601").read[_root_.org.joda.time.LocalDate]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").read[_root_.org.joda.time.DateTime]
+        decimal <- (__ \ "decimal").read[BigDecimal]
+        double <- (__ \ "double").read[Double]
+        integer <- (__ \ "integer").read[Int]
+        json <- (__ \ "json").read[_root_.play.api.libs.json.JsValue]
+        long <- (__ \ "long").read[Long]
+        `object` <- (__ \ "object").read[_root_.play.api.libs.json.JsObject]
+        string <- (__ \ "string").read[String]
+        uuid <- (__ \ "uuid").read[_root_.java.util.UUID]
+      } yield Required(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectRequired(obj: apibuilder.models.Required): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/generators/play-23-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-23-built-in-types.txt
@@ -104,19 +104,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesArray: play.api.libs.json.Reads[Array] = {
-      (
-        (__ \ "boolean").read[Seq[Boolean]] and
-        (__ \ "dateiso8601").read[Seq[_root_.org.joda.time.LocalDate]] and
-        (__ \ "datetimeiso8601").read[Seq[_root_.org.joda.time.DateTime]] and
-        (__ \ "decimal").read[Seq[BigDecimal]] and
-        (__ \ "double").read[Seq[Double]] and
-        (__ \ "integer").read[Seq[Int]] and
-        (__ \ "json").read[Seq[_root_.play.api.libs.json.JsValue]] and
-        (__ \ "long").read[Seq[Long]] and
-        (__ \ "object").read[Seq[_root_.play.api.libs.json.JsObject]] and
-        (__ \ "string").read[Seq[String]] and
-        (__ \ "uuid").read[Seq[_root_.java.util.UUID]]
-      )(Array.apply _)
+      for {
+        boolean <- (__ \ "boolean").read[Seq[Boolean]]
+        dateiso8601 <- (__ \ "dateiso8601").read[Seq[_root_.org.joda.time.LocalDate]]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").read[Seq[_root_.org.joda.time.DateTime]]
+        decimal <- (__ \ "decimal").read[Seq[BigDecimal]]
+        double <- (__ \ "double").read[Seq[Double]]
+        integer <- (__ \ "integer").read[Seq[Int]]
+        json <- (__ \ "json").read[Seq[_root_.play.api.libs.json.JsValue]]
+        long <- (__ \ "long").read[Seq[Long]]
+        `object` <- (__ \ "object").read[Seq[_root_.play.api.libs.json.JsObject]]
+        string <- (__ \ "string").read[Seq[String]]
+        uuid <- (__ \ "uuid").read[Seq[_root_.java.util.UUID]]
+      } yield Array(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectArray(obj: apibuilder.models.Array): play.api.libs.json.JsObject = {
@@ -144,19 +144,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesOptarray: play.api.libs.json.Reads[Optarray] = {
-      (
-        (__ \ "boolean").readNullable[Seq[Boolean]] and
-        (__ \ "dateiso8601").readNullable[Seq[_root_.org.joda.time.LocalDate]] and
-        (__ \ "datetimeiso8601").readNullable[Seq[_root_.org.joda.time.DateTime]] and
-        (__ \ "decimal").readNullable[Seq[BigDecimal]] and
-        (__ \ "double").readNullable[Seq[Double]] and
-        (__ \ "integer").readNullable[Seq[Int]] and
-        (__ \ "json").readNullable[Seq[_root_.play.api.libs.json.JsValue]] and
-        (__ \ "long").readNullable[Seq[Long]] and
-        (__ \ "object").readNullable[Seq[_root_.play.api.libs.json.JsObject]] and
-        (__ \ "string").readNullable[Seq[String]] and
-        (__ \ "uuid").readNullable[Seq[_root_.java.util.UUID]]
-      )(Optarray.apply _)
+      for {
+        boolean <- (__ \ "boolean").readNullable[Seq[Boolean]]
+        dateiso8601 <- (__ \ "dateiso8601").readNullable[Seq[_root_.org.joda.time.LocalDate]]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").readNullable[Seq[_root_.org.joda.time.DateTime]]
+        decimal <- (__ \ "decimal").readNullable[Seq[BigDecimal]]
+        double <- (__ \ "double").readNullable[Seq[Double]]
+        integer <- (__ \ "integer").readNullable[Seq[Int]]
+        json <- (__ \ "json").readNullable[Seq[_root_.play.api.libs.json.JsValue]]
+        long <- (__ \ "long").readNullable[Seq[Long]]
+        `object` <- (__ \ "object").readNullable[Seq[_root_.play.api.libs.json.JsObject]]
+        string <- (__ \ "string").readNullable[Seq[String]]
+        uuid <- (__ \ "uuid").readNullable[Seq[_root_.java.util.UUID]]
+      } yield Optarray(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectOptarray(obj: apibuilder.models.Optarray): play.api.libs.json.JsObject = {
@@ -215,19 +215,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesOptional: play.api.libs.json.Reads[Optional] = {
-      (
-        (__ \ "boolean").readNullable[Boolean] and
-        (__ \ "dateiso8601").readNullable[_root_.org.joda.time.LocalDate] and
-        (__ \ "datetimeiso8601").readNullable[_root_.org.joda.time.DateTime] and
-        (__ \ "decimal").readNullable[BigDecimal] and
-        (__ \ "double").readNullable[Double] and
-        (__ \ "integer").readNullable[Int] and
-        (__ \ "json").readNullable[_root_.play.api.libs.json.JsValue] and
-        (__ \ "long").readNullable[Long] and
-        (__ \ "object").readNullable[_root_.play.api.libs.json.JsObject] and
-        (__ \ "string").readNullable[String] and
-        (__ \ "uuid").readNullable[_root_.java.util.UUID]
-      )(Optional.apply _)
+      for {
+        boolean <- (__ \ "boolean").readNullable[Boolean]
+        dateiso8601 <- (__ \ "dateiso8601").readNullable[_root_.org.joda.time.LocalDate]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").readNullable[_root_.org.joda.time.DateTime]
+        decimal <- (__ \ "decimal").readNullable[BigDecimal]
+        double <- (__ \ "double").readNullable[Double]
+        integer <- (__ \ "integer").readNullable[Int]
+        json <- (__ \ "json").readNullable[_root_.play.api.libs.json.JsValue]
+        long <- (__ \ "long").readNullable[Long]
+        `object` <- (__ \ "object").readNullable[_root_.play.api.libs.json.JsObject]
+        string <- (__ \ "string").readNullable[String]
+        uuid <- (__ \ "uuid").readNullable[_root_.java.util.UUID]
+      } yield Optional(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectOptional(obj: apibuilder.models.Optional): play.api.libs.json.JsObject = {
@@ -286,19 +286,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesRequired: play.api.libs.json.Reads[Required] = {
-      (
-        (__ \ "boolean").read[Boolean] and
-        (__ \ "dateiso8601").read[_root_.org.joda.time.LocalDate] and
-        (__ \ "datetimeiso8601").read[_root_.org.joda.time.DateTime] and
-        (__ \ "decimal").read[BigDecimal] and
-        (__ \ "double").read[Double] and
-        (__ \ "integer").read[Int] and
-        (__ \ "json").read[_root_.play.api.libs.json.JsValue] and
-        (__ \ "long").read[Long] and
-        (__ \ "object").read[_root_.play.api.libs.json.JsObject] and
-        (__ \ "string").read[String] and
-        (__ \ "uuid").read[_root_.java.util.UUID]
-      )(Required.apply _)
+      for {
+        boolean <- (__ \ "boolean").read[Boolean]
+        dateiso8601 <- (__ \ "dateiso8601").read[_root_.org.joda.time.LocalDate]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").read[_root_.org.joda.time.DateTime]
+        decimal <- (__ \ "decimal").read[BigDecimal]
+        double <- (__ \ "double").read[Double]
+        integer <- (__ \ "integer").read[Int]
+        json <- (__ \ "json").read[_root_.play.api.libs.json.JsValue]
+        long <- (__ \ "long").read[Long]
+        `object` <- (__ \ "object").read[_root_.play.api.libs.json.JsObject]
+        string <- (__ \ "string").read[String]
+        uuid <- (__ \ "uuid").read[_root_.java.util.UUID]
+      } yield Required(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectRequired(obj: apibuilder.models.Required): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/generators/play-24-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-24-built-in-types.txt
@@ -104,19 +104,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesArray: play.api.libs.json.Reads[Array] = {
-      (
-        (__ \ "boolean").read[Seq[Boolean]] and
-        (__ \ "dateiso8601").read[Seq[_root_.org.joda.time.LocalDate]] and
-        (__ \ "datetimeiso8601").read[Seq[_root_.org.joda.time.DateTime]] and
-        (__ \ "decimal").read[Seq[BigDecimal]] and
-        (__ \ "double").read[Seq[Double]] and
-        (__ \ "integer").read[Seq[Int]] and
-        (__ \ "json").read[Seq[_root_.play.api.libs.json.JsValue]] and
-        (__ \ "long").read[Seq[Long]] and
-        (__ \ "object").read[Seq[_root_.play.api.libs.json.JsObject]] and
-        (__ \ "string").read[Seq[String]] and
-        (__ \ "uuid").read[Seq[_root_.java.util.UUID]]
-      )(Array.apply _)
+      for {
+        boolean <- (__ \ "boolean").read[Seq[Boolean]]
+        dateiso8601 <- (__ \ "dateiso8601").read[Seq[_root_.org.joda.time.LocalDate]]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").read[Seq[_root_.org.joda.time.DateTime]]
+        decimal <- (__ \ "decimal").read[Seq[BigDecimal]]
+        double <- (__ \ "double").read[Seq[Double]]
+        integer <- (__ \ "integer").read[Seq[Int]]
+        json <- (__ \ "json").read[Seq[_root_.play.api.libs.json.JsValue]]
+        long <- (__ \ "long").read[Seq[Long]]
+        `object` <- (__ \ "object").read[Seq[_root_.play.api.libs.json.JsObject]]
+        string <- (__ \ "string").read[Seq[String]]
+        uuid <- (__ \ "uuid").read[Seq[_root_.java.util.UUID]]
+      } yield Array(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectArray(obj: apibuilder.models.Array): play.api.libs.json.JsObject = {
@@ -144,19 +144,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesOptarray: play.api.libs.json.Reads[Optarray] = {
-      (
-        (__ \ "boolean").readNullable[Seq[Boolean]] and
-        (__ \ "dateiso8601").readNullable[Seq[_root_.org.joda.time.LocalDate]] and
-        (__ \ "datetimeiso8601").readNullable[Seq[_root_.org.joda.time.DateTime]] and
-        (__ \ "decimal").readNullable[Seq[BigDecimal]] and
-        (__ \ "double").readNullable[Seq[Double]] and
-        (__ \ "integer").readNullable[Seq[Int]] and
-        (__ \ "json").readNullable[Seq[_root_.play.api.libs.json.JsValue]] and
-        (__ \ "long").readNullable[Seq[Long]] and
-        (__ \ "object").readNullable[Seq[_root_.play.api.libs.json.JsObject]] and
-        (__ \ "string").readNullable[Seq[String]] and
-        (__ \ "uuid").readNullable[Seq[_root_.java.util.UUID]]
-      )(Optarray.apply _)
+      for {
+        boolean <- (__ \ "boolean").readNullable[Seq[Boolean]]
+        dateiso8601 <- (__ \ "dateiso8601").readNullable[Seq[_root_.org.joda.time.LocalDate]]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").readNullable[Seq[_root_.org.joda.time.DateTime]]
+        decimal <- (__ \ "decimal").readNullable[Seq[BigDecimal]]
+        double <- (__ \ "double").readNullable[Seq[Double]]
+        integer <- (__ \ "integer").readNullable[Seq[Int]]
+        json <- (__ \ "json").readNullable[Seq[_root_.play.api.libs.json.JsValue]]
+        long <- (__ \ "long").readNullable[Seq[Long]]
+        `object` <- (__ \ "object").readNullable[Seq[_root_.play.api.libs.json.JsObject]]
+        string <- (__ \ "string").readNullable[Seq[String]]
+        uuid <- (__ \ "uuid").readNullable[Seq[_root_.java.util.UUID]]
+      } yield Optarray(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectOptarray(obj: apibuilder.models.Optarray): play.api.libs.json.JsObject = {
@@ -215,19 +215,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesOptional: play.api.libs.json.Reads[Optional] = {
-      (
-        (__ \ "boolean").readNullable[Boolean] and
-        (__ \ "dateiso8601").readNullable[_root_.org.joda.time.LocalDate] and
-        (__ \ "datetimeiso8601").readNullable[_root_.org.joda.time.DateTime] and
-        (__ \ "decimal").readNullable[BigDecimal] and
-        (__ \ "double").readNullable[Double] and
-        (__ \ "integer").readNullable[Int] and
-        (__ \ "json").readNullable[_root_.play.api.libs.json.JsValue] and
-        (__ \ "long").readNullable[Long] and
-        (__ \ "object").readNullable[_root_.play.api.libs.json.JsObject] and
-        (__ \ "string").readNullable[String] and
-        (__ \ "uuid").readNullable[_root_.java.util.UUID]
-      )(Optional.apply _)
+      for {
+        boolean <- (__ \ "boolean").readNullable[Boolean]
+        dateiso8601 <- (__ \ "dateiso8601").readNullable[_root_.org.joda.time.LocalDate]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").readNullable[_root_.org.joda.time.DateTime]
+        decimal <- (__ \ "decimal").readNullable[BigDecimal]
+        double <- (__ \ "double").readNullable[Double]
+        integer <- (__ \ "integer").readNullable[Int]
+        json <- (__ \ "json").readNullable[_root_.play.api.libs.json.JsValue]
+        long <- (__ \ "long").readNullable[Long]
+        `object` <- (__ \ "object").readNullable[_root_.play.api.libs.json.JsObject]
+        string <- (__ \ "string").readNullable[String]
+        uuid <- (__ \ "uuid").readNullable[_root_.java.util.UUID]
+      } yield Optional(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectOptional(obj: apibuilder.models.Optional): play.api.libs.json.JsObject = {
@@ -286,19 +286,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesRequired: play.api.libs.json.Reads[Required] = {
-      (
-        (__ \ "boolean").read[Boolean] and
-        (__ \ "dateiso8601").read[_root_.org.joda.time.LocalDate] and
-        (__ \ "datetimeiso8601").read[_root_.org.joda.time.DateTime] and
-        (__ \ "decimal").read[BigDecimal] and
-        (__ \ "double").read[Double] and
-        (__ \ "integer").read[Int] and
-        (__ \ "json").read[_root_.play.api.libs.json.JsValue] and
-        (__ \ "long").read[Long] and
-        (__ \ "object").read[_root_.play.api.libs.json.JsObject] and
-        (__ \ "string").read[String] and
-        (__ \ "uuid").read[_root_.java.util.UUID]
-      )(Required.apply _)
+      for {
+        boolean <- (__ \ "boolean").read[Boolean]
+        dateiso8601 <- (__ \ "dateiso8601").read[_root_.org.joda.time.LocalDate]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").read[_root_.org.joda.time.DateTime]
+        decimal <- (__ \ "decimal").read[BigDecimal]
+        double <- (__ \ "double").read[Double]
+        integer <- (__ \ "integer").read[Int]
+        json <- (__ \ "json").read[_root_.play.api.libs.json.JsValue]
+        long <- (__ \ "long").read[Long]
+        `object` <- (__ \ "object").read[_root_.play.api.libs.json.JsObject]
+        string <- (__ \ "string").read[String]
+        uuid <- (__ \ "uuid").read[_root_.java.util.UUID]
+      } yield Required(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectRequired(obj: apibuilder.models.Required): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/generators/play-25-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-25-built-in-types.txt
@@ -104,19 +104,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesArray: play.api.libs.json.Reads[Array] = {
-      (
-        (__ \ "boolean").read[Seq[Boolean]] and
-        (__ \ "dateiso8601").read[Seq[_root_.org.joda.time.LocalDate]] and
-        (__ \ "datetimeiso8601").read[Seq[_root_.org.joda.time.DateTime]] and
-        (__ \ "decimal").read[Seq[BigDecimal]] and
-        (__ \ "double").read[Seq[Double]] and
-        (__ \ "integer").read[Seq[Int]] and
-        (__ \ "json").read[Seq[_root_.play.api.libs.json.JsValue]] and
-        (__ \ "long").read[Seq[Long]] and
-        (__ \ "object").read[Seq[_root_.play.api.libs.json.JsObject]] and
-        (__ \ "string").read[Seq[String]] and
-        (__ \ "uuid").read[Seq[_root_.java.util.UUID]]
-      )(Array.apply _)
+      for {
+        boolean <- (__ \ "boolean").read[Seq[Boolean]]
+        dateiso8601 <- (__ \ "dateiso8601").read[Seq[_root_.org.joda.time.LocalDate]]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").read[Seq[_root_.org.joda.time.DateTime]]
+        decimal <- (__ \ "decimal").read[Seq[BigDecimal]]
+        double <- (__ \ "double").read[Seq[Double]]
+        integer <- (__ \ "integer").read[Seq[Int]]
+        json <- (__ \ "json").read[Seq[_root_.play.api.libs.json.JsValue]]
+        long <- (__ \ "long").read[Seq[Long]]
+        `object` <- (__ \ "object").read[Seq[_root_.play.api.libs.json.JsObject]]
+        string <- (__ \ "string").read[Seq[String]]
+        uuid <- (__ \ "uuid").read[Seq[_root_.java.util.UUID]]
+      } yield Array(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectArray(obj: apibuilder.models.Array): play.api.libs.json.JsObject = {
@@ -144,19 +144,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesOptarray: play.api.libs.json.Reads[Optarray] = {
-      (
-        (__ \ "boolean").readNullable[Seq[Boolean]] and
-        (__ \ "dateiso8601").readNullable[Seq[_root_.org.joda.time.LocalDate]] and
-        (__ \ "datetimeiso8601").readNullable[Seq[_root_.org.joda.time.DateTime]] and
-        (__ \ "decimal").readNullable[Seq[BigDecimal]] and
-        (__ \ "double").readNullable[Seq[Double]] and
-        (__ \ "integer").readNullable[Seq[Int]] and
-        (__ \ "json").readNullable[Seq[_root_.play.api.libs.json.JsValue]] and
-        (__ \ "long").readNullable[Seq[Long]] and
-        (__ \ "object").readNullable[Seq[_root_.play.api.libs.json.JsObject]] and
-        (__ \ "string").readNullable[Seq[String]] and
-        (__ \ "uuid").readNullable[Seq[_root_.java.util.UUID]]
-      )(Optarray.apply _)
+      for {
+        boolean <- (__ \ "boolean").readNullable[Seq[Boolean]]
+        dateiso8601 <- (__ \ "dateiso8601").readNullable[Seq[_root_.org.joda.time.LocalDate]]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").readNullable[Seq[_root_.org.joda.time.DateTime]]
+        decimal <- (__ \ "decimal").readNullable[Seq[BigDecimal]]
+        double <- (__ \ "double").readNullable[Seq[Double]]
+        integer <- (__ \ "integer").readNullable[Seq[Int]]
+        json <- (__ \ "json").readNullable[Seq[_root_.play.api.libs.json.JsValue]]
+        long <- (__ \ "long").readNullable[Seq[Long]]
+        `object` <- (__ \ "object").readNullable[Seq[_root_.play.api.libs.json.JsObject]]
+        string <- (__ \ "string").readNullable[Seq[String]]
+        uuid <- (__ \ "uuid").readNullable[Seq[_root_.java.util.UUID]]
+      } yield Optarray(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectOptarray(obj: apibuilder.models.Optarray): play.api.libs.json.JsObject = {
@@ -215,19 +215,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesOptional: play.api.libs.json.Reads[Optional] = {
-      (
-        (__ \ "boolean").readNullable[Boolean] and
-        (__ \ "dateiso8601").readNullable[_root_.org.joda.time.LocalDate] and
-        (__ \ "datetimeiso8601").readNullable[_root_.org.joda.time.DateTime] and
-        (__ \ "decimal").readNullable[BigDecimal] and
-        (__ \ "double").readNullable[Double] and
-        (__ \ "integer").readNullable[Int] and
-        (__ \ "json").readNullable[_root_.play.api.libs.json.JsValue] and
-        (__ \ "long").readNullable[Long] and
-        (__ \ "object").readNullable[_root_.play.api.libs.json.JsObject] and
-        (__ \ "string").readNullable[String] and
-        (__ \ "uuid").readNullable[_root_.java.util.UUID]
-      )(Optional.apply _)
+      for {
+        boolean <- (__ \ "boolean").readNullable[Boolean]
+        dateiso8601 <- (__ \ "dateiso8601").readNullable[_root_.org.joda.time.LocalDate]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").readNullable[_root_.org.joda.time.DateTime]
+        decimal <- (__ \ "decimal").readNullable[BigDecimal]
+        double <- (__ \ "double").readNullable[Double]
+        integer <- (__ \ "integer").readNullable[Int]
+        json <- (__ \ "json").readNullable[_root_.play.api.libs.json.JsValue]
+        long <- (__ \ "long").readNullable[Long]
+        `object` <- (__ \ "object").readNullable[_root_.play.api.libs.json.JsObject]
+        string <- (__ \ "string").readNullable[String]
+        uuid <- (__ \ "uuid").readNullable[_root_.java.util.UUID]
+      } yield Optional(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectOptional(obj: apibuilder.models.Optional): play.api.libs.json.JsObject = {
@@ -286,19 +286,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesRequired: play.api.libs.json.Reads[Required] = {
-      (
-        (__ \ "boolean").read[Boolean] and
-        (__ \ "dateiso8601").read[_root_.org.joda.time.LocalDate] and
-        (__ \ "datetimeiso8601").read[_root_.org.joda.time.DateTime] and
-        (__ \ "decimal").read[BigDecimal] and
-        (__ \ "double").read[Double] and
-        (__ \ "integer").read[Int] and
-        (__ \ "json").read[_root_.play.api.libs.json.JsValue] and
-        (__ \ "long").read[Long] and
-        (__ \ "object").read[_root_.play.api.libs.json.JsObject] and
-        (__ \ "string").read[String] and
-        (__ \ "uuid").read[_root_.java.util.UUID]
-      )(Required.apply _)
+      for {
+        boolean <- (__ \ "boolean").read[Boolean]
+        dateiso8601 <- (__ \ "dateiso8601").read[_root_.org.joda.time.LocalDate]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").read[_root_.org.joda.time.DateTime]
+        decimal <- (__ \ "decimal").read[BigDecimal]
+        double <- (__ \ "double").read[Double]
+        integer <- (__ \ "integer").read[Int]
+        json <- (__ \ "json").read[_root_.play.api.libs.json.JsValue]
+        long <- (__ \ "long").read[Long]
+        `object` <- (__ \ "object").read[_root_.play.api.libs.json.JsObject]
+        string <- (__ \ "string").read[String]
+        uuid <- (__ \ "uuid").read[_root_.java.util.UUID]
+      } yield Required(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectRequired(obj: apibuilder.models.Required): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/generators/play-26-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-26-built-in-types.txt
@@ -104,19 +104,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesArray: play.api.libs.json.Reads[Array] = {
-      (
-        (__ \ "boolean").read[Seq[Boolean]] and
-        (__ \ "dateiso8601").read[Seq[_root_.org.joda.time.LocalDate]] and
-        (__ \ "datetimeiso8601").read[Seq[_root_.org.joda.time.DateTime]] and
-        (__ \ "decimal").read[Seq[BigDecimal]] and
-        (__ \ "double").read[Seq[Double]] and
-        (__ \ "integer").read[Seq[Int]] and
-        (__ \ "json").read[Seq[_root_.play.api.libs.json.JsValue]] and
-        (__ \ "long").read[Seq[Long]] and
-        (__ \ "object").read[Seq[_root_.play.api.libs.json.JsObject]] and
-        (__ \ "string").read[Seq[String]] and
-        (__ \ "uuid").read[Seq[_root_.java.util.UUID]]
-      )(Array.apply _)
+      for {
+        boolean <- (__ \ "boolean").read[Seq[Boolean]]
+        dateiso8601 <- (__ \ "dateiso8601").read[Seq[_root_.org.joda.time.LocalDate]]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").read[Seq[_root_.org.joda.time.DateTime]]
+        decimal <- (__ \ "decimal").read[Seq[BigDecimal]]
+        double <- (__ \ "double").read[Seq[Double]]
+        integer <- (__ \ "integer").read[Seq[Int]]
+        json <- (__ \ "json").read[Seq[_root_.play.api.libs.json.JsValue]]
+        long <- (__ \ "long").read[Seq[Long]]
+        `object` <- (__ \ "object").read[Seq[_root_.play.api.libs.json.JsObject]]
+        string <- (__ \ "string").read[Seq[String]]
+        uuid <- (__ \ "uuid").read[Seq[_root_.java.util.UUID]]
+      } yield Array(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectArray(obj: apibuilder.models.Array): play.api.libs.json.JsObject = {
@@ -144,19 +144,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesOptarray: play.api.libs.json.Reads[Optarray] = {
-      (
-        (__ \ "boolean").readNullable[Seq[Boolean]] and
-        (__ \ "dateiso8601").readNullable[Seq[_root_.org.joda.time.LocalDate]] and
-        (__ \ "datetimeiso8601").readNullable[Seq[_root_.org.joda.time.DateTime]] and
-        (__ \ "decimal").readNullable[Seq[BigDecimal]] and
-        (__ \ "double").readNullable[Seq[Double]] and
-        (__ \ "integer").readNullable[Seq[Int]] and
-        (__ \ "json").readNullable[Seq[_root_.play.api.libs.json.JsValue]] and
-        (__ \ "long").readNullable[Seq[Long]] and
-        (__ \ "object").readNullable[Seq[_root_.play.api.libs.json.JsObject]] and
-        (__ \ "string").readNullable[Seq[String]] and
-        (__ \ "uuid").readNullable[Seq[_root_.java.util.UUID]]
-      )(Optarray.apply _)
+      for {
+        boolean <- (__ \ "boolean").readNullable[Seq[Boolean]]
+        dateiso8601 <- (__ \ "dateiso8601").readNullable[Seq[_root_.org.joda.time.LocalDate]]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").readNullable[Seq[_root_.org.joda.time.DateTime]]
+        decimal <- (__ \ "decimal").readNullable[Seq[BigDecimal]]
+        double <- (__ \ "double").readNullable[Seq[Double]]
+        integer <- (__ \ "integer").readNullable[Seq[Int]]
+        json <- (__ \ "json").readNullable[Seq[_root_.play.api.libs.json.JsValue]]
+        long <- (__ \ "long").readNullable[Seq[Long]]
+        `object` <- (__ \ "object").readNullable[Seq[_root_.play.api.libs.json.JsObject]]
+        string <- (__ \ "string").readNullable[Seq[String]]
+        uuid <- (__ \ "uuid").readNullable[Seq[_root_.java.util.UUID]]
+      } yield Optarray(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectOptarray(obj: apibuilder.models.Optarray): play.api.libs.json.JsObject = {
@@ -215,19 +215,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesOptional: play.api.libs.json.Reads[Optional] = {
-      (
-        (__ \ "boolean").readNullable[Boolean] and
-        (__ \ "dateiso8601").readNullable[_root_.org.joda.time.LocalDate] and
-        (__ \ "datetimeiso8601").readNullable[_root_.org.joda.time.DateTime] and
-        (__ \ "decimal").readNullable[BigDecimal] and
-        (__ \ "double").readNullable[Double] and
-        (__ \ "integer").readNullable[Int] and
-        (__ \ "json").readNullable[_root_.play.api.libs.json.JsValue] and
-        (__ \ "long").readNullable[Long] and
-        (__ \ "object").readNullable[_root_.play.api.libs.json.JsObject] and
-        (__ \ "string").readNullable[String] and
-        (__ \ "uuid").readNullable[_root_.java.util.UUID]
-      )(Optional.apply _)
+      for {
+        boolean <- (__ \ "boolean").readNullable[Boolean]
+        dateiso8601 <- (__ \ "dateiso8601").readNullable[_root_.org.joda.time.LocalDate]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").readNullable[_root_.org.joda.time.DateTime]
+        decimal <- (__ \ "decimal").readNullable[BigDecimal]
+        double <- (__ \ "double").readNullable[Double]
+        integer <- (__ \ "integer").readNullable[Int]
+        json <- (__ \ "json").readNullable[_root_.play.api.libs.json.JsValue]
+        long <- (__ \ "long").readNullable[Long]
+        `object` <- (__ \ "object").readNullable[_root_.play.api.libs.json.JsObject]
+        string <- (__ \ "string").readNullable[String]
+        uuid <- (__ \ "uuid").readNullable[_root_.java.util.UUID]
+      } yield Optional(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectOptional(obj: apibuilder.models.Optional): play.api.libs.json.JsObject = {
@@ -286,19 +286,19 @@ package apibuilder.models {
     }
 
     implicit def jsonReadsBuiltInTypesRequired: play.api.libs.json.Reads[Required] = {
-      (
-        (__ \ "boolean").read[Boolean] and
-        (__ \ "dateiso8601").read[_root_.org.joda.time.LocalDate] and
-        (__ \ "datetimeiso8601").read[_root_.org.joda.time.DateTime] and
-        (__ \ "decimal").read[BigDecimal] and
-        (__ \ "double").read[Double] and
-        (__ \ "integer").read[Int] and
-        (__ \ "json").read[_root_.play.api.libs.json.JsValue] and
-        (__ \ "long").read[Long] and
-        (__ \ "object").read[_root_.play.api.libs.json.JsObject] and
-        (__ \ "string").read[String] and
-        (__ \ "uuid").read[_root_.java.util.UUID]
-      )(Required.apply _)
+      for {
+        boolean <- (__ \ "boolean").read[Boolean]
+        dateiso8601 <- (__ \ "dateiso8601").read[_root_.org.joda.time.LocalDate]
+        datetimeiso8601 <- (__ \ "datetimeiso8601").read[_root_.org.joda.time.DateTime]
+        decimal <- (__ \ "decimal").read[BigDecimal]
+        double <- (__ \ "double").read[Double]
+        integer <- (__ \ "integer").read[Int]
+        json <- (__ \ "json").read[_root_.play.api.libs.json.JsValue]
+        long <- (__ \ "long").read[Long]
+        `object` <- (__ \ "object").read[_root_.play.api.libs.json.JsObject]
+        string <- (__ \ "string").read[String]
+        uuid <- (__ \ "uuid").read[_root_.java.util.UUID]
+      } yield Required(boolean, dateiso8601, datetimeiso8601, decimal, double, integer, json, long, `object`, string, uuid)
     }
 
     def jsObjectRequired(obj: apibuilder.models.Required): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -188,29 +188,29 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiBig: play.api.libs.json.Reads[Big] = {
-      (
-        (__ \ "f1").read[String] and
-        (__ \ "f2").read[String] and
-        (__ \ "f3").read[String] and
-        (__ \ "f4").read[String] and
-        (__ \ "f5").read[String] and
-        (__ \ "f6").read[String] and
-        (__ \ "f7").read[String] and
-        (__ \ "f8").read[String] and
-        (__ \ "f9").read[String] and
-        (__ \ "f10").read[String] and
-        (__ \ "f11").read[String] and
-        (__ \ "f12").read[String] and
-        (__ \ "f13").read[String] and
-        (__ \ "f14").read[String] and
-        (__ \ "f15").read[String] and
-        (__ \ "f16").read[String] and
-        (__ \ "f17").read[String] and
-        (__ \ "f18").read[String] and
-        (__ \ "f19").read[String] and
-        (__ \ "f20").read[String] and
-        (__ \ "f21").read[String]
-      )(Big.apply _)
+      for {
+        f1 <- (__ \ "f1").read[String]
+        f2 <- (__ \ "f2").read[String]
+        f3 <- (__ \ "f3").read[String]
+        f4 <- (__ \ "f4").read[String]
+        f5 <- (__ \ "f5").read[String]
+        f6 <- (__ \ "f6").read[String]
+        f7 <- (__ \ "f7").read[String]
+        f8 <- (__ \ "f8").read[String]
+        f9 <- (__ \ "f9").read[String]
+        f10 <- (__ \ "f10").read[String]
+        f11 <- (__ \ "f11").read[String]
+        f12 <- (__ \ "f12").read[String]
+        f13 <- (__ \ "f13").read[String]
+        f14 <- (__ \ "f14").read[String]
+        f15 <- (__ \ "f15").read[String]
+        f16 <- (__ \ "f16").read[String]
+        f17 <- (__ \ "f17").read[String]
+        f18 <- (__ \ "f18").read[String]
+        f19 <- (__ \ "f19").read[String]
+        f20 <- (__ \ "f20").read[String]
+        f21 <- (__ \ "f21").read[String]
+      } yield Big(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21)
     }
 
     def jsObjectBig(obj: io.apibuilder.reference.api.v0.models.Big): play.api.libs.json.JsObject = {
@@ -266,10 +266,10 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiError: play.api.libs.json.Reads[Error] = {
-      (
-        (__ \ "code").read[String] and
-        (__ \ "message").read[String]
-      )(Error.apply _)
+      for {
+        code <- (__ \ "code").read[String]
+        message <- (__ \ "message").read[String]
+      } yield Error(code, message)
     }
 
     def jsObjectError(obj: io.apibuilder.reference.api.v0.models.Error): play.api.libs.json.JsObject = {
@@ -306,12 +306,12 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiMember: play.api.libs.json.Reads[Member] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "organization").read[io.apibuilder.reference.api.v0.models.Organization] and
-        (__ \ "user").read[io.apibuilder.reference.api.v0.models.User] and
-        (__ \ "role").read[String]
-      )(Member.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        organization <- (__ \ "organization").read[io.apibuilder.reference.api.v0.models.Organization]
+        user <- (__ \ "user").read[io.apibuilder.reference.api.v0.models.User]
+        role <- (__ \ "role").read[String]
+      } yield Member(guid, organization, user, role)
     }
 
     def jsObjectMember(obj: io.apibuilder.reference.api.v0.models.Member): play.api.libs.json.JsObject = {
@@ -332,10 +332,10 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiOrganization: play.api.libs.json.Reads[Organization] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "name").read[String]
-      )(Organization.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        name <- (__ \ "name").read[String]
+      } yield Organization(guid, name)
     }
 
     def jsObjectOrganization(obj: io.apibuilder.reference.api.v0.models.Organization): play.api.libs.json.JsObject = {
@@ -354,13 +354,13 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiUser: play.api.libs.json.Reads[User] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "email").read[String] and
-        (__ \ "active").read[Boolean] and
-        (__ \ "age_group").read[io.apibuilder.reference.api.v0.models.AgeGroup] and
-        (__ \ "tags").readNullable[Map[String, String]]
-      )(User.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        email <- (__ \ "email").read[String]
+        active <- (__ \ "active").read[Boolean]
+        ageGroup <- (__ \ "age_group").read[io.apibuilder.reference.api.v0.models.AgeGroup]
+        tags <- (__ \ "tags").readNullable[Map[String, String]]
+      } yield User(guid, email, active, ageGroup, tags)
     }
 
     def jsObjectUser(obj: io.apibuilder.reference.api.v0.models.User): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -28,7 +28,11 @@ package io.apibuilder.reference.api.v0.models {
     f18: String,
     f19: String,
     f20: String,
-    f21: String
+    f21: String,
+    f22: String,
+    f23: String,
+    f24: String,
+    f25: String
   )
 
   final case class Echo(
@@ -210,7 +214,11 @@ package io.apibuilder.reference.api.v0.models {
         f19 <- (__ \ "f19").read[String]
         f20 <- (__ \ "f20").read[String]
         f21 <- (__ \ "f21").read[String]
-      } yield Big(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21)
+        f22 <- (__ \ "f22").read[String]
+        f23 <- (__ \ "f23").read[String]
+        f24 <- (__ \ "f24").read[String]
+        f25 <- (__ \ "f25").read[String]
+      } yield Big(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25)
     }
 
     def jsObjectBig(obj: io.apibuilder.reference.api.v0.models.Big): play.api.libs.json.JsObject = {
@@ -235,7 +243,11 @@ package io.apibuilder.reference.api.v0.models {
         "f18" -> play.api.libs.json.JsString(obj.f18),
         "f19" -> play.api.libs.json.JsString(obj.f19),
         "f20" -> play.api.libs.json.JsString(obj.f20),
-        "f21" -> play.api.libs.json.JsString(obj.f21)
+        "f21" -> play.api.libs.json.JsString(obj.f21),
+        "f22" -> play.api.libs.json.JsString(obj.f22),
+        "f23" -> play.api.libs.json.JsString(obj.f23),
+        "f24" -> play.api.libs.json.JsString(obj.f24),
+        "f25" -> play.api.libs.json.JsString(obj.f25)
       )
     }
 

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -188,29 +188,29 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiBig: play.api.libs.json.Reads[Big] = {
-      (
-        (__ \ "f1").read[String] and
-        (__ \ "f2").read[String] and
-        (__ \ "f3").read[String] and
-        (__ \ "f4").read[String] and
-        (__ \ "f5").read[String] and
-        (__ \ "f6").read[String] and
-        (__ \ "f7").read[String] and
-        (__ \ "f8").read[String] and
-        (__ \ "f9").read[String] and
-        (__ \ "f10").read[String] and
-        (__ \ "f11").read[String] and
-        (__ \ "f12").read[String] and
-        (__ \ "f13").read[String] and
-        (__ \ "f14").read[String] and
-        (__ \ "f15").read[String] and
-        (__ \ "f16").read[String] and
-        (__ \ "f17").read[String] and
-        (__ \ "f18").read[String] and
-        (__ \ "f19").read[String] and
-        (__ \ "f20").read[String] and
-        (__ \ "f21").read[String]
-      )(Big.apply _)
+      for {
+        f1 <- (__ \ "f1").read[String]
+        f2 <- (__ \ "f2").read[String]
+        f3 <- (__ \ "f3").read[String]
+        f4 <- (__ \ "f4").read[String]
+        f5 <- (__ \ "f5").read[String]
+        f6 <- (__ \ "f6").read[String]
+        f7 <- (__ \ "f7").read[String]
+        f8 <- (__ \ "f8").read[String]
+        f9 <- (__ \ "f9").read[String]
+        f10 <- (__ \ "f10").read[String]
+        f11 <- (__ \ "f11").read[String]
+        f12 <- (__ \ "f12").read[String]
+        f13 <- (__ \ "f13").read[String]
+        f14 <- (__ \ "f14").read[String]
+        f15 <- (__ \ "f15").read[String]
+        f16 <- (__ \ "f16").read[String]
+        f17 <- (__ \ "f17").read[String]
+        f18 <- (__ \ "f18").read[String]
+        f19 <- (__ \ "f19").read[String]
+        f20 <- (__ \ "f20").read[String]
+        f21 <- (__ \ "f21").read[String]
+      } yield Big(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21)
     }
 
     def jsObjectBig(obj: io.apibuilder.reference.api.v0.models.Big): play.api.libs.json.JsObject = {
@@ -266,10 +266,10 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiError: play.api.libs.json.Reads[Error] = {
-      (
-        (__ \ "code").read[String] and
-        (__ \ "message").read[String]
-      )(Error.apply _)
+      for {
+        code <- (__ \ "code").read[String]
+        message <- (__ \ "message").read[String]
+      } yield Error(code, message)
     }
 
     def jsObjectError(obj: io.apibuilder.reference.api.v0.models.Error): play.api.libs.json.JsObject = {
@@ -306,12 +306,12 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiMember: play.api.libs.json.Reads[Member] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "organization").read[io.apibuilder.reference.api.v0.models.Organization] and
-        (__ \ "user").read[io.apibuilder.reference.api.v0.models.User] and
-        (__ \ "role").read[String]
-      )(Member.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        organization <- (__ \ "organization").read[io.apibuilder.reference.api.v0.models.Organization]
+        user <- (__ \ "user").read[io.apibuilder.reference.api.v0.models.User]
+        role <- (__ \ "role").read[String]
+      } yield Member(guid, organization, user, role)
     }
 
     def jsObjectMember(obj: io.apibuilder.reference.api.v0.models.Member): play.api.libs.json.JsObject = {
@@ -332,10 +332,10 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiOrganization: play.api.libs.json.Reads[Organization] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "name").read[String]
-      )(Organization.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        name <- (__ \ "name").read[String]
+      } yield Organization(guid, name)
     }
 
     def jsObjectOrganization(obj: io.apibuilder.reference.api.v0.models.Organization): play.api.libs.json.JsObject = {
@@ -354,13 +354,13 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiUser: play.api.libs.json.Reads[User] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "email").read[String] and
-        (__ \ "active").read[Boolean] and
-        (__ \ "age_group").read[io.apibuilder.reference.api.v0.models.AgeGroup] and
-        (__ \ "tags").readNullable[Map[String, String]]
-      )(User.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        email <- (__ \ "email").read[String]
+        active <- (__ \ "active").read[Boolean]
+        ageGroup <- (__ \ "age_group").read[io.apibuilder.reference.api.v0.models.AgeGroup]
+        tags <- (__ \ "tags").readNullable[Map[String, String]]
+      } yield User(guid, email, active, ageGroup, tags)
     }
 
     def jsObjectUser(obj: io.apibuilder.reference.api.v0.models.User): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -28,7 +28,11 @@ package io.apibuilder.reference.api.v0.models {
     f18: String,
     f19: String,
     f20: String,
-    f21: String
+    f21: String,
+    f22: String,
+    f23: String,
+    f24: String,
+    f25: String
   )
 
   final case class Echo(
@@ -210,7 +214,11 @@ package io.apibuilder.reference.api.v0.models {
         f19 <- (__ \ "f19").read[String]
         f20 <- (__ \ "f20").read[String]
         f21 <- (__ \ "f21").read[String]
-      } yield Big(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21)
+        f22 <- (__ \ "f22").read[String]
+        f23 <- (__ \ "f23").read[String]
+        f24 <- (__ \ "f24").read[String]
+        f25 <- (__ \ "f25").read[String]
+      } yield Big(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25)
     }
 
     def jsObjectBig(obj: io.apibuilder.reference.api.v0.models.Big): play.api.libs.json.JsObject = {
@@ -235,7 +243,11 @@ package io.apibuilder.reference.api.v0.models {
         "f18" -> play.api.libs.json.JsString(obj.f18),
         "f19" -> play.api.libs.json.JsString(obj.f19),
         "f20" -> play.api.libs.json.JsString(obj.f20),
-        "f21" -> play.api.libs.json.JsString(obj.f21)
+        "f21" -> play.api.libs.json.JsString(obj.f21),
+        "f22" -> play.api.libs.json.JsString(obj.f22),
+        "f23" -> play.api.libs.json.JsString(obj.f23),
+        "f24" -> play.api.libs.json.JsString(obj.f24),
+        "f25" -> play.api.libs.json.JsString(obj.f25)
       )
     }
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -28,7 +28,11 @@ package io.apibuilder.reference.api.v0.models {
     f18: String,
     f19: String,
     f20: String,
-    f21: String
+    f21: String,
+    f22: String,
+    f23: String,
+    f24: String,
+    f25: String
   )
 
   final case class Echo(
@@ -211,7 +215,11 @@ package io.apibuilder.reference.api.v0.models {
         f19 <- (__ \ "f19").read[String]
         f20 <- (__ \ "f20").read[String]
         f21 <- (__ \ "f21").read[String]
-      } yield Big(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21)
+        f22 <- (__ \ "f22").read[String]
+        f23 <- (__ \ "f23").read[String]
+        f24 <- (__ \ "f24").read[String]
+        f25 <- (__ \ "f25").read[String]
+      } yield Big(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25)
     }
 
     def jsObjectBig(obj: io.apibuilder.reference.api.v0.models.Big): play.api.libs.json.JsObject = {
@@ -236,7 +244,11 @@ package io.apibuilder.reference.api.v0.models {
         "f18" -> play.api.libs.json.JsString(obj.f18),
         "f19" -> play.api.libs.json.JsString(obj.f19),
         "f20" -> play.api.libs.json.JsString(obj.f20),
-        "f21" -> play.api.libs.json.JsString(obj.f21)
+        "f21" -> play.api.libs.json.JsString(obj.f21),
+        "f22" -> play.api.libs.json.JsString(obj.f22),
+        "f23" -> play.api.libs.json.JsString(obj.f23),
+        "f24" -> play.api.libs.json.JsString(obj.f24),
+        "f25" -> play.api.libs.json.JsString(obj.f25)
       )
     }
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -189,29 +189,29 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiBig: play.api.libs.json.Reads[Big] = {
-      (
-        (__ \ "f1").read[String] and
-        (__ \ "f2").read[String] and
-        (__ \ "f3").read[String] and
-        (__ \ "f4").read[String] and
-        (__ \ "f5").read[String] and
-        (__ \ "f6").read[String] and
-        (__ \ "f7").read[String] and
-        (__ \ "f8").read[String] and
-        (__ \ "f9").read[String] and
-        (__ \ "f10").read[String] and
-        (__ \ "f11").read[String] and
-        (__ \ "f12").read[String] and
-        (__ \ "f13").read[String] and
-        (__ \ "f14").read[String] and
-        (__ \ "f15").read[String] and
-        (__ \ "f16").read[String] and
-        (__ \ "f17").read[String] and
-        (__ \ "f18").read[String] and
-        (__ \ "f19").read[String] and
-        (__ \ "f20").read[String] and
-        (__ \ "f21").read[String]
-      )(Big.apply _)
+      for {
+        f1 <- (__ \ "f1").read[String]
+        f2 <- (__ \ "f2").read[String]
+        f3 <- (__ \ "f3").read[String]
+        f4 <- (__ \ "f4").read[String]
+        f5 <- (__ \ "f5").read[String]
+        f6 <- (__ \ "f6").read[String]
+        f7 <- (__ \ "f7").read[String]
+        f8 <- (__ \ "f8").read[String]
+        f9 <- (__ \ "f9").read[String]
+        f10 <- (__ \ "f10").read[String]
+        f11 <- (__ \ "f11").read[String]
+        f12 <- (__ \ "f12").read[String]
+        f13 <- (__ \ "f13").read[String]
+        f14 <- (__ \ "f14").read[String]
+        f15 <- (__ \ "f15").read[String]
+        f16 <- (__ \ "f16").read[String]
+        f17 <- (__ \ "f17").read[String]
+        f18 <- (__ \ "f18").read[String]
+        f19 <- (__ \ "f19").read[String]
+        f20 <- (__ \ "f20").read[String]
+        f21 <- (__ \ "f21").read[String]
+      } yield Big(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21)
     }
 
     def jsObjectBig(obj: io.apibuilder.reference.api.v0.models.Big): play.api.libs.json.JsObject = {
@@ -267,10 +267,10 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiError: play.api.libs.json.Reads[Error] = {
-      (
-        (__ \ "code").read[String] and
-        (__ \ "message").read[String]
-      )(Error.apply _)
+      for {
+        code <- (__ \ "code").read[String]
+        message <- (__ \ "message").read[String]
+      } yield Error(code, message)
     }
 
     def jsObjectError(obj: io.apibuilder.reference.api.v0.models.Error): play.api.libs.json.JsObject = {
@@ -307,12 +307,12 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiMember: play.api.libs.json.Reads[Member] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "organization").read[io.apibuilder.reference.api.v0.models.Organization] and
-        (__ \ "user").read[io.apibuilder.reference.api.v0.models.User] and
-        (__ \ "role").read[String]
-      )(Member.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        organization <- (__ \ "organization").read[io.apibuilder.reference.api.v0.models.Organization]
+        user <- (__ \ "user").read[io.apibuilder.reference.api.v0.models.User]
+        role <- (__ \ "role").read[String]
+      } yield Member(guid, organization, user, role)
     }
 
     def jsObjectMember(obj: io.apibuilder.reference.api.v0.models.Member): play.api.libs.json.JsObject = {
@@ -333,10 +333,10 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiOrganization: play.api.libs.json.Reads[Organization] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "name").read[String]
-      )(Organization.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        name <- (__ \ "name").read[String]
+      } yield Organization(guid, name)
     }
 
     def jsObjectOrganization(obj: io.apibuilder.reference.api.v0.models.Organization): play.api.libs.json.JsObject = {
@@ -355,13 +355,13 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiUser: play.api.libs.json.Reads[User] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "email").read[String] and
-        (__ \ "active").read[Boolean] and
-        (__ \ "age_group").read[io.apibuilder.reference.api.v0.models.AgeGroup] and
-        (__ \ "tags").readNullable[Map[String, String]]
-      )(User.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        email <- (__ \ "email").read[String]
+        active <- (__ \ "active").read[Boolean]
+        ageGroup <- (__ \ "age_group").read[io.apibuilder.reference.api.v0.models.AgeGroup]
+        tags <- (__ \ "tags").readNullable[Map[String, String]]
+      } yield User(guid, email, active, ageGroup, tags)
     }
 
     def jsObjectUser(obj: io.apibuilder.reference.api.v0.models.User): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -28,7 +28,11 @@ package io.apibuilder.reference.api.v0.models {
     f18: String,
     f19: String,
     f20: String,
-    f21: String
+    f21: String,
+    f22: String,
+    f23: String,
+    f24: String,
+    f25: String
   )
 
   final case class Echo(
@@ -211,7 +215,11 @@ package io.apibuilder.reference.api.v0.models {
         f19 <- (__ \ "f19").read[String]
         f20 <- (__ \ "f20").read[String]
         f21 <- (__ \ "f21").read[String]
-      } yield Big(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21)
+        f22 <- (__ \ "f22").read[String]
+        f23 <- (__ \ "f23").read[String]
+        f24 <- (__ \ "f24").read[String]
+        f25 <- (__ \ "f25").read[String]
+      } yield Big(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25)
     }
 
     def jsObjectBig(obj: io.apibuilder.reference.api.v0.models.Big): play.api.libs.json.JsObject = {
@@ -236,7 +244,11 @@ package io.apibuilder.reference.api.v0.models {
         "f18" -> play.api.libs.json.JsString(obj.f18),
         "f19" -> play.api.libs.json.JsString(obj.f19),
         "f20" -> play.api.libs.json.JsString(obj.f20),
-        "f21" -> play.api.libs.json.JsString(obj.f21)
+        "f21" -> play.api.libs.json.JsString(obj.f21),
+        "f22" -> play.api.libs.json.JsString(obj.f22),
+        "f23" -> play.api.libs.json.JsString(obj.f23),
+        "f24" -> play.api.libs.json.JsString(obj.f24),
+        "f25" -> play.api.libs.json.JsString(obj.f25)
       )
     }
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -189,29 +189,29 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiBig: play.api.libs.json.Reads[Big] = {
-      (
-        (__ \ "f1").read[String] and
-        (__ \ "f2").read[String] and
-        (__ \ "f3").read[String] and
-        (__ \ "f4").read[String] and
-        (__ \ "f5").read[String] and
-        (__ \ "f6").read[String] and
-        (__ \ "f7").read[String] and
-        (__ \ "f8").read[String] and
-        (__ \ "f9").read[String] and
-        (__ \ "f10").read[String] and
-        (__ \ "f11").read[String] and
-        (__ \ "f12").read[String] and
-        (__ \ "f13").read[String] and
-        (__ \ "f14").read[String] and
-        (__ \ "f15").read[String] and
-        (__ \ "f16").read[String] and
-        (__ \ "f17").read[String] and
-        (__ \ "f18").read[String] and
-        (__ \ "f19").read[String] and
-        (__ \ "f20").read[String] and
-        (__ \ "f21").read[String]
-      )(Big.apply _)
+      for {
+        f1 <- (__ \ "f1").read[String]
+        f2 <- (__ \ "f2").read[String]
+        f3 <- (__ \ "f3").read[String]
+        f4 <- (__ \ "f4").read[String]
+        f5 <- (__ \ "f5").read[String]
+        f6 <- (__ \ "f6").read[String]
+        f7 <- (__ \ "f7").read[String]
+        f8 <- (__ \ "f8").read[String]
+        f9 <- (__ \ "f9").read[String]
+        f10 <- (__ \ "f10").read[String]
+        f11 <- (__ \ "f11").read[String]
+        f12 <- (__ \ "f12").read[String]
+        f13 <- (__ \ "f13").read[String]
+        f14 <- (__ \ "f14").read[String]
+        f15 <- (__ \ "f15").read[String]
+        f16 <- (__ \ "f16").read[String]
+        f17 <- (__ \ "f17").read[String]
+        f18 <- (__ \ "f18").read[String]
+        f19 <- (__ \ "f19").read[String]
+        f20 <- (__ \ "f20").read[String]
+        f21 <- (__ \ "f21").read[String]
+      } yield Big(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21)
     }
 
     def jsObjectBig(obj: io.apibuilder.reference.api.v0.models.Big): play.api.libs.json.JsObject = {
@@ -267,10 +267,10 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiError: play.api.libs.json.Reads[Error] = {
-      (
-        (__ \ "code").read[String] and
-        (__ \ "message").read[String]
-      )(Error.apply _)
+      for {
+        code <- (__ \ "code").read[String]
+        message <- (__ \ "message").read[String]
+      } yield Error(code, message)
     }
 
     def jsObjectError(obj: io.apibuilder.reference.api.v0.models.Error): play.api.libs.json.JsObject = {
@@ -307,12 +307,12 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiMember: play.api.libs.json.Reads[Member] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "organization").read[io.apibuilder.reference.api.v0.models.Organization] and
-        (__ \ "user").read[io.apibuilder.reference.api.v0.models.User] and
-        (__ \ "role").read[String]
-      )(Member.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        organization <- (__ \ "organization").read[io.apibuilder.reference.api.v0.models.Organization]
+        user <- (__ \ "user").read[io.apibuilder.reference.api.v0.models.User]
+        role <- (__ \ "role").read[String]
+      } yield Member(guid, organization, user, role)
     }
 
     def jsObjectMember(obj: io.apibuilder.reference.api.v0.models.Member): play.api.libs.json.JsObject = {
@@ -333,10 +333,10 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiOrganization: play.api.libs.json.Reads[Organization] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "name").read[String]
-      )(Organization.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        name <- (__ \ "name").read[String]
+      } yield Organization(guid, name)
     }
 
     def jsObjectOrganization(obj: io.apibuilder.reference.api.v0.models.Organization): play.api.libs.json.JsObject = {
@@ -355,13 +355,13 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     implicit def jsonReadsApidocReferenceApiUser: play.api.libs.json.Reads[User] = {
-      (
-        (__ \ "guid").read[_root_.java.util.UUID] and
-        (__ \ "email").read[String] and
-        (__ \ "active").read[Boolean] and
-        (__ \ "age_group").read[io.apibuilder.reference.api.v0.models.AgeGroup] and
-        (__ \ "tags").readNullable[Map[String, String]]
-      )(User.apply _)
+      for {
+        guid <- (__ \ "guid").read[_root_.java.util.UUID]
+        email <- (__ \ "email").read[String]
+        active <- (__ \ "active").read[Boolean]
+        ageGroup <- (__ \ "age_group").read[io.apibuilder.reference.api.v0.models.AgeGroup]
+        tags <- (__ \ "tags").readNullable[Map[String, String]]
+      } yield User(guid, email, active, ageGroup, tags)
     }
 
     def jsObjectUser(obj: io.apibuilder.reference.api.v0.models.User): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/play2-json-spec-model-readers.txt
+++ b/lib/src/test/resources/play2-json-spec-model-readers.txt
@@ -1,5 +1,5 @@
-(
-  (__ \ "required_tags").read[Seq[String]] and
-  (__ \ "optional_tags").readNullable[Seq[String]] and
-  (__ \ "data").readNullable[Map[String, Long]]
-)(Content.apply _)
+for {
+  requiredTags <- (__ \ "required_tags").read[Seq[String]]
+  optionalTags <- (__ \ "optional_tags").readNullable[Seq[String]]
+  data <- (__ \ "data").readNullable[Map[String, Long]]
+} yield Content(requiredTags, optionalTags, data)

--- a/lib/src/test/resources/ruby-client-generator-gilt-0.0.1-test.txt
+++ b/lib/src/test/resources/ruby-client-generator-gilt-0.0.1-test.txt
@@ -285,11 +285,11 @@ module Io
             # A model with a lot of fields.
             class Big
 
-              attr_reader :f1, :f2, :f3, :f4, :f5, :f6, :f7, :f8, :f9, :f10, :f11, :f12, :f13, :f14, :f15, :f16, :f17, :f18, :f19, :f20, :f21
+              attr_reader :f1, :f2, :f3, :f4, :f5, :f6, :f7, :f8, :f9, :f10, :f11, :f12, :f13, :f14, :f15, :f16, :f17, :f18, :f19, :f20, :f21, :f22, :f23, :f24, :f25
 
               def initialize(incoming={})
                 opts = HttpClient::Helper.symbolize_keys(incoming)
-                HttpClient::Preconditions.require_keys(opts, [:f1, :f2, :f3, :f4, :f5, :f6, :f7, :f8, :f9, :f10, :f11, :f12, :f13, :f14, :f15, :f16, :f17, :f18, :f19, :f20, :f21], 'Big')
+                HttpClient::Preconditions.require_keys(opts, [:f1, :f2, :f3, :f4, :f5, :f6, :f7, :f8, :f9, :f10, :f11, :f12, :f13, :f14, :f15, :f16, :f17, :f18, :f19, :f20, :f21, :f22, :f23, :f24, :f25], 'Big')
                 @f1 = HttpClient::Preconditions.assert_class('f1', opts.delete(:f1), String)
                 @f2 = HttpClient::Preconditions.assert_class('f2', opts.delete(:f2), String)
                 @f3 = HttpClient::Preconditions.assert_class('f3', opts.delete(:f3), String)
@@ -311,6 +311,10 @@ module Io
                 @f19 = HttpClient::Preconditions.assert_class('f19', opts.delete(:f19), String)
                 @f20 = HttpClient::Preconditions.assert_class('f20', opts.delete(:f20), String)
                 @f21 = HttpClient::Preconditions.assert_class('f21', opts.delete(:f21), String)
+                @f22 = HttpClient::Preconditions.assert_class('f22', opts.delete(:f22), String)
+                @f23 = HttpClient::Preconditions.assert_class('f23', opts.delete(:f23), String)
+                @f24 = HttpClient::Preconditions.assert_class('f24', opts.delete(:f24), String)
+                @f25 = HttpClient::Preconditions.assert_class('f25', opts.delete(:f25), String)
               end
 
               def to_json
@@ -343,7 +347,11 @@ module Io
                   :f18 => f18,
                   :f19 => f19,
                   :f20 => f20,
-                  :f21 => f21
+                  :f21 => f21,
+                  :f22 => f22,
+                  :f23 => f23,
+                  :f24 => f24,
+                  :f25 => f25
                 }
               end
 

--- a/lib/src/test/resources/scala-union-models-json.txt
+++ b/lib/src/test/resources/scala-union-models-json.txt
@@ -1,10 +1,10 @@
 implicit def jsonReadsAPIBuilderTestGuestUser: play.api.libs.json.Reads[GuestUser] = {
-  (
-    (__ \ "id").read[Long] and
-    (__ \ "email").read[String] and
-    (__ \ "name").readNullable[String] and
-    (__ \ "bar").read[String]
-  )(GuestUser.apply _)
+  for {
+    id <- (__ \ "id").read[Long]
+    email <- (__ \ "email").read[String]
+    name <- (__ \ "name").readNullable[String]
+    bar <- (__ \ "bar").read[String]
+  } yield GuestUser(id, email, name, bar)
 }
 
 def jsObjectGuestUser(obj: test.apidoc.apidoctest.v0.models.GuestUser): play.api.libs.json.JsObject = {
@@ -19,12 +19,12 @@ def jsObjectGuestUser(obj: test.apidoc.apidoctest.v0.models.GuestUser): play.api
 }
 
 implicit def jsonReadsAPIBuilderTestRegisteredUser: play.api.libs.json.Reads[RegisteredUser] = {
-  (
-    (__ \ "id").read[Long] and
-    (__ \ "email").read[String] and
-    (__ \ "name").readNullable[String] and
-    (__ \ "foo").read[String]
-  )(RegisteredUser.apply _)
+  for {
+    id <- (__ \ "id").read[Long]
+    email <- (__ \ "email").read[String]
+    name <- (__ \ "name").readNullable[String]
+    foo <- (__ \ "foo").read[String]
+  } yield RegisteredUser(id, email, name, foo)
 }
 
 def jsObjectRegisteredUser(obj: test.apidoc.apidoctest.v0.models.RegisteredUser): play.api.libs.json.JsObject = {

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -171,10 +171,10 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
     }
 
     implicit def jsonReadsApidocExampleUnionTypesDiscriminatorGuestUser: play.api.libs.json.Reads[GuestUser] = {
-      (
-        (__ \ "id").read[String] and
-        (__ \ "email").readNullable[String]
-      )(GuestUser.apply _)
+      for {
+        id <- (__ \ "id").read[String]
+        email <- (__ \ "email").readNullable[String]
+      } yield GuestUser(id, email)
     }
 
     def jsObjectGuestUser(obj: io.apibuilder.example.union.types.discriminator.v0.models.GuestUser): play.api.libs.json.JsObject = {
@@ -187,10 +187,10 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
     }
 
     implicit def jsonReadsApidocExampleUnionTypesDiscriminatorRegisteredUser: play.api.libs.json.Reads[RegisteredUser] = {
-      (
-        (__ \ "id").read[String] and
-        (__ \ "email").read[String]
-      )(RegisteredUser.apply _)
+      for {
+        id <- (__ \ "id").read[String]
+        email <- (__ \ "email").read[String]
+      } yield RegisteredUser(id, email)
     }
 
     def jsObjectRegisteredUser(obj: io.apibuilder.example.union.types.discriminator.v0.models.RegisteredUser): play.api.libs.json.JsObject = {

--- a/scala-generator/src/main/scala/models/Play2Json.scala
+++ b/scala-generator/src/main/scala/models/Play2Json.scala
@@ -328,20 +328,19 @@ case class Play2Json(
     }
 
     model.fields match {
-      case field :: Nil => {
+      case field :: Nil =>
         serializations.head + s""".map { x => new ${model.name}(${field.name} = x) }"""
-      }
-      case fields => {
-        Seq(
-          "for {",
-          (fields zip serializations)
-            .map { case (field, reader) =>
-              s"${field.name} <- $reader".indent(2)
-            }
-            .mkString("\n"),
-          s"} yield ${model.name}(${fields.map(_.name).mkString(", ")})"
-        ).mkString("\n")
-      }
+
+      case fields =>
+        val constructorCall = s"${model.name}(${fields.map(_.name).mkString(", ")})"
+
+        val forComprehensions = (fields zip serializations).map { case (field, reader) =>
+          s"${field.name} <- $reader".indent(2)
+        }
+
+        s"""for {
+           |${forComprehensions.mkString("\n")}
+           |} yield $constructorCall""".stripMargin
     }
   }
 

--- a/scala-generator/src/main/scala/models/Play2Json.scala
+++ b/scala-generator/src/main/scala/models/Play2Json.scala
@@ -333,9 +333,13 @@ case class Play2Json(
       }
       case fields => {
         Seq(
-          "(",
-          serializations.mkString(" and\n").indent(2),
-          s")(${model.name}.apply _)"
+          "for {",
+          (fields zip serializations)
+            .map { case (field, reader) =>
+              s"${field.name} <- $reader".indent(2)
+            }
+            .mkString("\n"),
+          s"} yield ${model.name}(${fields.map(_.name).mkString(", ")})"
         ).mkString("\n")
       }
     }

--- a/scala-generator/src/test/scala/models/Play2JsonSpec.scala
+++ b/scala-generator/src/test/scala/models/Play2JsonSpec.scala
@@ -95,12 +95,12 @@ class Play2JsonSpec extends FunSpec with Matchers {
       val ssd = ScalaService(models.TestHelper.service(json2))
       val model = ssd.models.head
       Play2Json(ssd).fieldReaders(model) should be (
-        """(
-          |  (__ \ "one").read[Seq[String]] and
-          |  (__ \ "two").read[Int] and
-          |  (__ \ "three").read[_root_.org.joda.time.LocalDate] and
-          |  (__ \ "four").read[Boolean]
-          |)(B.apply _)""".stripMargin)
+        """for {
+          |  one <- (__ \ "one").read[Seq[String]]
+          |  two <- (__ \ "two").read[Int]
+          |  three <- (__ \ "three").read[_root_.org.joda.time.LocalDate]
+          |  four <- (__ \ "four").read[Boolean]
+          |} yield B(one, two, three, four)""".stripMargin)
     }
   }
 
@@ -159,12 +159,12 @@ class Play2JsonSpec extends FunSpec with Matchers {
       val ssd = ScalaService(models.TestHelper.service(json2))
       val model = ssd.models.head
       Play2Json(ssd).fieldReaders(model) should be (
-        """(
-          |  (__ \ "one").readWithDefault[Seq[String]](Nil) and
-          |  (__ \ "two").readWithDefault[Int](7) and
-          |  (__ \ "three").readWithDefault[_root_.org.joda.time.LocalDate](new _root_.org.joda.time.LocalDate(2008, 9, 15)) and
-          |  (__ \ "four").readWithDefault[Boolean](true)
-          |)(B.apply _)""".stripMargin)
+        """for {
+          |  one <- (__ \ "one").readWithDefault[Seq[String]](Nil)
+          |  two <- (__ \ "two").readWithDefault[Int](7)
+          |  three <- (__ \ "three").readWithDefault[_root_.org.joda.time.LocalDate](new _root_.org.joda.time.LocalDate(2008, 9, 15))
+          |  four <- (__ \ "four").readWithDefault[Boolean](true)
+          |} yield B(one, two, three, four)""".stripMargin)
     }
   }
 


### PR DESCRIPTION
Play Json combinators that we use in generator have known issue of supporting up to 22 fields only.
However, there exists a different way of encoding play readers that uses for comprehension / `flatMap` instead of combining using `and` from play DSL.

This is WiP as I adjusted only few tests to demonstrate the difference. Let me know what do you think - if you find it profitable, I can align remaining tests.