### PR TITLE
Add a request decorator

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -377,9 +377,10 @@ package io.apibuilder.example.union.types.v0 {
 
     object Users extends Users {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.example.union.types.v0.models.User]] = {
-        _executeRequest("GET", s"/users", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.example.union.types.v0.Client.parseJson("Seq[io.apibuilder.example.union.types.v0.models.User]", r, _.validate[Seq[io.apibuilder.example.union.types.v0.models.User]])
           case r => throw io.apibuilder.example.union.types.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -387,9 +388,10 @@ package io.apibuilder.example.union.types.v0 {
 
       override def getByGuid(
         guid: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.example.union.types.v0.models.User] = {
-        _executeRequest("GET", s"/users/${guid}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users/${guid}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.example.union.types.v0.Client.parseJson("io.apibuilder.example.union.types.v0.models.User", r, _.validate[io.apibuilder.example.union.types.v0.models.User])
           case r if r.getStatusCode == 404 => throw io.apibuilder.example.union.types.v0.errors.UnitResponse(r.getStatusCode)
           case r => throw io.apibuilder.example.union.types.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200, 404", requestUri = Some(r.getUri))
@@ -398,11 +400,12 @@ package io.apibuilder.example.union.types.v0 {
 
       override def post(
         user: io.apibuilder.example.union.types.v0.models.User,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.example.union.types.v0.models.User] = {
         val payload = play.api.libs.json.Json.toJson(user)
 
-        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 201 => _root_.io.apibuilder.example.union.types.v0.Client.parseJson("io.apibuilder.example.union.types.v0.models.User", r, _.validate[io.apibuilder.example.union.types.v0.models.User])
           case r => throw io.apibuilder.example.union.types.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 201", requestUri = Some(r.getUri))
         }
@@ -421,8 +424,8 @@ package io.apibuilder.example.union.types.v0 {
       }
     }
 
-    def _requestBuilder(method: String, path: String, requestHeaders: Seq[(String, String)]): RequestBuilder = {
-      val builder = new RequestBuilder(method)
+    def _requestBuilder(method: String, path: String, requestHeaders: Seq[(String, String)]): _root_.com.ning.http.client.RequestBuilder = {
+      val builder = new _root_.com.ning.http.client.RequestBuilder(method)
         .setUrl(baseUrl + path)
         .addHeader("User-Agent", Constants.UserAgent)
         .addHeader("X-Apidoc-Version", Constants.Version)
@@ -451,7 +454,8 @@ package io.apibuilder.example.union.types.v0 {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.ning.http.client.Response] = {
       val allHeaders = body match {
         case None => requestHeaders
@@ -469,7 +473,7 @@ package io.apibuilder.example.union.types.v0 {
         request.setBody(serialized)
       }
 
-      val finalRequest = requestWithParamsAndBody.build()
+      val finalRequest = requestModifier(requestWithParamsAndBody).build()
       _logRequest(finalRequest)
 
       val result = scala.concurrent.Promise[com.ning.http.client.Response]()
@@ -539,17 +543,20 @@ package io.apibuilder.example.union.types.v0 {
 
   trait Users {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.example.union.types.v0.models.User]]
 
     def getByGuid(
       guid: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.example.union.types.v0.models.User]
 
     def post(
       user: io.apibuilder.example.union.types.v0.models.User,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.example.union.types.v0.models.User]
   }
 

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -495,9 +495,10 @@ package io.apibuilder.example.union.types.v0 {
 
     object Users extends Users {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.example.union.types.v0.models.User]] = {
-        _executeRequest("GET", s"/users", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.example.union.types.v0.Client.parseJson("Seq[io.apibuilder.example.union.types.v0.models.User]", r, _.validate[Seq[io.apibuilder.example.union.types.v0.models.User]])
           case r => throw io.apibuilder.example.union.types.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -505,9 +506,10 @@ package io.apibuilder.example.union.types.v0 {
 
       override def getByGuid(
         guid: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.example.union.types.v0.models.User] = {
-        _executeRequest("GET", s"/users/${guid}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users/${guid}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.example.union.types.v0.Client.parseJson("io.apibuilder.example.union.types.v0.models.User", r, _.validate[io.apibuilder.example.union.types.v0.models.User])
           case r if r.status == 404 => throw io.apibuilder.example.union.types.v0.errors.UnitResponse(r.status)
           case r => throw io.apibuilder.example.union.types.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200, 404")
@@ -516,11 +518,12 @@ package io.apibuilder.example.union.types.v0 {
 
       override def post(
         user: io.apibuilder.example.union.types.v0.models.User,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.example.union.types.v0.models.User] = {
         val payload = play.api.libs.json.Json.toJson(user)
 
-        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 201 => _root_.io.apibuilder.example.union.types.v0.Client.parseJson("io.apibuilder.example.union.types.v0.models.User", r, _.validate[io.apibuilder.example.union.types.v0.models.User])
           case r => throw io.apibuilder.example.union.types.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 201")
         }
@@ -560,32 +563,41 @@ package io.apibuilder.example.union.types.v0 {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("PUT", request).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("PATCH", request).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("DELETE", request).delete()
         }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
+        case "HEAD" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("HEAD", request).head()
         }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
+        case "OPTIONS" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("OPTIONS", request).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }
@@ -637,17 +649,20 @@ package io.apibuilder.example.union.types.v0 {
 
   trait Users {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.example.union.types.v0.models.User]]
 
     def getByGuid(
       guid: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.example.union.types.v0.models.User]
 
     def post(
       user: io.apibuilder.example.union.types.v0.models.User,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.example.union.types.v0.models.User]
   }
 

--- a/lib/src/test/resources/generators/collection-json-defaults-ahc-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ahc-client.txt
@@ -150,11 +150,12 @@ package com.gilt.test.v0 {
     object Users extends Users {
       override def post(
         user: com.gilt.test.v0.models.User,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User] = {
         val payload = play.api.libs.json.Json.toJson(user)
 
-        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 201 => _root_.com.gilt.test.v0.Client.parseJson("com.gilt.test.v0.models.User", r, _.validate[com.gilt.test.v0.models.User])
           case r => throw com.gilt.test.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 201", requestUri = Some(r.getUri.toJavaNetURI))
         }
@@ -163,9 +164,10 @@ package com.gilt.test.v0 {
       @deprecated("to be removed")
       override def getByEmail(
         @deprecated email: String,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User] = {
-        _executeRequest("GET", s"/users/${_root_.com.gilt.test.v0.PathSegment.encode(email, "UTF-8")}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users/${_root_.com.gilt.test.v0.PathSegment.encode(email, "UTF-8")}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.com.gilt.test.v0.Client.parseJson("com.gilt.test.v0.models.User", r, _.validate[com.gilt.test.v0.models.User])
           case r => throw com.gilt.test.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri.toJavaNetURI))
         }
@@ -173,11 +175,12 @@ package com.gilt.test.v0 {
 
       override def patch(
         userPatch: com.gilt.test.v0.models.UserPatch,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User] = {
         val payload = play.api.libs.json.Json.toJson(userPatch)
 
-        _executeRequest("PATCH", s"/users", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("PATCH", s"/users", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.com.gilt.test.v0.Client.parseJson("com.gilt.test.v0.models.User", r, _.validate[com.gilt.test.v0.models.User])
           case r => throw com.gilt.test.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri.toJavaNetURI))
         }
@@ -196,8 +199,8 @@ package com.gilt.test.v0 {
       }
     }
 
-    def _requestBuilder(method: String, path: String, requestHeaders: Seq[(String, String)]): RequestBuilder = {
-      val builder = new RequestBuilder(method)
+    def _requestBuilder(method: String, path: String, requestHeaders: Seq[(String, String)]): _root_.com.ning.http.client.RequestBuilder = {
+      val builder = new _root_.com.ning.http.client.RequestBuilder(method)
         .setUrl(baseUrl + path)
         .addHeader("User-Agent", Constants.UserAgent)
         .addHeader("X-Apidoc-Version", Constants.Version)
@@ -224,7 +227,8 @@ package com.gilt.test.v0 {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[org.asynchttpclient.Response] = {
       val allHeaders = body match {
         case None => requestHeaders
@@ -242,7 +246,7 @@ package com.gilt.test.v0 {
         request.setBody(serialized)
       }
 
-      val finalRequest = requestWithParamsAndBody.build()
+      val finalRequest = requestModifier(requestWithParamsAndBody).build()
       _logRequest(finalRequest)
 
       val result = scala.concurrent.Promise[org.asynchttpclient.Response]()
@@ -311,18 +315,21 @@ package com.gilt.test.v0 {
   trait Users {
     def post(
       user: com.gilt.test.v0.models.User,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User]
 
     @deprecated("to be removed")
     def getByEmail(
       @deprecated email: String,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User]
 
     def patch(
       userPatch: com.gilt.test.v0.models.UserPatch,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User]
   }
 

--- a/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
@@ -150,11 +150,12 @@ package com.gilt.test.v0 {
     object Users extends Users {
       override def post(
         user: com.gilt.test.v0.models.User,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User] = {
         val payload = play.api.libs.json.Json.toJson(user)
 
-        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 201 => _root_.com.gilt.test.v0.Client.parseJson("com.gilt.test.v0.models.User", r, _.validate[com.gilt.test.v0.models.User])
           case r => throw com.gilt.test.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 201", requestUri = Some(r.getUri))
         }
@@ -163,9 +164,10 @@ package com.gilt.test.v0 {
       @deprecated("to be removed")
       override def getByEmail(
         @deprecated email: String,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User] = {
-        _executeRequest("GET", s"/users/${_root_.com.gilt.test.v0.PathSegment.encode(email, "UTF-8")}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users/${_root_.com.gilt.test.v0.PathSegment.encode(email, "UTF-8")}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.com.gilt.test.v0.Client.parseJson("com.gilt.test.v0.models.User", r, _.validate[com.gilt.test.v0.models.User])
           case r => throw com.gilt.test.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -173,11 +175,12 @@ package com.gilt.test.v0 {
 
       override def patch(
         userPatch: com.gilt.test.v0.models.UserPatch,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User] = {
         val payload = play.api.libs.json.Json.toJson(userPatch)
 
-        _executeRequest("PATCH", s"/users", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("PATCH", s"/users", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.com.gilt.test.v0.Client.parseJson("com.gilt.test.v0.models.User", r, _.validate[com.gilt.test.v0.models.User])
           case r => throw com.gilt.test.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -196,8 +199,8 @@ package com.gilt.test.v0 {
       }
     }
 
-    def _requestBuilder(method: String, path: String, requestHeaders: Seq[(String, String)]): RequestBuilder = {
-      val builder = new RequestBuilder(method)
+    def _requestBuilder(method: String, path: String, requestHeaders: Seq[(String, String)]): _root_.com.ning.http.client.RequestBuilder = {
+      val builder = new _root_.com.ning.http.client.RequestBuilder(method)
         .setUrl(baseUrl + path)
         .addHeader("User-Agent", Constants.UserAgent)
         .addHeader("X-Apidoc-Version", Constants.Version)
@@ -226,7 +229,8 @@ package com.gilt.test.v0 {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.ning.http.client.Response] = {
       val allHeaders = body match {
         case None => requestHeaders
@@ -244,7 +248,7 @@ package com.gilt.test.v0 {
         request.setBody(serialized)
       }
 
-      val finalRequest = requestWithParamsAndBody.build()
+      val finalRequest = requestModifier(requestWithParamsAndBody).build()
       _logRequest(finalRequest)
 
       val result = scala.concurrent.Promise[com.ning.http.client.Response]()
@@ -315,18 +319,21 @@ package com.gilt.test.v0 {
   trait Users {
     def post(
       user: com.gilt.test.v0.models.User,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User]
 
     @deprecated("to be removed")
     def getByEmail(
       @deprecated email: String,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User]
 
     def patch(
       userPatch: com.gilt.test.v0.models.UserPatch,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User]
   }
 

--- a/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
@@ -245,11 +245,12 @@ package com.gilt.test.v0 {
     object Users extends Users {
       override def post(
         user: com.gilt.test.v0.models.User,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User] = {
         val payload = play.api.libs.json.Json.toJson(user)
 
-        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 201 => _root_.com.gilt.test.v0.Client.parseJson("com.gilt.test.v0.models.User", r, _.validate[com.gilt.test.v0.models.User])
           case r => throw com.gilt.test.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 201")
         }
@@ -258,9 +259,10 @@ package com.gilt.test.v0 {
       @deprecated("to be removed")
       override def getByEmail(
         @deprecated email: String,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User] = {
-        _executeRequest("GET", s"/users/${play.utils.UriEncoding.encodePathSegment(email, "UTF-8")}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users/${play.utils.UriEncoding.encodePathSegment(email, "UTF-8")}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.com.gilt.test.v0.Client.parseJson("com.gilt.test.v0.models.User", r, _.validate[com.gilt.test.v0.models.User])
           case r => throw com.gilt.test.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -268,11 +270,12 @@ package com.gilt.test.v0 {
 
       override def patch(
         userPatch: com.gilt.test.v0.models.UserPatch,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User] = {
         val payload = play.api.libs.json.Json.toJson(userPatch)
 
-        _executeRequest("PATCH", s"/users", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("PATCH", s"/users", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.com.gilt.test.v0.Client.parseJson("com.gilt.test.v0.models.User", r, _.validate[com.gilt.test.v0.models.User])
           case r => throw com.gilt.test.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -312,32 +315,41 @@ package com.gilt.test.v0 {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("PUT", request).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("PATCH", request).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("DELETE", request).delete()
         }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
+        case "HEAD" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("HEAD", request).head()
         }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
+        case "OPTIONS" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("OPTIONS", request).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }
@@ -390,18 +402,21 @@ package com.gilt.test.v0 {
   trait Users {
     def post(
       user: com.gilt.test.v0.models.User,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User]
 
     @deprecated("to be removed")
     def getByEmail(
       @deprecated email: String,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User]
 
     def patch(
       userPatch: com.gilt.test.v0.models.UserPatch,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User]
   }
 

--- a/lib/src/test/resources/generators/play-22-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-22-built-in-types.txt
@@ -461,9 +461,10 @@ package apibuilder {
 
     object Arrays extends Arrays {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WS.WSRequestHolder => play.api.libs.ws.WS.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Array] = {
-        _executeRequest("GET", s"/arrays", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/arrays", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Array", r, _.validate[apibuilder.models.Array])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200", requestUri = Some(r.ahcResponse.getUri))
         }
@@ -472,9 +473,10 @@ package apibuilder {
 
     object Optarrays extends Optarrays {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WS.WSRequestHolder => play.api.libs.ws.WS.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optarray] = {
-        _executeRequest("GET", s"/optarrays", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/optarrays", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Optarray", r, _.validate[apibuilder.models.Optarray])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200", requestUri = Some(r.ahcResponse.getUri))
         }
@@ -483,9 +485,10 @@ package apibuilder {
 
     object Optionals extends Optionals {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WS.WSRequestHolder => play.api.libs.ws.WS.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optional] = {
-        _executeRequest("GET", s"/optionals", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/optionals", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Optional", r, _.validate[apibuilder.models.Optional])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200", requestUri = Some(r.ahcResponse.getUri))
         }
@@ -494,9 +497,10 @@ package apibuilder {
 
     object Requireds extends Requireds {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WS.WSRequestHolder => play.api.libs.ws.WS.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Required] = {
-        _executeRequest("GET", s"/requireds", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/requireds", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Required", r, _.validate[apibuilder.models.Required])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200", requestUri = Some(r.ahcResponse.getUri))
         }
@@ -536,32 +540,40 @@ package apibuilder {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: play.api.libs.ws.WS.WSRequestHolder => play.api.libs.ws.WS.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.Response] = {
       method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("PUT", request).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
           sys.error("PATCH method is not supported in Play Framework Version 2.2.x")
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("DELETE", request).delete()
         }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
+        case "HEAD" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("HEAD", request).head()
         }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
+        case "OPTIONS" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("OPTIONS", request).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }
@@ -616,25 +628,29 @@ package apibuilder {
 
   trait Arrays {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WS.WSRequestHolder => play.api.libs.ws.WS.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Array]
   }
 
   trait Optarrays {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WS.WSRequestHolder => play.api.libs.ws.WS.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optarray]
   }
 
   trait Optionals {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WS.WSRequestHolder => play.api.libs.ws.WS.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optional]
   }
 
   trait Requireds {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WS.WSRequestHolder => play.api.libs.ws.WS.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Required]
   }
 

--- a/lib/src/test/resources/generators/play-23-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-23-built-in-types.txt
@@ -461,9 +461,10 @@ package apibuilder {
 
     object Arrays extends Arrays {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Array] = {
-        _executeRequest("GET", s"/arrays", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/arrays", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Array", r, _.validate[apibuilder.models.Array])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -472,9 +473,10 @@ package apibuilder {
 
     object Optarrays extends Optarrays {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optarray] = {
-        _executeRequest("GET", s"/optarrays", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/optarrays", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Optarray", r, _.validate[apibuilder.models.Optarray])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -483,9 +485,10 @@ package apibuilder {
 
     object Optionals extends Optionals {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optional] = {
-        _executeRequest("GET", s"/optionals", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/optionals", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Optional", r, _.validate[apibuilder.models.Optional])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -494,9 +497,10 @@ package apibuilder {
 
     object Requireds extends Requireds {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Required] = {
-        _executeRequest("GET", s"/requireds", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/requireds", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Required", r, _.validate[apibuilder.models.Required])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -536,32 +540,41 @@ package apibuilder {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("PUT", request).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("PATCH", request).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("DELETE", request).delete()
         }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
+        case "HEAD" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("HEAD", request).head()
         }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
+        case "OPTIONS" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("OPTIONS", request).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }
@@ -616,25 +629,29 @@ package apibuilder {
 
   trait Arrays {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Array]
   }
 
   trait Optarrays {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optarray]
   }
 
   trait Optionals {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optional]
   }
 
   trait Requireds {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Required]
   }
 

--- a/lib/src/test/resources/generators/play-24-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-24-built-in-types.txt
@@ -461,9 +461,10 @@ package apibuilder {
 
     object Arrays extends Arrays {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Array] = {
-        _executeRequest("GET", s"/arrays", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/arrays", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Array", r, _.validate[apibuilder.models.Array])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -472,9 +473,10 @@ package apibuilder {
 
     object Optarrays extends Optarrays {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optarray] = {
-        _executeRequest("GET", s"/optarrays", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/optarrays", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Optarray", r, _.validate[apibuilder.models.Optarray])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -483,9 +485,10 @@ package apibuilder {
 
     object Optionals extends Optionals {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optional] = {
-        _executeRequest("GET", s"/optionals", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/optionals", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Optional", r, _.validate[apibuilder.models.Optional])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -494,9 +497,10 @@ package apibuilder {
 
     object Requireds extends Requireds {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Required] = {
-        _executeRequest("GET", s"/requireds", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/requireds", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Required", r, _.validate[apibuilder.models.Required])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -536,32 +540,41 @@ package apibuilder {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("PUT", request).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("PATCH", request).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("DELETE", request).delete()
         }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
+        case "HEAD" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("HEAD", request).head()
         }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
+        case "OPTIONS" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("OPTIONS", request).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }
@@ -616,25 +629,29 @@ package apibuilder {
 
   trait Arrays {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Array]
   }
 
   trait Optarrays {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optarray]
   }
 
   trait Optionals {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optional]
   }
 
   trait Requireds {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Required]
   }
 

--- a/lib/src/test/resources/generators/play-25-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-25-built-in-types.txt
@@ -462,9 +462,10 @@ package apibuilder {
 
     object Arrays extends Arrays {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Array] = {
-        _executeRequest("GET", s"/arrays", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/arrays", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Array", r, _.validate[apibuilder.models.Array])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -473,9 +474,10 @@ package apibuilder {
 
     object Optarrays extends Optarrays {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optarray] = {
-        _executeRequest("GET", s"/optarrays", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/optarrays", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Optarray", r, _.validate[apibuilder.models.Optarray])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -484,9 +486,10 @@ package apibuilder {
 
     object Optionals extends Optionals {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optional] = {
-        _executeRequest("GET", s"/optionals", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/optionals", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Optional", r, _.validate[apibuilder.models.Optional])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -495,9 +498,10 @@ package apibuilder {
 
     object Requireds extends Requireds {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Required] = {
-        _executeRequest("GET", s"/requireds", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/requireds", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Required", r, _.validate[apibuilder.models.Required])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -536,32 +540,41 @@ package apibuilder {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("PUT", request).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("PATCH", request).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("DELETE", request).delete()
         }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
+        case "HEAD" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("HEAD", request).head()
         }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
+        case "OPTIONS" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("OPTIONS", request).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }
@@ -616,25 +629,29 @@ package apibuilder {
 
   trait Arrays {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Array]
   }
 
   trait Optarrays {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optarray]
   }
 
   trait Optionals {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optional]
   }
 
   trait Requireds {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Required]
   }
 

--- a/lib/src/test/resources/generators/play-26-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-26-built-in-types.txt
@@ -462,9 +462,10 @@ package apibuilder {
 
     object Arrays extends Arrays {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Array] = {
-        _executeRequest("GET", s"/arrays", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/arrays", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Array", r, _.validate[apibuilder.models.Array])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -473,9 +474,10 @@ package apibuilder {
 
     object Optarrays extends Optarrays {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optarray] = {
-        _executeRequest("GET", s"/optarrays", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/optarrays", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Optarray", r, _.validate[apibuilder.models.Optarray])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -484,9 +486,10 @@ package apibuilder {
 
     object Optionals extends Optionals {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optional] = {
-        _executeRequest("GET", s"/optionals", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/optionals", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Optional", r, _.validate[apibuilder.models.Optional])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -495,9 +498,10 @@ package apibuilder {
 
     object Requireds extends Requireds {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Required] = {
-        _executeRequest("GET", s"/requireds", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/requireds", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.apibuilder.Client.parseJson("apibuilder.models.Required", r, _.validate[apibuilder.models.Required])
           case r => throw apibuilder.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -536,32 +540,41 @@ package apibuilder {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*)).get()
+          val request = requestModifier(_requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*))
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).addHttpHeaders(_withJsonContentType(requestHeaders):_*).addQueryStringParameters(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).addHttpHeaders(_withJsonContentType(requestHeaders):_*).addQueryStringParameters(queryParameters:_*))
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).addHttpHeaders(_withJsonContentType(requestHeaders):_*).addQueryStringParameters(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).addHttpHeaders(_withJsonContentType(requestHeaders):_*).addQueryStringParameters(queryParameters:_*))
+          _logRequest("PUT", request).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*))
+          _logRequest("PATCH", request).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*)).delete()
+          val request = requestModifier(_requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*))
+          _logRequest("DELETE", request).delete()
         }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*)).head()
+        case "HEAD" => {
+          val request = requestModifier(_requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*))
+          _logRequest("HEAD", request).head()
         }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*)).options()
+        case "OPTIONS" => {
+          val request = requestModifier(_requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*))
+          _logRequest("OPTIONS", request).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*))
+          val request = requestModifier(_requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*))
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }
@@ -616,25 +629,29 @@ package apibuilder {
 
   trait Arrays {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Array]
   }
 
   trait Optarrays {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optarray]
   }
 
   trait Optionals {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Optional]
   }
 
   trait Requireds {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[apibuilder.models.Required]
   }
 

--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -460,7 +460,8 @@ package io.apibuilder.reference.api.v0 {
         foo: _root_.scala.Option[String] = None,
         optionalMessages: _root_.scala.Option[Seq[String]] = None,
         requiredMessages: Seq[String],
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
         val queryParameters = Seq(
           foo.map("foo" -> _)
@@ -468,7 +469,7 @@ package io.apibuilder.reference.api.v0 {
           optionalMessages.getOrElse(Nil).map("optional_messages" -> _) ++
           requiredMessages.map("required_messages" -> _)
 
-        _executeRequest("GET", s"/echoes", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/echoes", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 204 => ()
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 204", requestUri = Some(r.getUri))
         }
@@ -477,12 +478,13 @@ package io.apibuilder.reference.api.v0 {
       override def getArraysOnly(
         optionalMessages: _root_.scala.Option[Seq[String]] = None,
         requiredMessages: Seq[String],
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
         val queryParameters = optionalMessages.getOrElse(Nil).map("optional_messages" -> _) ++
           requiredMessages.map("required_messages" -> _)
 
-        _executeRequest("GET", s"/echoes/arrays-only", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/echoes/arrays-only", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 204 => ()
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 204", requestUri = Some(r.getUri))
         }
@@ -492,9 +494,10 @@ package io.apibuilder.reference.api.v0 {
     object Groups extends Groups {
       override def getByOrganization(
         organization: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]] = {
-        _executeRequest("GET", s"/groups/${organization}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/groups/${organization}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]", r, _.validate[Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -507,7 +510,8 @@ package io.apibuilder.reference.api.v0 {
         organization: _root_.java.util.UUID,
         user: _root_.java.util.UUID,
         role: String,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Member] = {
         val payload = play.api.libs.json.Json.obj(
           "guid" -> play.api.libs.json.Json.toJson(guid),
@@ -516,7 +520,7 @@ package io.apibuilder.reference.api.v0 {
           "role" -> play.api.libs.json.Json.toJson(role)
         )
 
-        _executeRequest("POST", s"/members", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/members", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 201 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.Member", r, _.validate[io.apibuilder.reference.api.v0.models.Member])
           case r if r.getStatusCode == 409 => throw io.apibuilder.reference.api.v0.errors.ErrorsResponse(r)
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 201, 409", requestUri = Some(r.getUri))
@@ -528,7 +532,8 @@ package io.apibuilder.reference.api.v0 {
         organizationGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
         userGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
         role: _root_.scala.Option[String] = None,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]] = {
         val queryParameters = Seq(
           guid.map("guid" -> _.toString),
@@ -537,7 +542,7 @@ package io.apibuilder.reference.api.v0 {
           role.map("role" -> _)
         ).flatten
 
-        _executeRequest("GET", s"/members", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/members", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Member]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Member]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -545,9 +550,10 @@ package io.apibuilder.reference.api.v0 {
 
       override def getByOrganization(
         organization: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]] = {
-        _executeRequest("GET", s"/members/${organization}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/members/${organization}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Member]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Member]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -556,11 +562,12 @@ package io.apibuilder.reference.api.v0 {
       override def postMembersBulkByOrganization(
         organization: _root_.java.util.UUID,
         members: Seq[io.apibuilder.reference.api.v0.models.Member],
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]] = {
         val payload = play.api.libs.json.Json.toJson(members)
 
-        _executeRequest("POST", s"/members/${organization}/members_bulk", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/members/${organization}/members_bulk", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Member]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Member]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -570,13 +577,14 @@ package io.apibuilder.reference.api.v0 {
     object Organizations extends Organizations {
       override def post(
         organization: io.apibuilder.reference.api.v0.models.Organization,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization] = {
         val payload = play.api.libs.json.Json.obj(
           "organization" -> play.api.libs.json.Json.toJson(organization)
         )
 
-        _executeRequest("POST", s"/organizations", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/organizations", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 201 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.Organization", r, _.validate[io.apibuilder.reference.api.v0.models.Organization])
           case r if r.getStatusCode == 409 => throw io.apibuilder.reference.api.v0.errors.ErrorsResponse(r)
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 201, 409", requestUri = Some(r.getUri))
@@ -586,14 +594,15 @@ package io.apibuilder.reference.api.v0 {
       override def get(
         guid: _root_.scala.Option[_root_.java.util.UUID] = None,
         name: _root_.scala.Option[String] = None,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Organization]] = {
         val queryParameters = Seq(
           guid.map("guid" -> _.toString),
           name.map("name" -> _)
         ).flatten
 
-        _executeRequest("GET", s"/organizations", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/organizations", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Organization]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Organization]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -601,9 +610,10 @@ package io.apibuilder.reference.api.v0 {
 
       override def getByGuid(
         guid: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization] = {
-        _executeRequest("GET", s"/organizations/${guid}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/organizations/${guid}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.Organization", r, _.validate[io.apibuilder.reference.api.v0.models.Organization])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -615,7 +625,8 @@ package io.apibuilder.reference.api.v0 {
         guid: _root_.java.util.UUID,
         email: String,
         active: Boolean,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.User] = {
         val payload = play.api.libs.json.Json.obj(
           "guid" -> play.api.libs.json.Json.toJson(guid),
@@ -623,7 +634,7 @@ package io.apibuilder.reference.api.v0 {
           "active" -> play.api.libs.json.Json.toJson(active)
         )
 
-        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 201 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.User", r, _.validate[io.apibuilder.reference.api.v0.models.User])
           case r if r.getStatusCode == 409 => throw io.apibuilder.reference.api.v0.errors.ErrorsResponse(r)
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 201, 409", requestUri = Some(r.getUri))
@@ -636,7 +647,8 @@ package io.apibuilder.reference.api.v0 {
         ageGroup: _root_.scala.Option[io.apibuilder.reference.api.v0.models.AgeGroup] = None,
         email: _root_.scala.Option[String] = None,
         active: Boolean = true,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]] = {
         val queryParameters = Seq(
           guid.map("guid" -> _.toString),
@@ -646,7 +658,7 @@ package io.apibuilder.reference.api.v0 {
         ).flatten ++
           organizationGuids.getOrElse(Nil).map("organization_guids" -> _.toString)
 
-        _executeRequest("GET", s"/users", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.User]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.User]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -654,18 +666,20 @@ package io.apibuilder.reference.api.v0 {
 
       override def getByAgeGroup(
         ageGroup: io.apibuilder.reference.api.v0.models.AgeGroup,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]] = {
-        _executeRequest("GET", s"/users/${_root_.io.apibuilder.reference.api.v0.PathSegment.encode(ageGroup.toString, "UTF-8")}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users/${_root_.io.apibuilder.reference.api.v0.PathSegment.encode(ageGroup.toString, "UTF-8")}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.User]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.User]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
       }
 
       override def postNoop(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
-        _executeRequest("POST", s"/users/noop", requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users/noop", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => ()
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -684,8 +698,8 @@ package io.apibuilder.reference.api.v0 {
       }
     }
 
-    def _requestBuilder(method: String, path: String, requestHeaders: Seq[(String, String)]): RequestBuilder = {
-      val builder = new RequestBuilder(method)
+    def _requestBuilder(method: String, path: String, requestHeaders: Seq[(String, String)]): _root_.com.ning.http.client.RequestBuilder = {
+      val builder = new _root_.com.ning.http.client.RequestBuilder(method)
         .setUrl(baseUrl + path)
         .addHeader("User-Agent", Constants.UserAgent)
         .addHeader("X-Apidoc-Version", Constants.Version)
@@ -714,7 +728,8 @@ package io.apibuilder.reference.api.v0 {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.ning.http.client.Response] = {
       val allHeaders = body match {
         case None => requestHeaders
@@ -732,7 +747,7 @@ package io.apibuilder.reference.api.v0 {
         request.setBody(serialized)
       }
 
-      val finalRequest = requestWithParamsAndBody.build()
+      val finalRequest = requestModifier(requestWithParamsAndBody).build()
       _logRequest(finalRequest)
 
       val result = scala.concurrent.Promise[com.ning.http.client.Response]()
@@ -809,20 +824,23 @@ package io.apibuilder.reference.api.v0 {
       foo: _root_.scala.Option[String] = None,
       optionalMessages: _root_.scala.Option[Seq[String]] = None,
       requiredMessages: Seq[String],
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit]
 
     def getArraysOnly(
       optionalMessages: _root_.scala.Option[Seq[String]] = None,
       requiredMessages: Seq[String],
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit]
   }
 
   trait Groups {
     def getByOrganization(
       organization: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]]
   }
 
@@ -832,7 +850,8 @@ package io.apibuilder.reference.api.v0 {
       organization: _root_.java.util.UUID,
       user: _root_.java.util.UUID,
       role: String,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Member]
 
     def get(
@@ -840,36 +859,42 @@ package io.apibuilder.reference.api.v0 {
       organizationGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
       userGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
       role: _root_.scala.Option[String] = None,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]]
 
     def getByOrganization(
       organization: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]]
 
     def postMembersBulkByOrganization(
       organization: _root_.java.util.UUID,
       members: Seq[io.apibuilder.reference.api.v0.models.Member],
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]]
   }
 
   trait Organizations {
     def post(
       organization: io.apibuilder.reference.api.v0.models.Organization,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization]
 
     def get(
       guid: _root_.scala.Option[_root_.java.util.UUID] = None,
       name: _root_.scala.Option[String] = None,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Organization]]
 
     def getByGuid(
       guid: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization]
   }
 
@@ -878,7 +903,8 @@ package io.apibuilder.reference.api.v0 {
       guid: _root_.java.util.UUID,
       email: String,
       active: Boolean,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.User]
 
     /**
@@ -891,16 +917,19 @@ package io.apibuilder.reference.api.v0 {
       ageGroup: _root_.scala.Option[io.apibuilder.reference.api.v0.models.AgeGroup] = None,
       email: _root_.scala.Option[String] = None,
       active: Boolean = true,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]]
 
     def getByAgeGroup(
       ageGroup: io.apibuilder.reference.api.v0.models.AgeGroup,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]]
 
     def postNoop(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit]
   }
 

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -569,7 +569,8 @@ package io.apibuilder.reference.api.v0 {
         foo: _root_.scala.Option[String] = None,
         optionalMessages: _root_.scala.Option[Seq[String]] = None,
         requiredMessages: Seq[String],
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
         val queryParameters = Seq(
           foo.map("foo" -> _)
@@ -577,7 +578,7 @@ package io.apibuilder.reference.api.v0 {
           optionalMessages.getOrElse(Nil).map("optional_messages" -> _) ++
           requiredMessages.map("required_messages" -> _)
 
-        _executeRequest("GET", s"/echoes", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/echoes", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 204 => ()
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 204")
         }
@@ -586,12 +587,13 @@ package io.apibuilder.reference.api.v0 {
       override def getArraysOnly(
         optionalMessages: _root_.scala.Option[Seq[String]] = None,
         requiredMessages: Seq[String],
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
         val queryParameters = optionalMessages.getOrElse(Nil).map("optional_messages" -> _) ++
           requiredMessages.map("required_messages" -> _)
 
-        _executeRequest("GET", s"/echoes/arrays-only", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/echoes/arrays-only", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 204 => ()
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 204")
         }
@@ -601,9 +603,10 @@ package io.apibuilder.reference.api.v0 {
     object Groups extends Groups {
       override def getByOrganization(
         organization: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]] = {
-        _executeRequest("GET", s"/groups/${organization}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/groups/${organization}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]", r, _.validate[Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -616,7 +619,8 @@ package io.apibuilder.reference.api.v0 {
         organization: _root_.java.util.UUID,
         user: _root_.java.util.UUID,
         role: String,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Member] = {
         val payload = play.api.libs.json.Json.obj(
           "guid" -> play.api.libs.json.Json.toJson(guid),
@@ -625,7 +629,7 @@ package io.apibuilder.reference.api.v0 {
           "role" -> play.api.libs.json.Json.toJson(role)
         )
 
-        _executeRequest("POST", s"/members", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/members", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 201 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.Member", r, _.validate[io.apibuilder.reference.api.v0.models.Member])
           case r if r.status == 409 => throw io.apibuilder.reference.api.v0.errors.ErrorsResponse(r)
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 201, 409")
@@ -637,7 +641,8 @@ package io.apibuilder.reference.api.v0 {
         organizationGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
         userGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
         role: _root_.scala.Option[String] = None,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]] = {
         val queryParameters = Seq(
           guid.map("guid" -> _.toString),
@@ -646,7 +651,7 @@ package io.apibuilder.reference.api.v0 {
           role.map("role" -> _)
         ).flatten
 
-        _executeRequest("GET", s"/members", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/members", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Member]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Member]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -654,9 +659,10 @@ package io.apibuilder.reference.api.v0 {
 
       override def getByOrganization(
         organization: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]] = {
-        _executeRequest("GET", s"/members/${organization}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/members/${organization}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Member]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Member]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -665,11 +671,12 @@ package io.apibuilder.reference.api.v0 {
       override def postMembersBulkByOrganization(
         organization: _root_.java.util.UUID,
         members: Seq[io.apibuilder.reference.api.v0.models.Member],
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]] = {
         val payload = play.api.libs.json.Json.toJson(members)
 
-        _executeRequest("POST", s"/members/${organization}/members_bulk", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/members/${organization}/members_bulk", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Member]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Member]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -679,13 +686,14 @@ package io.apibuilder.reference.api.v0 {
     object Organizations extends Organizations {
       override def post(
         organization: io.apibuilder.reference.api.v0.models.Organization,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization] = {
         val payload = play.api.libs.json.Json.obj(
           "organization" -> play.api.libs.json.Json.toJson(organization)
         )
 
-        _executeRequest("POST", s"/organizations", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/organizations", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 201 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.Organization", r, _.validate[io.apibuilder.reference.api.v0.models.Organization])
           case r if r.status == 409 => throw io.apibuilder.reference.api.v0.errors.ErrorsResponse(r)
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 201, 409")
@@ -695,14 +703,15 @@ package io.apibuilder.reference.api.v0 {
       override def get(
         guid: _root_.scala.Option[_root_.java.util.UUID] = None,
         name: _root_.scala.Option[String] = None,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Organization]] = {
         val queryParameters = Seq(
           guid.map("guid" -> _.toString),
           name.map("name" -> _)
         ).flatten
 
-        _executeRequest("GET", s"/organizations", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/organizations", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Organization]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Organization]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -710,9 +719,10 @@ package io.apibuilder.reference.api.v0 {
 
       override def getByGuid(
         guid: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization] = {
-        _executeRequest("GET", s"/organizations/${guid}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/organizations/${guid}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.Organization", r, _.validate[io.apibuilder.reference.api.v0.models.Organization])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -724,7 +734,8 @@ package io.apibuilder.reference.api.v0 {
         guid: _root_.java.util.UUID,
         email: String,
         active: Boolean,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.User] = {
         val payload = play.api.libs.json.Json.obj(
           "guid" -> play.api.libs.json.Json.toJson(guid),
@@ -732,7 +743,7 @@ package io.apibuilder.reference.api.v0 {
           "active" -> play.api.libs.json.Json.toJson(active)
         )
 
-        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 201 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.User", r, _.validate[io.apibuilder.reference.api.v0.models.User])
           case r if r.status == 409 => throw io.apibuilder.reference.api.v0.errors.ErrorsResponse(r)
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 201, 409")
@@ -745,7 +756,8 @@ package io.apibuilder.reference.api.v0 {
         ageGroup: _root_.scala.Option[io.apibuilder.reference.api.v0.models.AgeGroup] = None,
         email: _root_.scala.Option[String] = None,
         active: Boolean = true,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]] = {
         val queryParameters = Seq(
           guid.map("guid" -> _.toString),
@@ -755,7 +767,7 @@ package io.apibuilder.reference.api.v0 {
         ).flatten ++
           organizationGuids.getOrElse(Nil).map("organization_guids" -> _.toString)
 
-        _executeRequest("GET", s"/users", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.User]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.User]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -763,18 +775,20 @@ package io.apibuilder.reference.api.v0 {
 
       override def getByAgeGroup(
         ageGroup: io.apibuilder.reference.api.v0.models.AgeGroup,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]] = {
-        _executeRequest("GET", s"/users/${play.utils.UriEncoding.encodePathSegment(ageGroup.toString, "UTF-8")}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users/${play.utils.UriEncoding.encodePathSegment(ageGroup.toString, "UTF-8")}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.User]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.User]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
       }
 
       override def postNoop(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
-        _executeRequest("POST", s"/users/noop", requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users/noop", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => ()
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -814,32 +828,41 @@ package io.apibuilder.reference.api.v0 {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("PUT", request).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("PATCH", request).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("DELETE", request).delete()
         }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
+        case "HEAD" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("HEAD", request).head()
         }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
+        case "OPTIONS" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("OPTIONS", request).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }
@@ -898,20 +921,23 @@ package io.apibuilder.reference.api.v0 {
       foo: _root_.scala.Option[String] = None,
       optionalMessages: _root_.scala.Option[Seq[String]] = None,
       requiredMessages: Seq[String],
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit]
 
     def getArraysOnly(
       optionalMessages: _root_.scala.Option[Seq[String]] = None,
       requiredMessages: Seq[String],
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit]
   }
 
   trait Groups {
     def getByOrganization(
       organization: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]]
   }
 
@@ -921,7 +947,8 @@ package io.apibuilder.reference.api.v0 {
       organization: _root_.java.util.UUID,
       user: _root_.java.util.UUID,
       role: String,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Member]
 
     def get(
@@ -929,36 +956,42 @@ package io.apibuilder.reference.api.v0 {
       organizationGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
       userGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
       role: _root_.scala.Option[String] = None,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]]
 
     def getByOrganization(
       organization: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]]
 
     def postMembersBulkByOrganization(
       organization: _root_.java.util.UUID,
       members: Seq[io.apibuilder.reference.api.v0.models.Member],
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]]
   }
 
   trait Organizations {
     def post(
       organization: io.apibuilder.reference.api.v0.models.Organization,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization]
 
     def get(
       guid: _root_.scala.Option[_root_.java.util.UUID] = None,
       name: _root_.scala.Option[String] = None,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Organization]]
 
     def getByGuid(
       guid: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization]
   }
 
@@ -967,7 +1000,8 @@ package io.apibuilder.reference.api.v0 {
       guid: _root_.java.util.UUID,
       email: String,
       active: Boolean,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.User]
 
     /**
@@ -980,16 +1014,19 @@ package io.apibuilder.reference.api.v0 {
       ageGroup: _root_.scala.Option[io.apibuilder.reference.api.v0.models.AgeGroup] = None,
       email: _root_.scala.Option[String] = None,
       active: Boolean = true,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]]
 
     def getByAgeGroup(
       ageGroup: io.apibuilder.reference.api.v0.models.AgeGroup,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]]
 
     def postNoop(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit]
   }
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -462,7 +462,8 @@ package io.apibuilder.reference.api.v0 {
         foo: _root_.scala.Option[String] = None,
         optionalMessages: _root_.scala.Option[Seq[String]] = None,
         requiredMessages: Seq[String],
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
         val queryParameters = Seq(
           foo.map("foo" -> _)
@@ -470,7 +471,7 @@ package io.apibuilder.reference.api.v0 {
           optionalMessages.getOrElse(Nil).map("optional_messages" -> _) ++
           requiredMessages.map("required_messages" -> _)
 
-        _executeRequest("GET", s"/echoes", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/echoes", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 204 => ()
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 204", requestUri = Some(r.getUri))
         }
@@ -479,12 +480,13 @@ package io.apibuilder.reference.api.v0 {
       override def getArraysOnly(
         optionalMessages: _root_.scala.Option[Seq[String]] = None,
         requiredMessages: Seq[String],
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
         val queryParameters = optionalMessages.getOrElse(Nil).map("optional_messages" -> _) ++
           requiredMessages.map("required_messages" -> _)
 
-        _executeRequest("GET", s"/echoes/arrays-only", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/echoes/arrays-only", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 204 => ()
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 204", requestUri = Some(r.getUri))
         }
@@ -494,9 +496,10 @@ package io.apibuilder.reference.api.v0 {
     object Groups extends Groups {
       override def getByOrganization(
         organization: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]] = {
-        _executeRequest("GET", s"/groups/${organization}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/groups/${organization}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]", r, _.validate[Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -509,7 +512,8 @@ package io.apibuilder.reference.api.v0 {
         organization: _root_.java.util.UUID,
         user: _root_.java.util.UUID,
         role: String,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Member] = {
         val payload = play.api.libs.json.Json.obj(
           "guid" -> play.api.libs.json.Json.toJson(guid),
@@ -518,7 +522,7 @@ package io.apibuilder.reference.api.v0 {
           "role" -> play.api.libs.json.Json.toJson(role)
         )
 
-        _executeRequest("POST", s"/members", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/members", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 201 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.Member", r, _.validate[io.apibuilder.reference.api.v0.models.Member])
           case r if r.getStatusCode == 409 => throw io.apibuilder.reference.api.v0.errors.ErrorsResponse(r)
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 201, 409", requestUri = Some(r.getUri))
@@ -530,7 +534,8 @@ package io.apibuilder.reference.api.v0 {
         organizationGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
         userGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
         role: _root_.scala.Option[String] = None,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]] = {
         val queryParameters = Seq(
           guid.map("guid" -> _.toString),
@@ -539,7 +544,7 @@ package io.apibuilder.reference.api.v0 {
           role.map("role" -> _)
         ).flatten
 
-        _executeRequest("GET", s"/members", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/members", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Member]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Member]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -547,9 +552,10 @@ package io.apibuilder.reference.api.v0 {
 
       override def getByOrganization(
         organization: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]] = {
-        _executeRequest("GET", s"/members/${organization}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/members/${organization}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Member]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Member]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -558,11 +564,12 @@ package io.apibuilder.reference.api.v0 {
       override def postMembersBulkByOrganization(
         organization: _root_.java.util.UUID,
         members: Seq[io.apibuilder.reference.api.v0.models.Member],
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]] = {
         val payload = play.api.libs.json.Json.toJson(members)
 
-        _executeRequest("POST", s"/members/${organization}/members_bulk", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/members/${organization}/members_bulk", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Member]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Member]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -572,13 +579,14 @@ package io.apibuilder.reference.api.v0 {
     object Organizations extends Organizations {
       override def postOrganizations(
         organization: io.apibuilder.reference.api.v0.models.Organization,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization] = {
         val payload = play.api.libs.json.Json.obj(
           "organization" -> play.api.libs.json.Json.toJson(organization)
         )
 
-        _executeRequest("POST", s"/organizations", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/organizations", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 201 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.Organization", r, _.validate[io.apibuilder.reference.api.v0.models.Organization])
           case r if r.getStatusCode == 409 => throw io.apibuilder.reference.api.v0.errors.ErrorsResponse(r)
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 201, 409", requestUri = Some(r.getUri))
@@ -588,14 +596,15 @@ package io.apibuilder.reference.api.v0 {
       override def getOrganizations(
         guid: _root_.scala.Option[_root_.java.util.UUID] = None,
         name: _root_.scala.Option[String] = None,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Organization]] = {
         val queryParameters = Seq(
           guid.map("guid" -> _.toString),
           name.map("name" -> _)
         ).flatten
 
-        _executeRequest("GET", s"/organizations", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/organizations", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Organization]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Organization]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -603,9 +612,10 @@ package io.apibuilder.reference.api.v0 {
 
       override def getByGuid(
         guid: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization] = {
-        _executeRequest("GET", s"/${guid}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/${guid}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.Organization", r, _.validate[io.apibuilder.reference.api.v0.models.Organization])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -617,7 +627,8 @@ package io.apibuilder.reference.api.v0 {
         guid: _root_.java.util.UUID,
         email: String,
         active: Boolean,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.User] = {
         val payload = play.api.libs.json.Json.obj(
           "guid" -> play.api.libs.json.Json.toJson(guid),
@@ -625,7 +636,7 @@ package io.apibuilder.reference.api.v0 {
           "active" -> play.api.libs.json.Json.toJson(active)
         )
 
-        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 201 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.User", r, _.validate[io.apibuilder.reference.api.v0.models.User])
           case r if r.getStatusCode == 409 => throw io.apibuilder.reference.api.v0.errors.ErrorsResponse(r)
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 201, 409", requestUri = Some(r.getUri))
@@ -638,7 +649,8 @@ package io.apibuilder.reference.api.v0 {
         ageGroup: _root_.scala.Option[io.apibuilder.reference.api.v0.models.AgeGroup] = None,
         email: _root_.scala.Option[String] = None,
         active: Boolean = true,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]] = {
         val queryParameters = Seq(
           guid.map("guid" -> _.toString),
@@ -648,7 +660,7 @@ package io.apibuilder.reference.api.v0 {
         ).flatten ++
           organizationGuids.getOrElse(Nil).map("organization_guids" -> _.toString)
 
-        _executeRequest("GET", s"/users", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.User]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.User]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -656,18 +668,20 @@ package io.apibuilder.reference.api.v0 {
 
       override def getByAgeGroup(
         ageGroup: io.apibuilder.reference.api.v0.models.AgeGroup,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]] = {
-        _executeRequest("GET", s"/users/${_root_.io.apibuilder.reference.api.v0.PathSegment.encode(ageGroup.toString, "UTF-8")}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users/${_root_.io.apibuilder.reference.api.v0.PathSegment.encode(ageGroup.toString, "UTF-8")}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.User]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.User]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
       }
 
       override def postNoop(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
-        _executeRequest("POST", s"/users/noop", requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users/noop", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.getStatusCode == 200 => ()
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
@@ -686,8 +700,8 @@ package io.apibuilder.reference.api.v0 {
       }
     }
 
-    def _requestBuilder(method: String, path: String, requestHeaders: Seq[(String, String)]): RequestBuilder = {
-      val builder = new RequestBuilder(method)
+    def _requestBuilder(method: String, path: String, requestHeaders: Seq[(String, String)]): _root_.com.ning.http.client.RequestBuilder = {
+      val builder = new _root_.com.ning.http.client.RequestBuilder(method)
         .setUrl(baseUrl + path)
         .addHeader("User-Agent", Constants.UserAgent)
         .addHeader("X-Apidoc-Version", Constants.Version)
@@ -716,7 +730,8 @@ package io.apibuilder.reference.api.v0 {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.ning.http.client.Response] = {
       val allHeaders = body match {
         case None => requestHeaders
@@ -734,7 +749,7 @@ package io.apibuilder.reference.api.v0 {
         request.setBody(serialized)
       }
 
-      val finalRequest = requestWithParamsAndBody.build()
+      val finalRequest = requestModifier(requestWithParamsAndBody).build()
       _logRequest(finalRequest)
 
       val result = scala.concurrent.Promise[com.ning.http.client.Response]()
@@ -811,20 +826,23 @@ package io.apibuilder.reference.api.v0 {
       foo: _root_.scala.Option[String] = None,
       optionalMessages: _root_.scala.Option[Seq[String]] = None,
       requiredMessages: Seq[String],
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit]
 
     def getArraysOnly(
       optionalMessages: _root_.scala.Option[Seq[String]] = None,
       requiredMessages: Seq[String],
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit]
   }
 
   trait Groups {
     def getByOrganization(
       organization: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]]
   }
 
@@ -834,7 +852,8 @@ package io.apibuilder.reference.api.v0 {
       organization: _root_.java.util.UUID,
       user: _root_.java.util.UUID,
       role: String,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Member]
 
     def get(
@@ -842,36 +861,42 @@ package io.apibuilder.reference.api.v0 {
       organizationGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
       userGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
       role: _root_.scala.Option[String] = None,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]]
 
     def getByOrganization(
       organization: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]]
 
     def postMembersBulkByOrganization(
       organization: _root_.java.util.UUID,
       members: Seq[io.apibuilder.reference.api.v0.models.Member],
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]]
   }
 
   trait Organizations {
     def postOrganizations(
       organization: io.apibuilder.reference.api.v0.models.Organization,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization]
 
     def getOrganizations(
       guid: _root_.scala.Option[_root_.java.util.UUID] = None,
       name: _root_.scala.Option[String] = None,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Organization]]
 
     def getByGuid(
       guid: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization]
   }
 
@@ -880,7 +905,8 @@ package io.apibuilder.reference.api.v0 {
       guid: _root_.java.util.UUID,
       email: String,
       active: Boolean,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.User]
 
     /**
@@ -893,16 +919,19 @@ package io.apibuilder.reference.api.v0 {
       ageGroup: _root_.scala.Option[io.apibuilder.reference.api.v0.models.AgeGroup] = None,
       email: _root_.scala.Option[String] = None,
       active: Boolean = true,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]]
 
     def getByAgeGroup(
       ageGroup: io.apibuilder.reference.api.v0.models.AgeGroup,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]]
 
     def postNoop(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: _root_.com.ning.http.client.RequestBuilder => _root_.com.ning.http.client.RequestBuilder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit]
   }
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -571,7 +571,8 @@ package io.apibuilder.reference.api.v0 {
         foo: _root_.scala.Option[String] = None,
         optionalMessages: _root_.scala.Option[Seq[String]] = None,
         requiredMessages: Seq[String],
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
         val queryParameters = Seq(
           foo.map("foo" -> _)
@@ -579,7 +580,7 @@ package io.apibuilder.reference.api.v0 {
           optionalMessages.getOrElse(Nil).map("optional_messages" -> _) ++
           requiredMessages.map("required_messages" -> _)
 
-        _executeRequest("GET", s"/echoes", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/echoes", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 204 => ()
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 204")
         }
@@ -588,12 +589,13 @@ package io.apibuilder.reference.api.v0 {
       override def getArraysOnly(
         optionalMessages: _root_.scala.Option[Seq[String]] = None,
         requiredMessages: Seq[String],
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
         val queryParameters = optionalMessages.getOrElse(Nil).map("optional_messages" -> _) ++
           requiredMessages.map("required_messages" -> _)
 
-        _executeRequest("GET", s"/echoes/arrays-only", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/echoes/arrays-only", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 204 => ()
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 204")
         }
@@ -603,9 +605,10 @@ package io.apibuilder.reference.api.v0 {
     object Groups extends Groups {
       override def getByOrganization(
         organization: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]] = {
-        _executeRequest("GET", s"/groups/${organization}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/groups/${organization}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]", r, _.validate[Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -618,7 +621,8 @@ package io.apibuilder.reference.api.v0 {
         organization: _root_.java.util.UUID,
         user: _root_.java.util.UUID,
         role: String,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Member] = {
         val payload = play.api.libs.json.Json.obj(
           "guid" -> play.api.libs.json.Json.toJson(guid),
@@ -627,7 +631,7 @@ package io.apibuilder.reference.api.v0 {
           "role" -> play.api.libs.json.Json.toJson(role)
         )
 
-        _executeRequest("POST", s"/members", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/members", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 201 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.Member", r, _.validate[io.apibuilder.reference.api.v0.models.Member])
           case r if r.status == 409 => throw io.apibuilder.reference.api.v0.errors.ErrorsResponse(r)
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 201, 409")
@@ -639,7 +643,8 @@ package io.apibuilder.reference.api.v0 {
         organizationGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
         userGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
         role: _root_.scala.Option[String] = None,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]] = {
         val queryParameters = Seq(
           guid.map("guid" -> _.toString),
@@ -648,7 +653,7 @@ package io.apibuilder.reference.api.v0 {
           role.map("role" -> _)
         ).flatten
 
-        _executeRequest("GET", s"/members", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/members", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Member]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Member]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -656,9 +661,10 @@ package io.apibuilder.reference.api.v0 {
 
       override def getByOrganization(
         organization: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]] = {
-        _executeRequest("GET", s"/members/${organization}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/members/${organization}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Member]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Member]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -667,11 +673,12 @@ package io.apibuilder.reference.api.v0 {
       override def postMembersBulkByOrganization(
         organization: _root_.java.util.UUID,
         members: Seq[io.apibuilder.reference.api.v0.models.Member],
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]] = {
         val payload = play.api.libs.json.Json.toJson(members)
 
-        _executeRequest("POST", s"/members/${organization}/members_bulk", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/members/${organization}/members_bulk", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Member]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Member]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -681,13 +688,14 @@ package io.apibuilder.reference.api.v0 {
     object Organizations extends Organizations {
       override def postOrganizations(
         organization: io.apibuilder.reference.api.v0.models.Organization,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization] = {
         val payload = play.api.libs.json.Json.obj(
           "organization" -> play.api.libs.json.Json.toJson(organization)
         )
 
-        _executeRequest("POST", s"/organizations", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/organizations", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 201 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.Organization", r, _.validate[io.apibuilder.reference.api.v0.models.Organization])
           case r if r.status == 409 => throw io.apibuilder.reference.api.v0.errors.ErrorsResponse(r)
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 201, 409")
@@ -697,14 +705,15 @@ package io.apibuilder.reference.api.v0 {
       override def getOrganizations(
         guid: _root_.scala.Option[_root_.java.util.UUID] = None,
         name: _root_.scala.Option[String] = None,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Organization]] = {
         val queryParameters = Seq(
           guid.map("guid" -> _.toString),
           name.map("name" -> _)
         ).flatten
 
-        _executeRequest("GET", s"/organizations", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/organizations", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.Organization]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.Organization]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -712,9 +721,10 @@ package io.apibuilder.reference.api.v0 {
 
       override def getByGuid(
         guid: _root_.java.util.UUID,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization] = {
-        _executeRequest("GET", s"/${guid}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/${guid}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.Organization", r, _.validate[io.apibuilder.reference.api.v0.models.Organization])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -726,7 +736,8 @@ package io.apibuilder.reference.api.v0 {
         guid: _root_.java.util.UUID,
         email: String,
         active: Boolean,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.User] = {
         val payload = play.api.libs.json.Json.obj(
           "guid" -> play.api.libs.json.Json.toJson(guid),
@@ -734,7 +745,7 @@ package io.apibuilder.reference.api.v0 {
           "active" -> play.api.libs.json.Json.toJson(active)
         )
 
-        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 201 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("io.apibuilder.reference.api.v0.models.User", r, _.validate[io.apibuilder.reference.api.v0.models.User])
           case r if r.status == 409 => throw io.apibuilder.reference.api.v0.errors.ErrorsResponse(r)
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 201, 409")
@@ -747,7 +758,8 @@ package io.apibuilder.reference.api.v0 {
         ageGroup: _root_.scala.Option[io.apibuilder.reference.api.v0.models.AgeGroup] = None,
         email: _root_.scala.Option[String] = None,
         active: Boolean = true,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]] = {
         val queryParameters = Seq(
           guid.map("guid" -> _.toString),
@@ -757,7 +769,7 @@ package io.apibuilder.reference.api.v0 {
         ).flatten ++
           organizationGuids.getOrElse(Nil).map("organization_guids" -> _.toString)
 
-        _executeRequest("GET", s"/users", queryParameters = queryParameters, requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users", queryParameters = queryParameters, requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.User]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.User]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -765,18 +777,20 @@ package io.apibuilder.reference.api.v0 {
 
       override def getByAgeGroup(
         ageGroup: io.apibuilder.reference.api.v0.models.AgeGroup,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]] = {
-        _executeRequest("GET", s"/users/${play.utils.UriEncoding.encodePathSegment(ageGroup.toString, "UTF-8")}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users/${play.utils.UriEncoding.encodePathSegment(ageGroup.toString, "UTF-8")}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.reference.api.v0.Client.parseJson("Seq[io.apibuilder.reference.api.v0.models.User]", r, _.validate[Seq[io.apibuilder.reference.api.v0.models.User]])
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
       }
 
       override def postNoop(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
-        _executeRequest("POST", s"/users/noop", requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users/noop", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => ()
           case r => throw io.apibuilder.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -816,32 +830,41 @@ package io.apibuilder.reference.api.v0 {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("PUT", request).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("PATCH", request).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("DELETE", request).delete()
         }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
+        case "HEAD" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("HEAD", request).head()
         }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
+        case "OPTIONS" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("OPTIONS", request).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }
@@ -900,20 +923,23 @@ package io.apibuilder.reference.api.v0 {
       foo: _root_.scala.Option[String] = None,
       optionalMessages: _root_.scala.Option[Seq[String]] = None,
       requiredMessages: Seq[String],
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit]
 
     def getArraysOnly(
       optionalMessages: _root_.scala.Option[Seq[String]] = None,
       requiredMessages: Seq[String],
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit]
   }
 
   trait Groups {
     def getByOrganization(
       organization: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Map[String, Seq[io.apibuilder.reference.api.v0.models.User]]]
   }
 
@@ -923,7 +949,8 @@ package io.apibuilder.reference.api.v0 {
       organization: _root_.java.util.UUID,
       user: _root_.java.util.UUID,
       role: String,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Member]
 
     def get(
@@ -931,36 +958,42 @@ package io.apibuilder.reference.api.v0 {
       organizationGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
       userGuid: _root_.scala.Option[_root_.java.util.UUID] = None,
       role: _root_.scala.Option[String] = None,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]]
 
     def getByOrganization(
       organization: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]]
 
     def postMembersBulkByOrganization(
       organization: _root_.java.util.UUID,
       members: Seq[io.apibuilder.reference.api.v0.models.Member],
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Member]]
   }
 
   trait Organizations {
     def postOrganizations(
       organization: io.apibuilder.reference.api.v0.models.Organization,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization]
 
     def getOrganizations(
       guid: _root_.scala.Option[_root_.java.util.UUID] = None,
       name: _root_.scala.Option[String] = None,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.Organization]]
 
     def getByGuid(
       guid: _root_.java.util.UUID,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.Organization]
   }
 
@@ -969,7 +1002,8 @@ package io.apibuilder.reference.api.v0 {
       guid: _root_.java.util.UUID,
       email: String,
       active: Boolean,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.reference.api.v0.models.User]
 
     /**
@@ -982,16 +1016,19 @@ package io.apibuilder.reference.api.v0 {
       ageGroup: _root_.scala.Option[io.apibuilder.reference.api.v0.models.AgeGroup] = None,
       email: _root_.scala.Option[String] = None,
       active: Boolean = true,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]]
 
     def getByAgeGroup(
       ageGroup: io.apibuilder.reference.api.v0.models.AgeGroup,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.reference.api.v0.models.User]]
 
     def postNoop(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit]
   }
 

--- a/lib/src/test/resources/generators/scala-primitive-object-response-list.txt
+++ b/lib/src/test/resources/generators/scala-primitive-object-response-list.txt
@@ -1,8 +1,9 @@
 object Contents extends Contents {
   override def get(
-    requestHeaders: Seq[(String, String)] = Nil
+    requestHeaders: Seq[(String, String)] = Nil,
+    requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
   )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[_root_.play.api.libs.json.JsObject]] = {
-    _executeRequest("GET", s"/contents/data", requestHeaders = requestHeaders).map {
+    _executeRequest("GET", s"/contents/data", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
       case r if r.status == 200 => _root_.test.apidoc.Client.parseJson("Seq[_root_.play.api.libs.json.JsObject]", r, _.validate[Seq[_root_.play.api.libs.json.JsObject]])
       case r => throw test.apidoc.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
     }

--- a/lib/src/test/resources/generators/scala-primitive-object-response-map.txt
+++ b/lib/src/test/resources/generators/scala-primitive-object-response-map.txt
@@ -1,8 +1,9 @@
 object Contents extends Contents {
   override def get(
-    requestHeaders: Seq[(String, String)] = Nil
+    requestHeaders: Seq[(String, String)] = Nil,
+    requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
   )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Map[String, _root_.play.api.libs.json.JsObject]] = {
-    _executeRequest("GET", s"/contents/data", requestHeaders = requestHeaders).map {
+    _executeRequest("GET", s"/contents/data", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
       case r if r.status == 200 => _root_.test.apidoc.Client.parseJson("Map[String, _root_.play.api.libs.json.JsObject]", r, _.validate[Map[String, _root_.play.api.libs.json.JsObject]])
       case r => throw test.apidoc.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
     }

--- a/lib/src/test/resources/generators/scala-primitive-object-response-singleton.txt
+++ b/lib/src/test/resources/generators/scala-primitive-object-response-singleton.txt
@@ -1,8 +1,9 @@
 object Contents extends Contents {
   override def get(
-    requestHeaders: Seq[(String, String)] = Nil
+    requestHeaders: Seq[(String, String)] = Nil,
+    requestModifier: play.api.libs.ws.WSRequestHolder => play.api.libs.ws.WSRequestHolder = identity
   )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[_root_.play.api.libs.json.JsObject] = {
-    _executeRequest("GET", s"/contents/data", requestHeaders = requestHeaders).map {
+    _executeRequest("GET", s"/contents/data", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
       case r if r.status == 200 => _root_.test.apidoc.Client.parseJson("_root_.play.api.libs.json.JsObject", r, _.validate[_root_.play.api.libs.json.JsObject])
       case r => throw test.apidoc.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
     }

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -380,9 +380,10 @@ package io.apibuilder.example.union.types.discriminator.v0 {
 
     object Users extends Users {
       override def get(
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.example.union.types.discriminator.v0.models.User]] = {
-        _executeRequest("GET", s"/users", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.example.union.types.discriminator.v0.Client.parseJson("Seq[io.apibuilder.example.union.types.discriminator.v0.models.User]", r, _.validate[Seq[io.apibuilder.example.union.types.discriminator.v0.models.User]])
           case r => throw io.apibuilder.example.union.types.discriminator.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
@@ -390,9 +391,10 @@ package io.apibuilder.example.union.types.discriminator.v0 {
 
       override def getById(
         id: String,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.example.union.types.discriminator.v0.models.User] = {
-        _executeRequest("GET", s"/users/${play.utils.UriEncoding.encodePathSegment(id, "UTF-8")}", requestHeaders = requestHeaders).map {
+        _executeRequest("GET", s"/users/${play.utils.UriEncoding.encodePathSegment(id, "UTF-8")}", requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 200 => _root_.io.apibuilder.example.union.types.discriminator.v0.Client.parseJson("io.apibuilder.example.union.types.discriminator.v0.models.User", r, _.validate[io.apibuilder.example.union.types.discriminator.v0.models.User])
           case r if r.status == 404 => throw io.apibuilder.example.union.types.discriminator.v0.errors.UnitResponse(r.status)
           case r => throw io.apibuilder.example.union.types.discriminator.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200, 404")
@@ -401,11 +403,12 @@ package io.apibuilder.example.union.types.discriminator.v0 {
 
       override def post(
         user: io.apibuilder.example.union.types.discriminator.v0.models.User,
-        requestHeaders: Seq[(String, String)] = Nil
+        requestHeaders: Seq[(String, String)] = Nil,
+        requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.example.union.types.discriminator.v0.models.User] = {
         val payload = play.api.libs.json.Json.toJson(user)
 
-        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders).map {
+        _executeRequest("POST", s"/users", body = Some(payload), requestHeaders = requestHeaders, requestModifier = requestModifier).map {
           case r if r.status == 201 => _root_.io.apibuilder.example.union.types.discriminator.v0.Client.parseJson("io.apibuilder.example.union.types.discriminator.v0.models.User", r, _.validate[io.apibuilder.example.union.types.discriminator.v0.models.User])
           case r => throw io.apibuilder.example.union.types.discriminator.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 201")
         }
@@ -445,32 +448,41 @@ package io.apibuilder.example.union.types.discriminator.v0 {
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*))
+          _logRequest("PUT", request).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("PATCH", request).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("DELETE", request).delete()
         }
-         case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
+        case "HEAD" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("HEAD", request).head()
         }
-         case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
+        case "OPTIONS" => {
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest("OPTIONS", request).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          val request = requestModifier(_requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }
@@ -522,17 +534,20 @@ package io.apibuilder.example.union.types.discriminator.v0 {
 
   trait Users {
     def get(
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[io.apibuilder.example.union.types.discriminator.v0.models.User]]
 
     def getById(
       id: String,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.example.union.types.discriminator.v0.models.User]
 
     def post(
       user: io.apibuilder.example.union.types.discriminator.v0.models.User,
-      requestHeaders: Seq[(String, String)] = Nil
+      requestHeaders: Seq[(String, String)] = Nil,
+      requestModifier: play.api.libs.ws.WSRequest => play.api.libs.ws.WSRequest = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.example.union.types.discriminator.v0.models.User]
   }
 

--- a/scala-generator/src/main/scala/models/generator/ScalaClientMethodConfig.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientMethodConfig.scala
@@ -37,6 +37,11 @@ trait ScalaClientMethodConfig {
     */
   def responseClass: String
 
+  /**
+    * The class name for building the Request object.
+    */
+  def requestBuilderClass: String
+
   /** Whether or not play.api.libs.ws.WS exists as a static object, or if
     * play.api.libs.ws.WSClient is expected to be passed in.
     */
@@ -102,6 +107,7 @@ object ScalaClientMethodConfigs {
 
   case class Play22(namespace: String, baseUrl: Option[String]) extends Play {
     override val responseClass = "play.api.libs.ws.Response"
+    override val requestBuilderClass = "play.api.libs.ws.WS.WSRequestHolder"
     override val requestUriMethod = Some("ahcResponse.getUri")
     override val expectsInjectedWsClient = false
     override val canSerializeUuid = false
@@ -109,6 +115,7 @@ object ScalaClientMethodConfigs {
 
   case class Play23(namespace: String, baseUrl: Option[String]) extends Play {
     override val responseClass = "play.api.libs.ws.WSResponse"
+    override val requestBuilderClass = "play.api.libs.ws.WSRequestHolder"
     override val requestUriMethod: Option[String] = None
     override val expectsInjectedWsClient = false
     override val canSerializeUuid = true
@@ -116,6 +123,7 @@ object ScalaClientMethodConfigs {
 
   case class Play24(namespace: String, baseUrl: Option[String]) extends Play {
     override val responseClass = "play.api.libs.ws.WSResponse"
+    override val requestBuilderClass = "play.api.libs.ws.WSRequest"
     override val requestUriMethod: Option[String] = None
     override val expectsInjectedWsClient = false
     override val canSerializeUuid = true
@@ -123,6 +131,7 @@ object ScalaClientMethodConfigs {
 
   case class Play25(namespace: String, baseUrl: Option[String]) extends Play {
     override val responseClass = "play.api.libs.ws.WSResponse"
+    override val requestBuilderClass = "play.api.libs.ws.WSRequest"
     override val requestUriMethod: Option[String] = None
     override val expectsInjectedWsClient = true
     override val canSerializeUuid = true
@@ -130,6 +139,7 @@ object ScalaClientMethodConfigs {
 
   case class Play26(namespace: String, baseUrl: Option[String]) extends Play {
     override val responseClass = "play.api.libs.ws.WSResponse"
+    override val requestBuilderClass = "play.api.libs.ws.WSRequest"
     override val requestUriMethod: Option[String] = None
     override val expectsInjectedWsClient = true
     override val canSerializeUuid = true
@@ -140,6 +150,7 @@ object ScalaClientMethodConfigs {
     override val responseStatusMethod = "getStatusCode"
     override val responseBodyMethod = """getResponseBody("UTF-8")"""
     override val responseClass = "_root_.com.ning.http.client.Response"
+    override val requestBuilderClass = "_root_.com.ning.http.client.RequestBuilder"
     override val extraClientCtorArgs = Some(",\n  asyncHttpClient: AsyncHttpClient = Client.defaultAsyncHttpClient")
     override val extraClientObjectMethods = Some("""
 private lazy val defaultAsyncHttpClient = {
@@ -194,6 +205,7 @@ private lazy val defaultAsyncHttpClient = {
     override val responseStatusMethod = "status.code"
     override val responseBodyMethod = """body"""
     override val responseClass = "org.http4s.Response"
+    override val requestBuilderClass: String = "org.http4s.Request"
     override def extraClientCtorArgs: Option[String] = Some(",\n  asyncHttpClient: org.http4s.client.Client = Client.defaultAsyncHttpClient")
     override val extraClientObjectMethods = Some("""
 implicit def circeJsonDecoder[A](implicit decoder: io.circe.Decoder[A]) = org.http4s.circe.jsonOf[A]
@@ -213,7 +225,6 @@ private lazy val defaultAsyncHttpClient = PooledHttp1Client()
     def rightType: String
     def monadTransformerInvoke: String
     def asyncFailure: String
-    def requestClass: String = "org.http4s.Request"
     def messageClass: String = "org.http4s.Message"
     def httpServiceClass: String = "org.http4s.HttpService"
     def generateDecodeResult(datatypeName: String): String = s"org.http4s.DecodeResult[$datatypeName]"
@@ -269,7 +280,7 @@ implicit def circeJsonDecoder[${asyncTypeParam(Some("Sync")).map(_+", ").getOrEl
       """)
     override val asyncSuccess: String = "pure"
     override def asyncFailure: String = "raiseError"
-    override def requestClass: String = s"org.http4s.Request[$asyncType]"
+    override val requestBuilderClass: String = s"org.http4s.Request[$asyncType]"
     override def generateDecodeResult(datatypeName: String): String = s"org.http4s.DecodeResult[$asyncType, $datatypeName]"
     override def messageClass: String = s"org.http4s.Message[$asyncType]"
     override def httpServiceClass: String = s"org.http4s.HttpService[$asyncType]"

--- a/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
@@ -64,6 +64,8 @@ class ScalaClientMethodGenerator (
         args.append("requestHeaders = (requestHeaders ++ headerParameters)")
       }
 
+      args.append("requestModifier = requestModifier")
+
       val reqType = op.body.fold("Unit")(b => b.datatype.name)
 
       val hasOptionResult = featureMigration.hasImplicit404s match {
@@ -169,11 +171,14 @@ class ScalaClientMethodGenerator (
         }.mkString("\n")
       } + hasOptionResult.getOrElse("") + s"\n$defaultResponse\n"
 
+      val extraArgs = Seq(s"requestModifier: ${config.requestBuilderClass} => ${config.requestBuilderClass} = identity")
+
       new ScalaClientMethod(
         operation = op,
         returnType = s"${config.asyncType}[$resType]",
         methodCall = methodCall,
         response = matchResponse,
+        extraArgs = extraArgs,
         implicitArgs = config.implicitArgs,
         typeParam = config.asyncTypeParam()
       )
@@ -221,9 +226,10 @@ class ScalaClientMethod(
   returnType: String,
   methodCall: String,
   response: String,
+  extraArgs: Seq[String],
   implicitArgs: Option[String],
   typeParam: Option[String]
-) extends scala.generator.ScalaClientMethod(operation, returnType, methodCall, response, implicitArgs) {
+) extends scala.generator.ScalaClientMethod(operation, returnType, methodCall, response, extraArgs, implicitArgs) {
   import lib.Text._
 
   override val interface: String = {

--- a/scala-generator/src/main/scala/models/http4s/server/Route.scala
+++ b/scala-generator/src/main/scala/models/http4s/server/Route.scala
@@ -64,7 +64,7 @@ case class Route(ssd: ScalaService, resource: ScalaResource, op: ScalaOperation,
     )
 
     val params =
-      Seq(Some(s"_req: ${config.requestClass}")) ++
+      Seq(Some(s"_req: ${config.requestBuilderClass}")) ++
       nonHeaderParameters ++
       Seq(op.body.map(body => s"body: => ${config.generateDecodeResult(body.datatype.name)}"))
 

--- a/scala-generator/src/main/scala/models/ning/NingClientGenerator.scala
+++ b/scala-generator/src/main/scala/models/ning/NingClientGenerator.scala
@@ -99,8 +99,8 @@ ${methodGenerator.objects().indent(4)}
       }
     }
 
-    def _requestBuilder(method: String, path: String, requestHeaders: Seq[(String, String)]): RequestBuilder = {
-      val builder = new RequestBuilder(method)
+    def _requestBuilder(method: String, path: String, requestHeaders: Seq[(String, String)]): ${config.requestBuilderClass} = {
+      val builder = new ${config.requestBuilderClass}(method)
         .setUrl(baseUrl + path)
 ${headerString.indent(8)}
 
@@ -125,7 +125,8 @@ ${config.realmBuilder("username", """passwordOpt.getOrElse("")""").indent(12)}
       path: String,
       queryParameters: Seq[(String, String)] = Nil,
       requestHeaders: Seq[(String, String)] = Nil,
-      body: Option[play.api.libs.json.JsValue] = None
+      body: Option[play.api.libs.json.JsValue] = None,
+      requestModifier: ${config.requestBuilderClass} => ${config.requestBuilderClass} = identity
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[${config.ningPackage}.Response] = {
       val allHeaders = body match {
         case None => requestHeaders
@@ -143,7 +144,7 @@ ${config.realmBuilder("username", """passwordOpt.getOrElse("")""").indent(12)}
         request.setBody(serialized)
       }
 
-      val finalRequest = requestWithParamsAndBody.build()
+      val finalRequest = requestModifier(requestWithParamsAndBody).build()
       _logRequest(finalRequest)
 
       val result = scala.concurrent.Promise[${config.ningPackage}.Response]()
@@ -177,7 +178,8 @@ ${PlayScalaClientCommon(config).indent(2)}
 ${methodGenerator.traitsAndErrors().indent(2)}
 
 ${PathSegment.definition.indent(2)}
-}"""
+}
+"""
   }
 
 }


### PR DESCRIPTION
Goal is to allow users to modify the request being issued.

Typical use case includes:

```scala
generatedClient.get(_.withRequestTimeout(2.seconds).withFollowRedirects(true))
```