### PR TITLE
Generate value classes for single-field wrappers over primitives/containers

### DIFF
--- a/lib/src/main/scala/generator/GeneratorUtil.scala
+++ b/lib/src/main/scala/generator/GeneratorUtil.scala
@@ -99,7 +99,7 @@ object GeneratorUtil {
 
   /**
    * Turns a URL path to a camelcased method name.
-   * 
+   *
    * @param resourcePath The path to the resource itself, if known
    * @param resourceOperationPaths The full set of paths to all operations. This is
    *        used to compute a resource path (longest common string) if resource path
@@ -152,15 +152,6 @@ object GeneratorUtil {
     } else {
       method.toString.toLowerCase + notNamed.mkString("And") + "By" + named.mkString("And")
     }
-  }
-
-  /**
-    * Creates a canonical form for the specified name. Eg
-    * MembershipRequest and membership-request both end up as
-    * membership_request
-    */
-  private def formatName(name: String): String = {
-    Text.splitIntoWords(Text.camelCaseToUnderscore(name)).mkString("_")
   }
 
   /**

--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -19,7 +19,7 @@ package io.apibuilder.example.union.types.v0.models {
 
     case object RegisteredUser extends UserDiscriminator { override def toString = "registered_user" }
     case object GuestUser extends UserDiscriminator { override def toString = "guest_user" }
-    @deprecated 
+    @deprecated
     case object Uuid extends UserDiscriminator { override def toString = "uuid" }
 
     final case class UNDEFINED(override val toString: String) extends UserDiscriminator
@@ -55,7 +55,7 @@ package io.apibuilder.example.union.types.v0.models {
    * Provides future compatibility in clients - in the future, when a type is added
    * to the union Foobar, it will need to be handled in the client code. This
    * implementation will deserialize these future types as an instance of this class.
-   * 
+   *
    * @param description Information about the type that we received that is undefined in this version of
    *        the client.
    */
@@ -67,7 +67,7 @@ package io.apibuilder.example.union.types.v0.models {
    * Provides future compatibility in clients - in the future, when a type is added
    * to the union User, it will need to be handled in the client code. This
    * implementation will deserialize these future types as an instance of this class.
-   * 
+   *
    * @param description Information about the type that we received that is undefined in this version of
    *        the client.
    */

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -19,7 +19,7 @@ package io.apibuilder.example.union.types.v0.models {
 
     case object RegisteredUser extends UserDiscriminator { override def toString = "registered_user" }
     case object GuestUser extends UserDiscriminator { override def toString = "guest_user" }
-    @deprecated 
+    @deprecated
     case object Uuid extends UserDiscriminator { override def toString = "uuid" }
 
     final case class UNDEFINED(override val toString: String) extends UserDiscriminator
@@ -55,7 +55,7 @@ package io.apibuilder.example.union.types.v0.models {
    * Provides future compatibility in clients - in the future, when a type is added
    * to the union Foobar, it will need to be handled in the client code. This
    * implementation will deserialize these future types as an instance of this class.
-   * 
+   *
    * @param description Information about the type that we received that is undefined in this version of
    *        the client.
    */
@@ -67,7 +67,7 @@ package io.apibuilder.example.union.types.v0.models {
    * Provides future compatibility in clients - in the future, when a type is added
    * to the union User, it will need to be handled in the client code. This
    * implementation will deserialize these future types as an instance of this class.
-   * 
+   *
    * @param description Information about the type that we received that is undefined in this version of
    *        the client.
    */

--- a/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
+++ b/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
@@ -9,12 +9,12 @@ package com.gilt.quality.v0.models {
    */
   final case class AdjournForm(
     adjournedAt: _root_.scala.Option[_root_.org.joda.time.DateTime] = None
-  )
+  ) extends AnyVal
 
   /**
    * Describe an agenda item for a meeting. Currently the only agenda items we have
    * are that a particular incident needs to be reviewed.
-   * 
+   *
    * @param id Internal unique identifier for this record.
    * @param meeting The meeting to which this agenda item belongs
    * @param incident Summary of the incident to review.
@@ -35,7 +35,7 @@ package com.gilt.quality.v0.models {
 
   final case class AuthenticationForm(
     email: String
-  )
+  ) extends AnyVal
 
   final case class EmailMessage(
     subject: String,
@@ -74,7 +74,7 @@ package com.gilt.quality.v0.models {
    * Every n days (e.g. 30) we follow up to see if a given plan has been implemented.
    * This gives teams the ability to say: Yes, completed. Not yet. or No, won't do.
    * After 3 consecutive no replies, we assume not doing.
-   * 
+   *
    * @param key Unique token identifying this response
    */
   final case class Followup(
@@ -97,11 +97,11 @@ package com.gilt.quality.v0.models {
 
   final case class Healthcheck(
     @deprecated("please use audience.label instead") status: String
-  )
+  ) extends AnyVal
 
   /**
    * URLs to key icons used through the application
-   * 
+   *
    * @param smileyUrl URL for the smiley icon
    * @param frownyUrl URL for the frowny icon
    */
@@ -112,7 +112,7 @@ package com.gilt.quality.v0.models {
 
   /**
    * A bug or error that affected public or internal users in a negative way
-   * 
+   *
    * @param id Internal unique identifier for this incident.
    * @param organization Organization to which this incident belongs
    * @param summary Summary of the incident.
@@ -166,7 +166,7 @@ package com.gilt.quality.v0.models {
    * Incidents can then be reviewed from the context of a meeting, facilitating
    * online navigation. Incidents within a meeting can require one of two actions -
    * team assignment or plan review.
-   * 
+   *
    * @param id Internal unique identifier for this meeting.
    * @param organization Organization to which this meeting belongs
    * @param scheduledAt The date and time for which this meeting is scheduled.
@@ -183,7 +183,7 @@ package com.gilt.quality.v0.models {
 
   final case class MeetingForm(
     scheduledAt: _root_.org.joda.time.DateTime
-  )
+  ) extends AnyVal
 
   /**
    * Used to enable pagination when walking through the issues in a particular
@@ -199,7 +199,7 @@ package com.gilt.quality.v0.models {
   /**
    * Top level organization for which we are managing quality. Key entities like
    * teams and meetings are scoped to the organization.
-   * 
+   *
    * @param key Used as a unique key for this organization that is URL safe.
    * @param name The name of this organization.
    */
@@ -218,7 +218,7 @@ package com.gilt.quality.v0.models {
 
   /**
    * Details for how an incident will be resolved
-   * 
+   *
    * @param id Internal unique identifier for this incident.
    * @param body Full description of the incident
    * @param grade Grade given to this plan on a scale of 0 (bad) to 100 (good)
@@ -238,7 +238,7 @@ package com.gilt.quality.v0.models {
 
   /**
    * Statistics on each team's quality metrics, number of issues
-   * 
+   *
    * @param team Team for statistics.
    * @param totalGrades Number of graded plans given time span requested.
    * @param averageGrade Average grade for graded plans given time span requested.
@@ -259,7 +259,7 @@ package com.gilt.quality.v0.models {
 
   /**
    * Represents a user that is currently subscribed to a publication
-   * 
+   *
    * @param id Internal unique identifier for this subscription record
    */
   final case class Subscription(
@@ -278,7 +278,7 @@ package com.gilt.quality.v0.models {
   /**
    * A team is the main actor in the system. Teams have a unique key and own
    * incidents
-   * 
+   *
    * @param organization Organization to which this team belongs
    * @param key Unique identifier for this team
    * @param email Email address for members of this team. If provided, used to send updates on new
@@ -324,7 +324,7 @@ package com.gilt.quality.v0.models {
 
   /**
    * A user is a top level person.
-   * 
+   *
    * @param guid Internal unique identifier for this user.
    */
   final case class User(
@@ -334,7 +334,7 @@ package com.gilt.quality.v0.models {
 
   final case class UserForm(
     email: String
-  )
+  ) extends AnyVal
 
   /**
    * An external service with which an organization can integrate.

--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -37,7 +37,7 @@ package io.apibuilder.reference.api.v0.models {
 
   final case class Echo(
     value: String
-  )
+  ) extends AnyVal
 
   /**
    * Models an API error.
@@ -52,7 +52,7 @@ package io.apibuilder.reference.api.v0.models {
    */
   final case class Group(
     members: Seq[io.apibuilder.reference.api.v0.models.User]
-  )
+  ) extends AnyVal
 
   final case class Member(
     guid: _root_.java.util.UUID,
@@ -76,7 +76,7 @@ package io.apibuilder.reference.api.v0.models {
 
   final case class UserList(
     users: Seq[io.apibuilder.reference.api.v0.models.User]
-  )
+  ) extends AnyVal
 
   sealed trait AgeGroup extends _root_.scala.Product with _root_.scala.Serializable
 

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -37,7 +37,7 @@ package io.apibuilder.reference.api.v0.models {
 
   final case class Echo(
     value: String
-  )
+  ) extends AnyVal
 
   /**
    * Models an API error.
@@ -52,7 +52,7 @@ package io.apibuilder.reference.api.v0.models {
    */
   final case class Group(
     members: Seq[io.apibuilder.reference.api.v0.models.User]
-  )
+  ) extends AnyVal
 
   final case class Member(
     guid: _root_.java.util.UUID,
@@ -76,7 +76,7 @@ package io.apibuilder.reference.api.v0.models {
 
   final case class UserList(
     users: Seq[io.apibuilder.reference.api.v0.models.User]
-  )
+  ) extends AnyVal
 
   sealed trait AgeGroup extends _root_.scala.Product with _root_.scala.Serializable
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -37,7 +37,7 @@ package io.apibuilder.reference.api.v0.models {
 
   final case class Echo(
     value: String
-  )
+  ) extends AnyVal
 
   /**
    * Models an API error.
@@ -52,7 +52,7 @@ package io.apibuilder.reference.api.v0.models {
    */
   final case class Group(
     members: Seq[io.apibuilder.reference.api.v0.models.User]
-  )
+  ) extends AnyVal
 
   final case class Member(
     guid: _root_.java.util.UUID,
@@ -76,7 +76,7 @@ package io.apibuilder.reference.api.v0.models {
 
   final case class UserList(
     users: Seq[io.apibuilder.reference.api.v0.models.User]
-  )
+  ) extends AnyVal
 
   sealed trait AgeGroup extends _root_.scala.Product with _root_.scala.Serializable
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -37,7 +37,7 @@ package io.apibuilder.reference.api.v0.models {
 
   final case class Echo(
     value: String
-  )
+  ) extends AnyVal
 
   /**
    * Models an API error.
@@ -52,7 +52,7 @@ package io.apibuilder.reference.api.v0.models {
    */
   final case class Group(
     members: Seq[io.apibuilder.reference.api.v0.models.User]
-  )
+  ) extends AnyVal
 
   final case class Member(
     guid: _root_.java.util.UUID,
@@ -76,7 +76,7 @@ package io.apibuilder.reference.api.v0.models {
 
   final case class UserList(
     users: Seq[io.apibuilder.reference.api.v0.models.User]
-  )
+  ) extends AnyVal
 
   sealed trait AgeGroup extends _root_.scala.Product with _root_.scala.Serializable
 

--- a/lib/src/test/resources/generators/scala-primitive-object-list.txt
+++ b/lib/src/test/resources/generators/scala-primitive-object-list.txt
@@ -2,6 +2,6 @@ package test.apidoc.apidoctest.v0.models {
 
   final case class Content(
     data: Seq[_root_.play.api.libs.json.JsObject]
-  )
+  ) extends AnyVal
 
 }

--- a/lib/src/test/resources/generators/scala-primitive-object-map.txt
+++ b/lib/src/test/resources/generators/scala-primitive-object-map.txt
@@ -2,6 +2,6 @@ package test.apidoc.apidoctest.v0.models {
 
   final case class Content(
     data: Map[String, _root_.play.api.libs.json.JsObject]
-  )
+  ) extends AnyVal
 
 }

--- a/lib/src/test/resources/generators/scala-primitive-object-singleton.txt
+++ b/lib/src/test/resources/generators/scala-primitive-object-singleton.txt
@@ -2,6 +2,6 @@ package test.apidoc.apidoctest.v0.models {
 
   final case class Content(
     data: _root_.play.api.libs.json.JsObject
-  )
+  ) extends AnyVal
 
 }

--- a/lib/src/test/resources/scala-nested-union-models-case-classes.txt
+++ b/lib/src/test/resources/scala-nested-union-models-case-classes.txt
@@ -14,7 +14,7 @@ package test.apidoc.apidoctest.v0.models {
    * Provides future compatibility in clients - in the future, when a type is added
    * to the union InnerType, it will need to be handled in the client code. This
    * implementation will deserialize these future types as an instance of this class.
-   * 
+   *
    * @param description Information about the type that we received that is undefined in this version of
    *        the client.
    */
@@ -26,7 +26,7 @@ package test.apidoc.apidoctest.v0.models {
    * Provides future compatibility in clients - in the future, when a type is added
    * to the union OuterType, it will need to be handled in the client code. This
    * implementation will deserialize these future types as an instance of this class.
-   * 
+   *
    * @param description Information about the type that we received that is undefined in this version of
    *        the client.
    */
@@ -39,7 +39,7 @@ package test.apidoc.apidoctest.v0.models {
    * to the union SecondOuterType, it will need to be handled in the client code.
    * This implementation will deserialize these future types as an instance of this
    * class.
-   * 
+   *
    * @param description Information about the type that we received that is undefined in this version of
    *        the client.
    */

--- a/lib/src/test/resources/scala-union-models-case-classes.txt
+++ b/lib/src/test/resources/scala-union-models-case-classes.txt
@@ -20,7 +20,7 @@ package test.apidoc.apidoctest.v0.models {
    * Provides future compatibility in clients - in the future, when a type is added
    * to the union User, it will need to be handled in the client code. This
    * implementation will deserialize these future types as an instance of this class.
-   * 
+   *
    * @param description Information about the type that we received that is undefined in this version of
    *        the client.
    */

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -47,7 +47,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
    * Provides future compatibility in clients - in the future, when a type is added
    * to the union User, it will need to be handled in the client code. This
    * implementation will deserialize these future types as an instance of this class.
-   * 
+   *
    * @param description Information about the type that we received that is undefined in this version of
    *        the client.
    */

--- a/scala-generator/src/main/scala/models/Play2Models.scala
+++ b/scala-generator/src/main/scala/models/Play2Models.scala
@@ -24,7 +24,6 @@ trait Play2Models extends CodeGenerator {
     val ssd = ScalaService(form.service)
 
     val caseClasses = ScalaCaseClasses.generateCode(ssd, form.userAgent, addHeader = false).map(_.contents).mkString("\n\n")
-    val prefix = underscoreAndDashToInitCap(ssd.name)
     val play2json = Play2Json(ssd)
     val enumJson: String = play2json.generateEnums()
     val modelAndUnionJson: String = play2json.generateModelsAndUnions()

--- a/scala-generator/src/main/scala/models/generator/ScalaCaseClasses.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaCaseClasses.scala
@@ -98,9 +98,15 @@ trait ScalaCaseClasses extends CodeGenerator {
   }
 
   def generateCaseClass(model: ScalaModel, unions: Seq[ScalaUnion]): String = {
+    val extendsAnyval = if(model.isValueClass) Some(" extends AnyVal") else None
+
+    val extendsClause = ScalaUtil.extendsClause(unions.map(_.name))
+      .orElse(extendsAnyval)
+      .getOrElse("")
+
     Seq(
       Some(ScalaUtil.deprecationString(model.deprecation).trim).filter(_.nonEmpty),
-      Some(s"final case class ${model.name}(${model.argList.getOrElse("")})" + ScalaUtil.extendsClause(unions.map(_.name)).getOrElse(""))
+      Some(s"final case class ${model.name}(${model.argList.getOrElse("")})" + extendsClause)
     ).flatten.mkString("\n")
   }
 

--- a/scala-generator/src/main/scala/models/generator/ScalaDatatype.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaDatatype.scala
@@ -356,7 +356,7 @@ object ScalaDatatype {
     override def definition(
       originalVarName: String,
       default: scala.Option[String],
-      deprecation: scala.Option[Deprecation],
+      deprecation: scala.Option[Deprecation]
     ): String = {
       super.definition(
         originalVarName,

--- a/scala-generator/src/main/scala/models/generator/ScalaDatatype.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaDatatype.scala
@@ -359,9 +359,9 @@ object ScalaDatatype {
       deprecation: scala.Option[Deprecation]
     ): String = {
       super.definition(
-        originalVarName,
-        default.orElse(Some("None")),
-        deprecation
+        originalVarName = originalVarName,
+        default = default.orElse(Some("None")),
+        deprecation = deprecation
       )
     }
 

--- a/scala-generator/src/main/scala/models/generator/ScalaDatatype.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaDatatype.scala
@@ -26,9 +26,13 @@ sealed trait ScalaDatatype {
     deprecation: Option[Deprecation]
   ): String = {
     val varName = ScalaUtil.quoteNameIfKeyword(originalVarName)
-    default.fold(s"${deprecationString(deprecation)}$varName: $name") { default =>
-      s"$varName: $name = $default"
-    }
+
+    val defaultString = default.map(" = " + _).getOrElse("")
+    val depString = deprecationString(deprecation)
+
+    val baseString = s"$varName: $name"
+
+    depString + baseString + defaultString
   }
 
   def default(value: String): String = {
@@ -352,12 +356,13 @@ object ScalaDatatype {
     override def definition(
       originalVarName: String,
       default: scala.Option[String],
-      deprecation: scala.Option[Deprecation]
+      deprecation: scala.Option[Deprecation],
     ): String = {
-      val varName = ScalaUtil.quoteNameIfKeyword(originalVarName)
-      default.fold(s"${deprecationString(deprecation)}$varName: $name = None") { default =>
-        s"${deprecationString(deprecation)}$varName: $name = $default"
-      }
+      super.definition(
+        originalVarName,
+        default.orElse(Some("None")),
+        deprecation
+      )
     }
 
     // override, since options contain at most one element

--- a/scala-generator/src/main/scala/models/generator/ScalaUnionDiscriminator.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaUnionDiscriminator.scala
@@ -38,7 +38,7 @@ case class ScalaUnionDiscriminator(
       union.types.map { typ =>
         Seq(
           typ.description.map { desc => ScalaUtil.textToComment(desc) },
-          ScalaUtil.deprecationString(typ.deprecation) match {
+          ScalaUtil.deprecationString(typ.deprecation).trim match {
             case "" => None
             case v => Some(v)
           },

--- a/scala-generator/src/main/scala/models/generator/ScalaUtil.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaUtil.scala
@@ -28,7 +28,12 @@ object ScalaUtil {
   }
 
   def textToComment(text: Seq[String]): String = {
-    "/**\n * " + text.mkString("\n * ") + "\n */"
+    val commentText = text.zipWithIndex.map {
+      case ("", _)   => s" *"
+      case (line, _) => s" * $line"
+    }.mkString("\n")
+
+    "/**\n" + commentText + "\n */"
   }
 
   def textToComment(text: String): String = {


### PR DESCRIPTION
For now, only for primitives and containers.

To allow user-created datatypes we'd need to make sure we don't wrap over something that's already a value class, and we can't make sure if a type comes from another spec.

But I doubt it's a common usecase anyway (wrapping a model from another spec in a single-field model), so for now all "custom" types are excluded from being wrapped in a VC.

Other changes: 

- I also updated the Scaladoc generation to not add trailing spaces... it's really annoying if you have automatic removal of trailing spaces on in your IDE ;)
- Same for trailing spaces after `@deprecated` before discriminator object definition.
- Also made sure to add `@deprecated` even if a type has defaults set - if there was a reason to keep it that way, I'll revert.
- At last, some minor cleanup (removing braces from a pure function, etc.)