### PR TITLE
Revert: Kotlin: retrofit does not like DELETE method with body, so we have to define it differently (#430)

### DIFF
--- a/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinGenerator.scala
+++ b/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinGenerator.scala
@@ -232,20 +232,7 @@ class KotlinGenerator
 
         maybeAnnotationClass.map(annotationClass => {
 
-          val deleteWithBody = annotationClass == classOf[retrofit2.http.DELETE] && operation.body.isDefined
-
-          val methodAnnotation =
-          //Retrofit does not like DELETE method with body, so we have to define it differently
-            if (deleteWithBody) {
-              AnnotationSpec.builder(classOf[retrofit2.http.HTTP])
-                .addMember("path=\"" + retrofitPath + "\"")
-                .addMember("method = \"DELETE\"")
-                .addMember("hasBody = true")
-                .build()
-            } else {
-              AnnotationSpec.builder(annotationClass).addMember("value=\"" + retrofitPath + "\"").build()
-            }
-
+          val methodAnnotation = AnnotationSpec.builder(annotationClass).addMember("value=\"" + retrofitPath + "\"").build()
           val methodName =
             if (operation.path == "/")
               toMethodName(operation.method.toString.toLowerCase)
@@ -257,10 +244,6 @@ class KotlinGenerator
           operation.description.map(description => {
             method.addKdoc(description)
           })
-
-          if (deleteWithBody) {
-            method.addKdoc(" Note: Retrofit does not like @DELETE with body, so it's defined as @HTTP instead")
-          }
 
           operation.deprecation.map(deprecation => {
             val deprecationAnnotation = AnnotationSpec.builder(classOf[Deprecated]).build


### PR DESCRIPTION
In retrospect, introducing support for DELETE with method body was a mistake.  

HTTP 1.1 spec for this is vague, and support, therefore is spotty.  

http4s supports it
retorfit(android) does not, but has a workaround
akamai does not seem to support it, we have not gotten an answer from them, but from our expirementation it look like they're swallowing the body 

I think in general apibuilder should not allow defining DELETE with body, I will open an issue for this.