### PR TITLE
Kotlin: changed parameterized return type to Single<Response<ReturnType>>

### DIFF
--- a/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinGenerator.scala
+++ b/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinGenerator.scala
@@ -97,7 +97,9 @@ class KotlinGenerator
       makeFile(enumsNameSpace, className, builder)
     }
 
-    def getRetrofitReturnTypeWrapperClass(): ClassName = classToClassName(classOf[Single[Void]])
+    def getRetrofitSingleTypeWrapperClass(): ClassName = classToClassName(classOf[Single[Void]])
+
+    def getRetrofitResponseTypeWrapperClass(): ClassName = classToClassName(classOf[retrofit2.Response[Void]])
 
     def generateUnionType(union: Union, service: Service): File = {
       val className = toClassName(union.name)
@@ -335,8 +337,12 @@ class KotlinGenerator
 
           maybeSuccessfulResponse.map(successfulResponse => {
             val returnType = dataTypeFromField(successfulResponse.`type`, nameSpace, service)
-            val retrofitWrappedClassname = getRetrofitReturnTypeWrapperClass()
-            method.returns(ParameterizedTypeName.get(retrofitWrappedClassname, returnType))
+            method.returns(
+              ParameterizedTypeName.get(
+                getRetrofitSingleTypeWrapperClass(),
+                ParameterizedTypeName.get(
+                  getRetrofitResponseTypeWrapperClass,
+                  returnType)))
           })
 
           builder.addFunction(method.build)
@@ -447,17 +453,24 @@ class KotlinGenerator
                 combinedFunction.addParameter(param)
               }
             )
-            combinedFunction.addStatement("return %T(client." + methodName + "(" + parametersCache.map({
+            combinedFunction.addStatement("return %T(\n" +
+              "   client." + methodName + "(" + parametersCache.map({
               _.getName
-            }).mkString(",") + "), toError)", apiNetworkCallResponseTypeClassName)
+              }).mkString(",") + ")\n"
+              + "     .map{ response -> \n"
+              + "         if(response.isSuccessful)\n"
+              + "           response.body()?.let { body -> Pair(body, response.code())}\n"
+              + "         else\n"
+              + "           throw HttpException(response)}\n"
+              + "     .map{it}\n"
+              + ", toError)", apiNetworkCallResponseTypeClassName)
+
 
 
             callObjectBuilder.addFunction(combinedFunction.build())
             callObjectBuilder.addType(callErrorResopnseSealedClassBuilder.build())
             builder.addType(callObjectBuilder.build())
           }
-
-
         })
       }
 
@@ -672,23 +685,31 @@ class KotlinGenerator
 
       val throwableTypeName = getThrowableClassName().asInstanceOf[TypeName]
 
-      val singleParameterizedByN = ParameterizedTypeName.get(classToClassName(classOf[Single[Void]]), n)
+      val singleParameterized =
+        ParameterizedTypeName.get(
+          getRetrofitSingleTypeWrapperClass,
+          ParameterizedTypeName.get(
+            getKotlinPairClassName(),
+            n,
+            getKotlinIntClassName())
+        )
+
       val throwableToELambda = LambdaTypeName.get(null, Array(throwableTypeName), e)
       val apiNetworkCallResponseBuilder = TypeSpec.classBuilder(apiNetworkCallResponseTypeClassName)
         .addModifiers(KModifier.PUBLIC, KModifier.DATA)
         .addTypeVariable(n)
         .addTypeVariable(e)
         .primaryConstructor(FunSpec.constructorBuilder()
-          .addParameter("networkSingle", singleParameterizedByN)
+          .addParameter("networkSingle", singleParameterized)
           .addParameter("toError", throwableToELambda)
           .build())
-        .addProperty(PropertySpec.builder("networkSingle", singleParameterizedByN)
+        .addProperty(PropertySpec.builder("networkSingle", singleParameterized)
           .initializer("networkSingle")
           .build())
         .addProperty(PropertySpec.builder("toError", throwableToELambda)
           .initializer("toError")
           .build())
-        .addKdoc(s"Utility data class to combine a call and it's error responses\n" + kdocClassMessage)
+        .addKdoc(s"Utility data class to combine a call with its response code and its error responses\n" + kdocClassMessage)
 
 
       //output file

--- a/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinUtil.scala
+++ b/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinUtil.scala
@@ -233,4 +233,8 @@ trait KotlinUtil {
     new ClassName("kotlin", "String")
   }
 
+  def getKotlinPairClassName(): ClassName = {
+    new ClassName("kotlin", "Pair")
+  }
+
 }


### PR DESCRIPTION
Changed call return type from `Single<Object>` to be `Single<Response<Object>>` to enable more granular such as response code on success cases.

Changed ApiNetworkCallResponse to return the unwrapped response object as well as the response code in a `Pair`.