### PR TITLE
issue-415: support http4s client form params

### DIFF
--- a/scala-generator/src/main/scala/models/generator/ScalaClientMethodConfig.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientMethodConfig.scala
@@ -225,7 +225,8 @@ private lazy val defaultAsyncHttpClient = PooledHttp1Client()
     def asyncTypeImport: String = ""
     def routeExtends: Option[String] = None
     def matchersExtends: Option[String] = None
-    def clientImports: String = """import org.http4s.client.blaze._"""
+    def clientImports: String = """import org.http4s.client.blaze._
+                                  |import io.circe.syntax._""".stripMargin
     def closeClient: Option[String] = Some("""
                                              |def closeAsyncHttpClient(): Unit = {
                                              |  asyncHttpClient.shutdownNow()
@@ -287,7 +288,8 @@ implicit def circeJsonDecoder[${asyncTypeParam(Some("Sync")).map(_+", ").getOrEl
     override val routeExtends: Option[String] = Some(s" extends Matchers[$asyncType]")
     override val matchersExtends = Some(s" extends Http4sDsl[$asyncType]")
     override val clientImports: String = """import cats.effect._
-                                           |import cats.implicits._""".stripMargin
+                                           |import cats.implicits._
+                                           |import io.circe.syntax._""".stripMargin
 
     override val closeClient = None
 

--- a/scala-generator/src/main/scala/models/http4s/Http4sClient.scala
+++ b/scala-generator/src/main/scala/models/http4s/Http4sClient.scala
@@ -73,7 +73,7 @@ ${headerString.indent(6)}
                                        uri = uri,
                                        headers = headers)
 
-      val authReq = auth.fold(request) {
+      val reqAndMaybeAuth = auth.fold(request) {
         case Authorization.Basic(username, passwordOpt) => {
           val userpass = s"$$username:$${passwordOpt.getOrElse("")}"
           val token = java.util.Base64.getEncoder.encodeToString(userpass.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1))
@@ -82,9 +82,11 @@ ${headerString.indent(6)}
         case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
 
-      val authBody = body.fold(${config.wrappedAsyncType("Sync").getOrElse(config.asyncType)}.${config.asyncSuccess}(authReq))(authReq.withBody)
 
-      ${config.httpClient}.fetch(modifyRequest(authBody))(handler)
+
+      val reqAndMaybeAuthAndBody = body.fold(${config.wrappedAsyncType("Sync").getOrElse(config.asyncType)}.${config.asyncSuccess}(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
+
+      ${config.httpClient}.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }${methodGenerator.modelErrors().indent(4)}
   }
 

--- a/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
@@ -50,7 +50,7 @@ class ScalaClientMethodGenerator (
 
       payload.foreach { v =>
         code.append(v)
-        args.append("body = Some(payload)")
+        args.append("body = payload, formBody = formPayload")
       }
 
       queryParameters.foreach { v =>
@@ -64,7 +64,7 @@ class ScalaClientMethodGenerator (
         args.append("requestHeaders = (requestHeaders ++ headerParameters)")
       }
 
-      val reqType = if (op.formParameters.nonEmpty) "org.http4s.UrlForm" else op.body.fold("Unit")(b => b.datatype.name)
+      val reqType = op.body.fold("Unit")(b => b.datatype.name)
 
       val hasOptionResult = featureMigration.hasImplicit404s match {
         case true => {

--- a/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
@@ -64,7 +64,7 @@ class ScalaClientMethodGenerator (
         args.append("requestHeaders = (requestHeaders ++ headerParameters)")
       }
 
-      val reqType = op.body.fold("Unit")(b => b.datatype.name)
+      val reqType = if (op.formParameters.nonEmpty) "org.http4s.UrlForm" else op.body.fold("Unit")(b => b.datatype.name)
 
       val hasOptionResult = featureMigration.hasImplicit404s match {
         case true => {

--- a/scala-generator/src/main/scala/models/http4s/ScalaGeneratorUtil.scala
+++ b/scala-generator/src/main/scala/models/http4s/ScalaGeneratorUtil.scala
@@ -37,7 +37,7 @@ class ScalaGeneratorUtil(config: ScalaClientMethodConfig) extends scala.generato
         encodeValue(varName, body.datatype)
       }
 
-      Some(s"val payload = $payload")
+      Some(s"val (payload, formPayload) = (Some($payload), None)")
 
     } else {
       val params = op.formParameters.map { param =>
@@ -46,7 +46,8 @@ class ScalaGeneratorUtil(config: ScalaClientMethodConfig) extends scala.generato
       }.mkString(",\n")
       Some(
         Seq(
-          "val payload = { import io.circe.syntax._ ; org.http4s.UrlForm(",
+          "val payload = None",
+          "val formPayload = Some { import io.circe.syntax._ ; org.http4s.UrlForm(",
           params.indent,
           ") }"
         ).mkString("\n")

--- a/scala-generator/src/main/scala/models/http4s/ScalaGeneratorUtil.scala
+++ b/scala-generator/src/main/scala/models/http4s/ScalaGeneratorUtil.scala
@@ -47,9 +47,9 @@ class ScalaGeneratorUtil(config: ScalaClientMethodConfig) extends scala.generato
       Some(
         Seq(
           "val payload = None",
-          "val formPayload = Some { import io.circe.syntax._ ; org.http4s.UrlForm(",
+          "val formPayload = Some(org.http4s.UrlForm(",
           params.indent,
-          ") }"
+          "))"
         ).mkString("\n")
       )
     }

--- a/scala-generator/src/main/scala/models/http4s/ScalaGeneratorUtil.scala
+++ b/scala-generator/src/main/scala/models/http4s/ScalaGeneratorUtil.scala
@@ -42,13 +42,13 @@ class ScalaGeneratorUtil(config: ScalaClientMethodConfig) extends scala.generato
     } else {
       val params = op.formParameters.map { param =>
         val value = encodeValue(param.asScalaVal, param.datatype)
-        s""""${param.originalName}" -> ${value}.asJson"""
+        s""""${param.originalName}" -> ${value}.asJson.noSpaces"""
       }.mkString(",\n")
       Some(
         Seq(
-          "val payload = Map(",
+          "val payload = { import io.circe.syntax._ ; org.http4s.UrlForm(",
           params.indent,
-          ")"
+          ") }"
         ).mkString("\n")
       )
     }

--- a/scala-generator/src/test/scala/models/http4s/Http4sClientGeneratorSpec.scala
+++ b/scala-generator/src/test/scala/models/http4s/Http4sClientGeneratorSpec.scala
@@ -94,5 +94,17 @@ class Http4sClientGeneratorSpec extends FunSpec with Matchers {
 
       scalaSourceCode should not include ("import cats.implicits._")
     }
+
+    it("Generator produces valid url form marshalling code") {
+      val service = models.TestHelper.referenceApiService
+      val ssd = new ScalaService(service)
+      val invocationForm = new InvocationForm(service, Seq.empty, None)
+      val clientMethodConfig = new ScalaClientMethodConfigs.Http4s018(namespace = "whatever", baseUrl = None)
+      val client = Http4sClient(invocationForm, ssd, clientMethodConfig)
+      val scalaSourceCode = client.generate()
+      assertValidScalaSourceCode(scalaSourceCode)
+      scalaSourceCode should include ("_executeRequest[org.http4s.UrlForm,")
+      scalaSourceCode should include (""""active" -> active.asJson.noSpaces""")
+    }
   }
 }

--- a/scala-generator/src/test/scala/models/http4s/Http4sClientGeneratorSpec.scala
+++ b/scala-generator/src/test/scala/models/http4s/Http4sClientGeneratorSpec.scala
@@ -103,7 +103,7 @@ class Http4sClientGeneratorSpec extends FunSpec with Matchers {
       val client = Http4sClient(invocationForm, ssd, clientMethodConfig)
       val scalaSourceCode = client.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      scalaSourceCode should include ("_executeRequest[org.http4s.UrlForm,")
+      scalaSourceCode should include ("formBody = formPayload,")
       scalaSourceCode should include (""""active" -> active.asJson.noSpaces""")
     }
   }


### PR DESCRIPTION
there are a number of ways to do this.  I have ported
the approach from the play generator.  will not
address consistency between params in the url
and body. play generator has the same problem.

http4s client test suite is inadequate.  can't
address that either at this time.  will need
someone to do do an adhoc test because I
do not have much of a dev env for the generators.