### PR TITLE
 Fix broken handling of resource filenames for codegen tests

### DIFF
--- a/java-generator/src/test/scala/models/generator/JavaClassesSpec.scala
+++ b/java-generator/src/test/scala/models/generator/JavaClassesSpec.scala
@@ -237,7 +237,7 @@ class JavaClassesSpec extends FunSpec with Matchers with MockitoSugar {
       case Left(errors) => fail(errors.mkString(", "))
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 4
-        models.TestHelper.assertEqualsFile("/generators/java-built-in-types.txt", sourceFiles.map(_.contents).mkString("\n"))
+        models.TestHelper.assertEqualsFile("/generators/java-built-in-types", sourceFiles.map(_.contents).mkString("\n"))
       }
     }
   }

--- a/lib/src/test/resources/generators/scala-primitive-object-singleton.txt
+++ b/lib/src/test/resources/generators/scala-primitive-object-singleton.txt
@@ -1,7 +1,7 @@
 package test.apidoc.apidoctest.v0.models {
 
   final case class Content(
-    data: _root_.play.api.libs.json.JsObject
+    data: _root_.play.ap i.libs.json.JsObject
   )
 
 }

--- a/lib/src/test/resources/generators/scala-primitive-object-singleton.txt
+++ b/lib/src/test/resources/generators/scala-primitive-object-singleton.txt
@@ -1,7 +1,7 @@
 package test.apidoc.apidoctest.v0.models {
 
   final case class Content(
-    data: _root_.play.ap i.libs.json.JsObject
+    data: _root_.play.api.libs.json.JsObject
   )
 
 }

--- a/lib/src/test/scala/TestHelper.scala
+++ b/lib/src/test/scala/TestHelper.scala
@@ -106,16 +106,20 @@ object TestHelper extends Matchers {
     }
   }
 
-  def assertEqualsFile(filename: String, contents: String): Unit = {
-    val actualPath = resolvePath(filename)
+  def assertEqualsFile(filename: String, contents: String, extension: Option[String] = Some("txt")): Unit = {
+    val extensionString = extension.fold("")("." + _)
+
+    val fullFileName = filename + extensionString
+
+    val actualPath = resolvePath(fullFileName)
     val current = readFile(actualPath).trim
     if (current != contents.trim) {
       import sys.process._
 
-      val expectedPath = "/tmp/apidoc.tmp.expected." + Text.safeName(filename)
+      val expectedPath = "/tmp/apidoc.tmp.expected." + Text.safeName(filename) + extensionString
       TestHelper.writeToFile(expectedPath, contents.trim)
       // TestHelper.writeToFile(actualPath, contents.trim)
-      
+
       val cmd = s"diff $expectedPath $actualPath"
       println(cmd)
       cmd.!

--- a/lib/src/test/scala/TestHelper.scala
+++ b/lib/src/test/scala/TestHelper.scala
@@ -111,16 +111,16 @@ object TestHelper extends Matchers {
 
     val fullFileName = filename + extensionString
 
-    val actualPath = resolvePath(fullFileName)
-    val current = readFile(actualPath).trim
+    val expectedPath = resolvePath(fullFileName)
+    val current = readFile(expectedPath).trim
     if (current != contents.trim) {
       import sys.process._
 
-      val expectedPath = "/tmp/apidoc.tmp.expected." + Text.safeName(filename) + extensionString
-      TestHelper.writeToFile(expectedPath, contents.trim)
-      // TestHelper.writeToFile(actualPath, contents.trim)
+      val actualPath = "/tmp/apidoc.tmp.actual." + Text.safeName(filename) + extensionString
+      TestHelper.writeToFile(actualPath, contents.trim)
+      // TestHelper.writeToFile(expectedPath, contents.trim)
 
-      val cmd = s"diff $expectedPath $actualPath"
+      val cmd = s"diff $actualPath $expectedPath"
       println(cmd)
       cmd.!
       sys.error(s"Test output did not match. $cmd")

--- a/ruby-generator/src/test/scala/models/BuiltInTypesSpec.scala
+++ b/ruby-generator/src/test/scala/models/BuiltInTypesSpec.scala
@@ -12,7 +12,7 @@ class BuiltInTypesSpec extends FunSpec with Matchers {
       case Left(errors) => fail(errors.mkString(", "))
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 1
-        models.TestHelper.assertEqualsFile("/generators/ruby-built-in-types.txt", sourceFiles.head.contents)
+        models.TestHelper.assertEqualsFile("/generators/ruby-built-in-types", sourceFiles.head.contents)
       }
     }
   }

--- a/ruby-generator/src/test/scala/models/ExampleUnionTypesSpec.scala
+++ b/ruby-generator/src/test/scala/models/ExampleUnionTypesSpec.scala
@@ -12,7 +12,7 @@ class ExampleUnionTypesSpec extends FunSpec with Matchers {
       case Left(errors) => fail(errors.mkString(", "))
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 1
-        models.TestHelper.assertEqualsFile("/example-union-types-ruby-client.txt", sourceFiles.head.contents)
+        models.TestHelper.assertEqualsFile("/example-union-types-ruby-client", sourceFiles.head.contents)
       }
     }
   }

--- a/ruby-generator/src/test/scala/models/ResponsesWithUnitTypeSpec.scala
+++ b/ruby-generator/src/test/scala/models/ResponsesWithUnitTypeSpec.scala
@@ -12,7 +12,7 @@ class ResponsesWithUnitTypeSpec extends FunSpec with Matchers {
       case Left(errors) => fail(errors.mkString(", "))
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 1
-        models.TestHelper.assertEqualsFile("/example-response-with-unit-type.txt", sourceFiles.head.contents)
+        models.TestHelper.assertEqualsFile("/example-response-with-unit-type", sourceFiles.head.contents)
       }
     }
   }

--- a/ruby-generator/src/test/scala/models/RubyClientGeneratorSpec.scala
+++ b/ruby-generator/src/test/scala/models/RubyClientGeneratorSpec.scala
@@ -38,7 +38,7 @@ class RubyClientGeneratorSpec extends FunSpec with Matchers {
         )
       )
 
-      models.TestHelper.assertEqualsFile("/ruby-gem-enums.txt", RubyClientGenerator.generateEnum(enum, None))
+      models.TestHelper.assertEqualsFile("/ruby-gem-enums", RubyClientGenerator.generateEnum(enum, None))
     }
 
     it("for enum with spaces") {
@@ -53,7 +53,7 @@ class RubyClientGeneratorSpec extends FunSpec with Matchers {
       case Left(errors) => fail(errors.mkString(", "))
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 1
-        models.TestHelper.assertEqualsFile("/ruby-client-generator-gilt-0.0.1-test.txt", sourceFiles.head.contents)
+        models.TestHelper.assertEqualsFile("/ruby-client-generator-gilt-0.0.1-test", sourceFiles.head.contents)
       }
     }
   }

--- a/ruby-generator/src/test/scala/models/RubyClientPrimitiveObjectSpec.scala
+++ b/ruby-generator/src/test/scala/models/RubyClientPrimitiveObjectSpec.scala
@@ -57,17 +57,17 @@ class RubyClientPrimitiveObjectSpec extends FunSpec with Matchers {
 
       it("singleton") {
         val code = RubyClientGenerator(InvocationForm(service("object"))).generateModel(model("object"), None)
-        models.TestHelper.assertEqualsFile("/generators/ruby-client-primitive-object-singleton.txt", code)
+        models.TestHelper.assertEqualsFile("/generators/ruby-client-primitive-object-singleton", code)
       }
 
       it("list") {
         val code = RubyClientGenerator(InvocationForm(service("object"))).generateModel(model("[object]"), None)
-        models.TestHelper.assertEqualsFile("/generators/ruby-client-primitive-object-list.txt", code)
+        models.TestHelper.assertEqualsFile("/generators/ruby-client-primitive-object-list", code)
       }
 
       it("map") {
         val code = RubyClientGenerator(InvocationForm(service("object"))).generateModel(model("map[object]"), None)
-        models.TestHelper.assertEqualsFile("/generators/ruby-client-primitive-object-map.txt", code)
+        models.TestHelper.assertEqualsFile("/generators/ruby-client-primitive-object-map", code)
       }
 
     }
@@ -146,17 +146,17 @@ class RubyClientPrimitiveObjectSpec extends FunSpec with Matchers {
 
       it("singleton") {
         val code = RubyClientGenerator(InvocationForm(service("object"))).generateResponses(operation("object"), "r")
-        models.TestHelper.assertEqualsFile("/generators/ruby-client-primitive-object-response-singleton.txt", code)
+        models.TestHelper.assertEqualsFile("/generators/ruby-client-primitive-object-response-singleton", code)
       }
 
       it("list") {
         val code = RubyClientGenerator(InvocationForm(service("object"))).generateResponses(operation("[object]"), "r")
-        models.TestHelper.assertEqualsFile("/generators/ruby-client-primitive-object-response-list.txt", code)
+        models.TestHelper.assertEqualsFile("/generators/ruby-client-primitive-object-response-list", code)
       }
 
       it("map") {
         val code = RubyClientGenerator(InvocationForm(service("object"))).generateResponses(operation("map[object]"), "r")
-        models.TestHelper.assertEqualsFile("/generators/ruby-client-primitive-object-response-map.txt", code)
+        models.TestHelper.assertEqualsFile("/generators/ruby-client-primitive-object-response-map", code)
       }
 
     }

--- a/scala-generator/src/test/scala/models/ExampleUnionTypesSpec.scala
+++ b/scala-generator/src/test/scala/models/ExampleUnionTypesSpec.scala
@@ -13,7 +13,7 @@ class ExampleUnionTypesSpec extends FunSpec with Matchers {
       case Left(errors) => fail(errors.mkString(", "))
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 1
-        models.TestHelper.assertEqualsFile("/example-union-types-play-23.txt", sourceFiles.head.contents)
+        models.TestHelper.assertEqualsFile("/example-union-types-play-23", sourceFiles.head.contents)
       }
     }
   }
@@ -23,7 +23,7 @@ class ExampleUnionTypesSpec extends FunSpec with Matchers {
       case Left(errors) => fail(errors.mkString(", "))
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 1
-        models.TestHelper.assertEqualsFile("/example-union-types-ning-client.txt", sourceFiles.head.contents)
+        models.TestHelper.assertEqualsFile("/example-union-types-ning-client", sourceFiles.head.contents)
       }
     }
   }

--- a/scala-generator/src/test/scala/models/ExampleUnionTypesWithDiscriminatorSpec.scala
+++ b/scala-generator/src/test/scala/models/ExampleUnionTypesWithDiscriminatorSpec.scala
@@ -12,7 +12,7 @@ class ExampleUnionTypesWithDiscriminatorSpec extends FunSpec with Matchers {
       case Left(errors) => fail(errors.mkString(", "))
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 1
-        models.TestHelper.assertEqualsFile("/union-types-discriminator-service-play-24.txt", sourceFiles.head.contents)
+        models.TestHelper.assertEqualsFile("/union-types-discriminator-service-play-24", sourceFiles.head.contents)
       }
     }
   }

--- a/scala-generator/src/test/scala/models/Play2BindablesSpec.scala
+++ b/scala-generator/src/test/scala/models/Play2BindablesSpec.scala
@@ -11,14 +11,14 @@ class Play2BindablesSpec extends FunSpec with Matchers {
 
   it("generates bindable for a single enum") {
     models.TestHelper.assertEqualsFile(
-      "/generators/play-2-bindable-age-group.txt",
+      "/generators/play-2-bindable-age-group",
       Play2Bindables(ssd).buildImplicit("AgeGroup")
     )
   }
 
   it("generates bindable object") {
     models.TestHelper.assertEqualsFile(
-      "/generators/play-2-bindable-reference-api-object.txt",
+      "/generators/play-2-bindable-reference-api-object",
       Play2Bindables(ssd).build()
     )
   }

--- a/scala-generator/src/test/scala/models/Play2ClientGeneratorSpec.scala
+++ b/scala-generator/src/test/scala/models/Play2ClientGeneratorSpec.scala
@@ -23,7 +23,7 @@ class Play2ClientGeneratorSpec extends FunSpec with Matchers {
     errorResponse.datatype.name should be("Seq[io.apibuilder.generator.v0.models.Error]")
 
     val contents = new ScalaClientMethodGenerator(clientMethodConfig, ssd).errorPackage()
-    models.TestHelper.assertEqualsFile("/generators/play2-client-generator-spec-errors-package.txt", contents)
+    models.TestHelper.assertEqualsFile("/generators/play2-client-generator-spec-errors-package", contents)
   }
 
   it("only generates error wrappers for model classes (not primitives)") {
@@ -72,7 +72,7 @@ class Play2ClientGeneratorSpec extends FunSpec with Matchers {
 
     val ssd = ScalaService(models.TestHelper.service(json))
     val contents = new ScalaClientMethodGenerator(clientMethodConfig, ssd).errorPackage()
-    models.TestHelper.assertEqualsFile("/generators/play2-client-generator-spec-errors-package-no-models.txt", contents)
+    models.TestHelper.assertEqualsFile("/generators/play2-client-generator-spec-errors-package-no-models", contents)
   }
 
   describe("Play 2.2.x generator basic output") {
@@ -82,7 +82,7 @@ class Play2ClientGeneratorSpec extends FunSpec with Matchers {
         case Left(errors) => fail(errors.mkString(", "))
         case Right(sourceFiles) => {
           sourceFiles.size shouldBe 1
-          models.TestHelper.assertEqualsFile("/generators/play-22-built-in-types.txt", sourceFiles.head.contents)
+          models.TestHelper.assertEqualsFile("/generators/play-22-built-in-types", sourceFiles.head.contents)
         }
       }
     }
@@ -95,7 +95,7 @@ class Play2ClientGeneratorSpec extends FunSpec with Matchers {
         case Left(errors) => fail(errors.mkString(", "))
         case Right(sourceFiles) => {
           sourceFiles.size shouldBe 1
-          models.TestHelper.assertEqualsFile("/generators/play-23-built-in-types.txt", sourceFiles.head.contents)
+          models.TestHelper.assertEqualsFile("/generators/play-23-built-in-types", sourceFiles.head.contents)
         }
       }
     }
@@ -108,7 +108,7 @@ class Play2ClientGeneratorSpec extends FunSpec with Matchers {
         case Left(errors) => fail(errors.mkString(", "))
         case Right(sourceFiles) => {
           sourceFiles.size shouldBe 1
-          models.TestHelper.assertEqualsFile("/generators/play-24-built-in-types.txt", sourceFiles.head.contents)
+          models.TestHelper.assertEqualsFile("/generators/play-24-built-in-types", sourceFiles.head.contents)
         }
       }
     }
@@ -121,7 +121,7 @@ class Play2ClientGeneratorSpec extends FunSpec with Matchers {
         case Left(errors) => fail(errors.mkString(", "))
         case Right(sourceFiles) => {
           sourceFiles.size shouldBe 1
-          models.TestHelper.assertEqualsFile("/generators/play-25-built-in-types.txt", sourceFiles.head.contents)
+          models.TestHelper.assertEqualsFile("/generators/play-25-built-in-types", sourceFiles.head.contents)
         }
       }
     }
@@ -152,7 +152,7 @@ class Play2ClientGeneratorSpec extends FunSpec with Matchers {
         case Left(errors) => fail(errors.mkString(", "))
         case Right(sourceFiles) => {
           sourceFiles.size shouldBe 1
-          models.TestHelper.assertEqualsFile("/generators/play-26-built-in-types.txt", sourceFiles.head.contents)
+          models.TestHelper.assertEqualsFile("/generators/play-26-built-in-types", sourceFiles.head.contents)
         }
       }
     }
@@ -163,7 +163,7 @@ class Play2ClientGeneratorSpec extends FunSpec with Matchers {
     val json = models.TestHelper.readFile("lib/src/test/resources/generators/play-2-union-model-enum-service.json")
     val ssd = ScalaService(models.TestHelper.service(json))
     val contents = ScalaClientMethodGenerator(clientMethodConfig, ssd).errorPackage()
-    models.TestHelper.assertEqualsFile("/generators/play2-client-generator-spec-errors-package-no-models.txt", contents)
+    models.TestHelper.assertEqualsFile("/generators/play2-client-generator-spec-errors-package-no-models", contents)
   }
  */
 }

--- a/scala-generator/src/test/scala/models/Play2JsonSpec.scala
+++ b/scala-generator/src/test/scala/models/Play2JsonSpec.scala
@@ -33,7 +33,7 @@ class Play2JsonSpec extends FunSpec with Matchers {
       val ssd = ScalaService(models.TestHelper.service(json))
       val model = ssd.models.head
       models.TestHelper.assertEqualsFile(
-        "/play2-json-spec-model-readers.txt",
+        "/play2-json-spec-model-readers",
         Play2Json(ssd).fieldReaders(model)
       )
     }
@@ -178,14 +178,14 @@ class Play2JsonSpec extends FunSpec with Matchers {
 
       it("readers") {
         models.TestHelper.assertEqualsFile(
-          "/generators/play-2-json-spec-quality-plan-readers.txt",
+          "/generators/play-2-json-spec-quality-plan-readers",
           Play2Json(quality).readers(plan)
         )
       }
 
       it("writers") {
         models.TestHelper.assertEqualsFile(
-          "/generators/play-2-json-spec-quality-plan-writers.txt",
+          "/generators/play-2-json-spec-quality-plan-writers",
           Play2Json(quality).writers(plan)
         )
       }
@@ -197,14 +197,14 @@ class Play2JsonSpec extends FunSpec with Matchers {
 
       it("readers") {
         models.TestHelper.assertEqualsFile(
-          "/generators/play-2-json-spec-quality-healthcheck-readers.txt",
+          "/generators/play-2-json-spec-quality-healthcheck-readers",
           Play2Json(quality).readers(healthcheck)
         )
       }
 
       it("writers") {
         models.TestHelper.assertEqualsFile(
-          "/generators/play-2-json-spec-quality-healthcheck-writers.txt",
+          "/generators/play-2-json-spec-quality-healthcheck-writers",
           Play2Json(quality).writers(healthcheck)
         )
       }

--- a/scala-generator/src/test/scala/models/Play2RouteGeneratorSpec.scala
+++ b/scala-generator/src/test/scala/models/Play2RouteGeneratorSpec.scala
@@ -76,8 +76,9 @@ class Play2RouteGeneratorSpec extends FunSpec with Matchers {
           sourceFiles.size shouldBe 1
           models.TestHelper.assertEqualsFile(
             "/generators/play-2-route-reference-api.routes",
-            sourceFiles.head.contents
-         ) 
+            sourceFiles.head.contents,
+            extension = None
+         )
         }
       }
     }

--- a/scala-generator/src/test/scala/models/Play2StandaloneModelsJsonSpec.scala
+++ b/scala-generator/src/test/scala/models/Play2StandaloneModelsJsonSpec.scala
@@ -15,7 +15,7 @@ class Play2StandaloneModelsJsonSpec extends FunSpec with Matchers {
         val scalaSourceCode = files.head.contents
         models.TestHelper.assertValidScalaSourceCode(scalaSourceCode)
         models.TestHelper.assertEqualsFile(
-          "/generators/play-2-standalone-json-spec-quality.txt",
+          "/generators/play-2-standalone-json-spec-quality",
           scalaSourceCode
         )
       }

--- a/scala-generator/src/test/scala/models/ScalaGeneratorUtilSpec.scala
+++ b/scala-generator/src/test/scala/models/ScalaGeneratorUtilSpec.scala
@@ -73,7 +73,7 @@ val queryParameters = optionalMessages.getOrElse(Nil).map("optional_messages" ->
     val operation = ssd.resources.find(_.plural == "Users").get.operations.find(op => op.method == Method.Get && op.path == "/users").get
 
     models.TestHelper.assertEqualsFile(
-      "/generators/play-2-route-util-reference-get-users.txt",
+      "/generators/play-2-route-util-reference-get-users",
       play2Util.queryParameters("queryParameters", operation.queryParameters).get
     )
   }

--- a/scala-generator/src/test/scala/models/ScalaNestedUnionSpec.scala
+++ b/scala-generator/src/test/scala/models/ScalaNestedUnionSpec.scala
@@ -73,13 +73,13 @@ class ScalaNestedUnionSpec extends FunSpec with Matchers {
   it("generates valid inner type readers") {
     val innerType = ssd.unions.find(_.name == "InnerType").get
     val code = Play2Json(ssd).readers(innerType)
-    models.TestHelper.assertEqualsFile("/scala-nested-union-models-json-union-type-readers-inner-type.txt", code)
+    models.TestHelper.assertEqualsFile("/scala-nested-union-models-json-union-type-readers-inner-type", code)
   }
 
   it("generates valid outer type readers") {
     val outerType = ssd.unions.find(_.name == "OuterType").get
     val code = Play2Json(ssd).readers(outerType)
-    models.TestHelper.assertEqualsFile("/scala-nested-union-models-json-union-type-readers-outer-type.txt", code)
+    models.TestHelper.assertEqualsFile("/scala-nested-union-models-json-union-type-readers-outer-type", code)
   }
 
   it("generates valid nested union traits") {
@@ -87,7 +87,7 @@ class ScalaNestedUnionSpec extends FunSpec with Matchers {
       case Left(errors) => fail(errors.mkString(", "))
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 1
-        models.TestHelper.assertEqualsFile("/scala-nested-union-models-case-classes.txt", sourceFiles.head.contents)
+        models.TestHelper.assertEqualsFile("/scala-nested-union-models-case-classes", sourceFiles.head.contents)
       }
     }
   }

--- a/scala-generator/src/test/scala/models/ScalaUnionSpec.scala
+++ b/scala-generator/src/test/scala/models/ScalaUnionSpec.scala
@@ -64,7 +64,7 @@ class ScalaUnionSpec extends FunSpec with Matchers {
         case Left(errors) => fail(errors.mkString(", "))
         case Right(sourceFiles) => {
           sourceFiles.size shouldBe 1
-          models.TestHelper.assertEqualsFile("/scala-union-models-case-classes.txt", sourceFiles.head.contents)
+          models.TestHelper.assertEqualsFile("/scala-union-models-case-classes", sourceFiles.head.contents)
         }
       }
     }
@@ -72,18 +72,18 @@ class ScalaUnionSpec extends FunSpec with Matchers {
     it("generates valid readers for the union type itself") {
       val user = ssd.unions.find(_.name == "User").get
       val code = Play2Json(ssd).readers(user)
-      models.TestHelper.assertEqualsFile("/scala-union-models-json-union-type-readers.txt", code)
+      models.TestHelper.assertEqualsFile("/scala-union-models-json-union-type-readers", code)
     }
 
     it("generates valid writers for the union type itself") {
       val user = ssd.unions.find(_.name == "User").get
       val code = Play2Json(ssd).writers(user)
-      models.TestHelper.assertEqualsFile("/scala-union-models-json-union-type-writers.txt", code)
+      models.TestHelper.assertEqualsFile("/scala-union-models-json-union-type-writers", code)
     }
 
     it("codegen") {
       val code = Play2Json(ssd).generateModelsAndUnions()
-      models.TestHelper.assertEqualsFile("/scala-union-models-json.txt", code)
+      models.TestHelper.assertEqualsFile("/scala-union-models-json", code)
     }
   }
 
@@ -135,7 +135,7 @@ class ScalaUnionSpec extends FunSpec with Matchers {
 
     it("codegen") {
       val code = Play2Json(ssd).generateModelsAndUnions()
-      models.TestHelper.assertEqualsFile("/scala-union-enums-json.txt", code)
+      models.TestHelper.assertEqualsFile("/scala-union-enums-json", code)
     }
   }
 

--- a/scala-generator/src/test/scala/models/generator/CollectionJsonDefaultsSpec.scala
+++ b/scala-generator/src/test/scala/models/generator/CollectionJsonDefaultsSpec.scala
@@ -14,13 +14,13 @@ class CollectionJsonDefaultsSpec extends FunSpec with Matchers {
   it("user case classes") {
     val model = ssd.models.find(_.name == "User").get
     val code = ScalaCaseClasses.generateCaseClassWithDoc(model, Seq.empty)
-    models.TestHelper.assertEqualsFile("/generators/collection-json-defaults-user-case-class.txt", code)
+    models.TestHelper.assertEqualsFile("/generators/collection-json-defaults-user-case-class", code)
   }
 
   it("user_patch case classes") {
     val model = ssd.models.find(_.name == "UserPatch").get
     val code = ScalaCaseClasses.generateCaseClassWithDoc(model, Seq.empty)
-    models.TestHelper.assertEqualsFile("/generators/collection-json-defaults-user-patch-case-class.txt", code)
+    models.TestHelper.assertEqualsFile("/generators/collection-json-defaults-user-patch-case-class", code)
   }
 
   it("generates expected code for play 2.3 client") {
@@ -29,7 +29,7 @@ class CollectionJsonDefaultsSpec extends FunSpec with Matchers {
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 1
 
-        models.TestHelper.assertEqualsFile("/generators/collection-json-defaults-play-23.txt", sourceFiles.head.contents)
+        models.TestHelper.assertEqualsFile("/generators/collection-json-defaults-play-23", sourceFiles.head.contents)
       }
     }
   }
@@ -39,7 +39,7 @@ class CollectionJsonDefaultsSpec extends FunSpec with Matchers {
       case Left(errors) => fail(errors.mkString(", "))
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 1
-        models.TestHelper.assertEqualsFile("/generators/collection-json-defaults-ning-client.txt", sourceFiles.head.contents)
+        models.TestHelper.assertEqualsFile("/generators/collection-json-defaults-ning-client", sourceFiles.head.contents)
       }
     }
   }
@@ -49,7 +49,7 @@ class CollectionJsonDefaultsSpec extends FunSpec with Matchers {
       case Left(errors) => fail(errors.mkString(", "))
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 1
-        models.TestHelper.assertEqualsFile("/generators/collection-json-defaults-ahc-client.txt", sourceFiles.head.contents)
+        models.TestHelper.assertEqualsFile("/generators/collection-json-defaults-ahc-client", sourceFiles.head.contents)
       }
     }
   }

--- a/scala-generator/src/test/scala/models/generator/ReferenceSpec.scala
+++ b/scala-generator/src/test/scala/models/generator/ReferenceSpec.scala
@@ -13,13 +13,13 @@ class ReferenceSpec extends FunSpec with Matchers {
   it("user case classes") {
     val model = ssd.models.find(_.name == "User").get
     val code = ScalaCaseClasses.generateCaseClassWithDoc(model, Seq.empty)
-    models.TestHelper.assertEqualsFile("/generators/reference-spec-user-case-class.txt", code)
+    models.TestHelper.assertEqualsFile("/generators/reference-spec-user-case-class", code)
   }
 
   it("member case classes") {
     val model = ssd.models.find(_.name == "Member").get
     val code = ScalaCaseClasses.generateCaseClassWithDoc(model, Seq.empty)
-    models.TestHelper.assertEqualsFile("/generators/reference-spec-member-case-class.txt", code)
+    models.TestHelper.assertEqualsFile("/generators/reference-spec-member-case-class", code)
   }
 
   it("generates expected code for play 2.3 client") {
@@ -27,7 +27,7 @@ class ReferenceSpec extends FunSpec with Matchers {
       case Left(errors) => fail(errors.mkString(", "))
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 1
-        models.TestHelper.assertEqualsFile("/generators/reference-spec-play-23.txt", sourceFiles.head.contents)
+        models.TestHelper.assertEqualsFile("/generators/reference-spec-play-23", sourceFiles.head.contents)
       }
     }
   }
@@ -38,7 +38,7 @@ class ReferenceSpec extends FunSpec with Matchers {
       case Right(sourceFiles) => {
         sourceFiles.size shouldBe 1
         models.TestHelper.assertValidScalaSourceFiles(sourceFiles)
-        models.TestHelper.assertEqualsFile("/generators/reference-spec-ning-client.txt", sourceFiles.head.contents)
+        models.TestHelper.assertEqualsFile("/generators/reference-spec-ning-client", sourceFiles.head.contents)
       }
     }
   }

--- a/scala-generator/src/test/scala/models/generator/ReferenceWithImportsSpec.scala
+++ b/scala-generator/src/test/scala/models/generator/ReferenceWithImportsSpec.scala
@@ -14,13 +14,13 @@ class ReferenceWithImportsSpec extends FunSpec with Matchers {
   it("user case classes") {
     val model = ssd.models.find(_.name == "User").get
     val code = ScalaCaseClasses.generateCaseClassWithDoc(model, Seq.empty)
-    models.TestHelper.assertEqualsFile("/generators/reference-spec-user-case-class.txt", code)
+    models.TestHelper.assertEqualsFile("/generators/reference-spec-user-case-class", code)
   }
 
   it("member case classes") {
     val model = ssd.models.find(_.name == "Member").get
     val code = ScalaCaseClasses.generateCaseClassWithDoc(model, Seq.empty)
-    models.TestHelper.assertEqualsFile("/generators/reference-spec-member-case-class.txt", code)
+    models.TestHelper.assertEqualsFile("/generators/reference-spec-member-case-class", code)
   }
 
   it("generates expected code for play 2.3 client") {
@@ -30,7 +30,7 @@ class ReferenceWithImportsSpec extends FunSpec with Matchers {
         sourceFiles.size shouldBe 1
         val sourceCode = sourceFiles.head.contents
         TestHelper.assertValidScalaSourceCode(sourceCode)
-        TestHelper.assertEqualsFile("/generators/reference-with-imports-spec-play-23.txt", sourceCode)
+        TestHelper.assertEqualsFile("/generators/reference-with-imports-spec-play-23", sourceCode)
       }
     }
   }
@@ -42,7 +42,7 @@ class ReferenceWithImportsSpec extends FunSpec with Matchers {
         sourceFiles.size shouldBe 1
         val sourceCode = sourceFiles.head.contents
         TestHelper.assertValidScalaSourceCode(sourceCode)
-        TestHelper.assertEqualsFile("/generators/reference-with-imports-spec-ning-client.txt", sourceCode)
+        TestHelper.assertEqualsFile("/generators/reference-with-imports-spec-ning-client", sourceCode)
       }
     }
   }

--- a/scala-generator/src/test/scala/models/generator/ScalaAnnotationsSpec.scala
+++ b/scala-generator/src/test/scala/models/generator/ScalaAnnotationsSpec.scala
@@ -55,12 +55,12 @@ class ScalaAnnotationsSpec extends FunSpec with Matchers {
 
     it("generates valid models") {
       val enums = ssd.enums.map { ScalaEnums(ssd, _).build() }.mkString("\n\n")
-      models.TestHelper.assertEqualsFile("/play2enums-example.txt", enums)
+      models.TestHelper.assertEqualsFile("/play2enums-example", enums)
     }
 
     it("generates valid json conversions") {
       val jsonConversions = Play2Json(ssd).generateEnums()
-      models.TestHelper.assertEqualsFile("/play2enums-json-example.txt", jsonConversions)
+      models.TestHelper.assertEqualsFile("/play2enums-json-example", jsonConversions)
     }
   }
 

--- a/scala-generator/src/test/scala/models/generator/ScalaEnumsSpec.scala
+++ b/scala-generator/src/test/scala/models/generator/ScalaEnumsSpec.scala
@@ -53,12 +53,12 @@ class ScalaEnumsSpec extends FunSpec with Matchers {
 
     it("generates valid models") {
       val enums = ssd.enums.map { ScalaEnums(ssd, _).build() }.mkString("\n\n")
-      models.TestHelper.assertEqualsFile("/play2enums-example.txt", enums)
+      models.TestHelper.assertEqualsFile("/play2enums-example", enums)
     }
 
     it("generates valid json conversions") {
       val jsonConversions = Play2Json(ssd).generateEnums()
-      models.TestHelper.assertEqualsFile("/play2enums-json-example.txt", jsonConversions)
+      models.TestHelper.assertEqualsFile("/play2enums-json-example", jsonConversions)
     }
   }
 

--- a/scala-generator/src/test/scala/models/generator/ScalaPrimitiveObjectSpec.scala
+++ b/scala-generator/src/test/scala/models/generator/ScalaPrimitiveObjectSpec.scala
@@ -63,7 +63,7 @@ class ScalaPrimitiveObjectSpec extends FunSpec with Matchers {
           case Left(errors) => fail(errors.mkString(", "))
           case Right(sourceFiles) => {
             sourceFiles.size shouldBe 1
-            models.TestHelper.assertEqualsFile("/generators/scala-primitive-object-singleton.txt", sourceFiles.head.contents)
+            models.TestHelper.assertEqualsFile("/generators/scala-primitive-object-singleton", sourceFiles.head.contents)
           }
         }
       }
@@ -73,7 +73,7 @@ class ScalaPrimitiveObjectSpec extends FunSpec with Matchers {
           case Left(errors) => fail(errors.mkString(", "))
           case Right(sourceFiles) => {
             sourceFiles.size shouldBe 1
-            models.TestHelper.assertEqualsFile("/generators/scala-primitive-object-list.txt", sourceFiles.head.contents)
+            models.TestHelper.assertEqualsFile("/generators/scala-primitive-object-list", sourceFiles.head.contents)
           }
         }
       }
@@ -83,7 +83,7 @@ class ScalaPrimitiveObjectSpec extends FunSpec with Matchers {
           case Left(errors) => fail(errors.mkString(", "))
           case Right(sourceFiles) => {
             sourceFiles.size shouldBe 1
-            models.TestHelper.assertEqualsFile("/generators/scala-primitive-object-map.txt", sourceFiles.head.contents)
+            models.TestHelper.assertEqualsFile("/generators/scala-primitive-object-map", sourceFiles.head.contents)
           }
         }
       }
@@ -167,17 +167,17 @@ class ScalaPrimitiveObjectSpec extends FunSpec with Matchers {
 
       it("singleton") {
         val generator = new ScalaClientMethodGenerator(clientMethodConfig, ssd("object"))
-        models.TestHelper.assertEqualsFile("/generators/scala-primitive-object-response-singleton.txt", generator.objects)
+        models.TestHelper.assertEqualsFile("/generators/scala-primitive-object-response-singleton", generator.objects)
       }
 
       it("list") {
         val generator = new ScalaClientMethodGenerator(clientMethodConfig, ssd("[object]"))
-        models.TestHelper.assertEqualsFile("/generators/scala-primitive-object-response-list.txt", generator.objects)
+        models.TestHelper.assertEqualsFile("/generators/scala-primitive-object-response-list", generator.objects)
       }
 
       it("map") {
         val generator = new ScalaClientMethodGenerator(clientMethodConfig, ssd("map[object]"))
-        models.TestHelper.assertEqualsFile("/generators/scala-primitive-object-response-map.txt", generator.objects)
+        models.TestHelper.assertEqualsFile("/generators/scala-primitive-object-response-map", generator.objects)
       }
 
     }

--- a/scala-generator/src/test/scala/models/generator/anorm/ParserGenerator24Spec.scala
+++ b/scala-generator/src/test/scala/models/generator/anorm/ParserGenerator24Spec.scala
@@ -98,8 +98,8 @@ class ParserGenerator24Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/reference-conversions-24.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/reference.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/reference-conversions-24", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/reference", files.last.contents)
       }
     }
   }
@@ -112,8 +112,8 @@ class ParserGenerator24Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/name-conversions-24.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/name.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/name-conversions-24", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/name", files.last.contents)
       }
     }
   }
@@ -138,8 +138,8 @@ class ParserGenerator24Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/user-conversions-24.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/user.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/user-conversions-24", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/user", files.last.contents)
       }
     }
   }
@@ -173,8 +173,8 @@ class ParserGenerator24Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/enum-conversions-24.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/enum.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/enum-conversions-24", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/enum", files.last.contents)
       }
     }
   }
@@ -198,8 +198,8 @@ class ParserGenerator24Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/list-conversions-24.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/list.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/list-conversions-24", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/list", files.last.contents)
       }
     }
   }
@@ -241,8 +241,8 @@ class ParserGenerator24Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/union-conversions-24.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/union-parsers.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/union-conversions-24", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/union-parsers", files.last.contents)
       }
     }
   }
@@ -265,8 +265,8 @@ class ParserGenerator24Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/location-conversions-24.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/location-parsers.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/location-conversions-24", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/location-parsers", files.last.contents)
       }
     }
   }

--- a/scala-generator/src/test/scala/models/generator/anorm/ParserGenerator26Spec.scala
+++ b/scala-generator/src/test/scala/models/generator/anorm/ParserGenerator26Spec.scala
@@ -112,8 +112,8 @@ class ParserGenerator26Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/reference-conversions-26.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/reference.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/reference-conversions-26", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/reference", files.last.contents)
       }
     }
   }
@@ -126,8 +126,8 @@ class ParserGenerator26Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/name-conversions-26.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/name.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/name-conversions-26", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/name", files.last.contents)
       }
     }
   }
@@ -140,8 +140,8 @@ class ParserGenerator26Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/cap-name-conversions-26.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/cap-name.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/cap-name-conversions-26", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/cap-name", files.last.contents)
       }
     }
   }
@@ -166,8 +166,8 @@ class ParserGenerator26Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/user-conversions-26.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/user.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/user-conversions-26", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/user", files.last.contents)
       }
     }
   }
@@ -201,8 +201,8 @@ class ParserGenerator26Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/enum-conversions-26.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/enum.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/enum-conversions-26", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/enum", files.last.contents)
       }
     }
   }
@@ -226,8 +226,8 @@ class ParserGenerator26Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/list-conversions-26.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/list.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/list-conversions-26", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/list", files.last.contents)
       }
     }
   }
@@ -269,8 +269,8 @@ class ParserGenerator26Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/union-conversions-26.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/union-parsers.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/union-conversions-26", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/union-parsers", files.last.contents)
       }
     }
   }
@@ -293,8 +293,8 @@ class ParserGenerator26Spec extends FunSpec with Matchers {
       }
       case Right(files) => {
         files.map(_.name) should be(fileNames)
-        models.TestHelper.assertEqualsFile("/generator/anorm/location-conversions-26.txt", files.head.contents)
-        models.TestHelper.assertEqualsFile("/generator/anorm/location-parsers.txt", files.last.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/location-conversions-26", files.head.contents)
+        models.TestHelper.assertEqualsFile("/generator/anorm/location-parsers", files.last.contents)
       }
     }
   }

--- a/scala-generator/src/test/scala/models/http4s/Http4sServerGeneratorSpec.scala
+++ b/scala-generator/src/test/scala/models/http4s/Http4sServerGeneratorSpec.scala
@@ -16,7 +16,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s015(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/path-params-015.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/path-params-015", scalaSourceCode)
     }
 
     it("http4s 0.17 server") {
@@ -26,7 +26,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s017(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/path-params-017.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/path-params-017", scalaSourceCode)
     }
 
     it("http4s 0.18 server") {
@@ -36,7 +36,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s018(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/path-params-018.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/path-params-018", scalaSourceCode)
     }
   }
 
@@ -48,7 +48,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s017(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/query-params-017.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/query-params-017", scalaSourceCode)
     }
 
     it("http4s 0.18 server") {
@@ -58,7 +58,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s018(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/query-params-018.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/query-params-018", scalaSourceCode)
     }
   }
 
@@ -70,7 +70,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s017(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/form-params-017.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/form-params-017", scalaSourceCode)
     }
 
     it("http4s 0.18 server") {
@@ -80,7 +80,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s018(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/form-params-018.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/form-params-018", scalaSourceCode)
     }
   }
 
@@ -92,7 +92,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s017(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/response-types-017.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/response-types-017", scalaSourceCode)
     }
 
     it("http4s 0.18 server") {
@@ -102,7 +102,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s018(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/response-types-018.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/response-types-018", scalaSourceCode)
     }
   }
 
@@ -114,7 +114,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s017(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/imported-types-017.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/imported-types-017", scalaSourceCode)
     }
 
     it("http4s 0.18 server") {
@@ -124,7 +124,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s018(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/imported-types-018.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/imported-types-018", scalaSourceCode)
     }
   }
 
@@ -136,7 +136,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s017(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/status-codes-017.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/status-codes-017", scalaSourceCode)
     }
 
     it("http4s 0.18 server") {
@@ -146,7 +146,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s018(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/status-codes-018.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/status-codes-018", scalaSourceCode)
     }
   }
 
@@ -158,7 +158,7 @@ class Http4sServerGeneratorSpec extends FunSpec with Matchers {
         new ScalaClientMethodConfigs.Http4s018(namespace = "whatever", baseUrl = None))
       val scalaSourceCode = server.generate()
       assertValidScalaSourceCode(scalaSourceCode)
-      models.TestHelper.assertEqualsFile("/http4s/kebab-and-snake-case-018.txt", scalaSourceCode)
+      models.TestHelper.assertEqualsFile("/http4s/kebab-and-snake-case-018", scalaSourceCode)
     }
   }
 }


### PR DESCRIPTION
Expected:
`diff /tmp/apidoc.tmp.expected.union-types-discriminator-service-play-24.txt ./lib/src/test/resources/union-types-discriminator-service-play-24.txt`

Actual:

`diff /tmp/apidoc.tmp.expected.union-types-discriminator-service-play-24txt ./lib/src/test/resources/union-types-discriminator-service-play-24.txt`

This PR solves this issue in the easiest way, moving the extension to another argument of the `assertEqualsFile` function, `Some("txt")` by default.

I grepped and removed all `.txt`s from Scala sources, which should only include the relevant file names, then specified `None` as the extension for the one case where the file is a Play `routes`.

Please let me know if it's better to just rename the file to end with `.txt`.

Also, it looks to me that the names actual/expected are wrong in these (and in the variables - I added a second commit renaming to `...tmp.actual.union-...`. and correcting the names of the variables.