### PR TITLE
Play 2 6 body parsers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,8 +62,12 @@ lazy val scalaGenerator = project
   .dependsOn(lib, lib % "test->test")
   .settings(commonSettings: _*)
   .settings(
-    Seq(ScoverageKeys.coverageMinimum := 80.0),
-    libraryDependencies += "com.geirsson" %% "scalafmt-core" % "1.5.1"
+    Seq(ScoverageKeys.coverageMinimum := 85.0),
+    scalacOptions += "-Ypartial-unification",
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-core" % "1.5.0",
+      "com.geirsson" %% "scalafmt-core" % "1.5.1"
+    )
   )
 
 lazy val rubyGenerator = project

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val scalaGenerator = project
   .dependsOn(lib, lib % "test->test")
   .settings(commonSettings: _*)
   .settings(
-    Seq(ScoverageKeys.coverageMinimum := 85.0),
+    Seq(ScoverageKeys.coverageMinimum := 80.0),
     scalacOptions += "-Ypartial-unification",
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % "1.5.0",

--- a/scala-generator/src/main/scala/models/play/Play26Generator.scala
+++ b/scala-generator/src/main/scala/models/play/Play26Generator.scala
@@ -20,8 +20,9 @@ object Play26Generator extends CodeGenerator {
       files.Client(form),
       files.MockClient(form),
       files.Models(form),
-      files.ModelsJson(form),
       files.ModelsBindables(form),
+      files.ModelsBodyParsers(form),
+      files.ModelsJson(form),
       files.Routes(form),
     )
     .map(_.flatMap(format))

--- a/scala-generator/src/main/scala/models/play/Play26Generator.scala
+++ b/scala-generator/src/main/scala/models/play/Play26Generator.scala
@@ -1,38 +1,47 @@
 package scala.models.play
 
+import cats.implicits._
 import io.apibuilder.generator.v0.models.{File, InvocationForm}
 import lib.generator.CodeGenerator
 
 object Play26Generator extends CodeGenerator {
 
-  def format(file: File): Either[Throwable, File] = file match {
-    case scalaFile if scalaFile.name.endsWith(".scala") =>
+  def file(form: InvocationForm, suffix: String, contents: String, extension: Option[String]): File =
+      generator.ServiceFileNames.toFile(
+          form.service.namespace,
+          form.service.organization.key,
+          form.service.application.key,
+          form.service.version,
+          suffix,
+          contents,
+          extension
+      )
+
+  def formatScala(contents: String): Either[Throwable, String] = {
       val config = org.scalafmt.config.ScalafmtConfig.default120
-      org.scalafmt.Scalafmt.format(scalaFile.contents, config)
+      org.scalafmt.Scalafmt.format(contents, config)
         .toEither
-        .map { formatted => scalaFile.copy(contents = formatted) }
-
-    case file => Right(file)
   }
 
-  override def invoke(form: InvocationForm): Either[Seq[String], Seq[File]] = {
-    val values = List(
-      files.Client(form),
-      files.MockClient(form),
-      files.Models(form),
-      files.ModelsBindables(form),
-      files.ModelsBodyParsers(form),
-      files.ModelsJson(form),
-      files.Routes(form),
+  def scalaFiles(form: InvocationForm): Either[Seq[String], List[File]] =
+    List(
+      ("Client", files.Client.contents(form)),
+      ("MockClient", files.MockClient.contents(form)),
+      ("Models", files.Models.contents(form)),
+      ("ModelsBindables", files.ModelsBindables.contents(form)),
+      ("ModelsBodyParsers", files.ModelsBodyParsers.contents(form)),
+      ("ModelsJson", files.ModelsJson.contents(form)),
     )
-    .map(_.flatMap(format))
-    .flatMap {
-      case Right(file) => List(file)
-      case Left(errors) =>
-        println(errors)
-        List.empty
-    }
+    .traverse { case (suffix, contents) => formatScala(contents).map((suffix, _)) }
+    .map(_.map { case (suffix, contents) => file(form, suffix, contents, Some("scala")) })
+    .leftMap { t => Seq(t.toString) }
 
-    Right(values)
-  }
+  def routesFile(form: InvocationForm): File =
+    File("routes", None, files.Routes.contents(form))
+
+  override def invoke(form: InvocationForm): Either[Seq[String], Seq[File]] = for {
+    scalaFiles <- this.scalaFiles(form)
+    routesFile = this.routesFile(form)
+  } yield scalaFiles :+ routesFile
+
 }

--- a/scala-generator/src/main/scala/models/play/Play26Generator.scala
+++ b/scala-generator/src/main/scala/models/play/Play26Generator.scala
@@ -47,7 +47,7 @@ object Play26Generator extends CodeGenerator {
   def formatRoutes(contents: String): String =
     contents
       .trim
-      .lines
+      .split("\n")
       .map(_.trim)
       .mkString("\n")
 

--- a/scala-generator/src/main/scala/models/play/files/Client.scala
+++ b/scala-generator/src/main/scala/models/play/files/Client.scala
@@ -3,18 +3,12 @@ package scala.models.play.files
 import io.apibuilder.generator.v0.models.InvocationForm
 
 object Client {
-    def contents(form: InvocationForm): String = {
-        val header = scala.models.ApidocComments(form.service.version, form.userAgent)
 
-        val gen = scala.models.Play2ClientGenerator(
-            scala.models.Play26ClientGenerator.config(form),
-            form
-        )
+  def contents(form: InvocationForm): String =
+    scala.models.Play2ClientGenerator(
+        scala.models.Play26ClientGenerator.config(form),
+        form
+      )
+      .client
 
-        s"""
-            ${header.toJavaString()}
-
-            ${gen.client()}
-        """
-    }
 }

--- a/scala-generator/src/main/scala/models/play/files/Client.scala
+++ b/scala-generator/src/main/scala/models/play/files/Client.scala
@@ -1,6 +1,6 @@
 package scala.models.play.files
 
-import io.apibuilder.generator.v0.models.{File, InvocationForm}
+import io.apibuilder.generator.v0.models.InvocationForm
 
 object Client {
     def contents(form: InvocationForm): String = {
@@ -16,23 +16,5 @@ object Client {
 
             ${gen.client()}
         """
-    }
-
-    def file(form: InvocationForm, contents: String): File =
-        generator.ServiceFileNames.toFile(
-            form.service.namespace,
-            form.service.organization.key,
-            form.service.application.key,
-            form.service.version,
-            "Client",
-            contents,
-            Some("Scala")
-        )
-
-    def apply(form: InvocationForm): Either[Seq[String], File] = {
-        val contents = this.contents(form)
-        val file = this.file(form, contents)
-
-        Right(file)
     }
 }

--- a/scala-generator/src/main/scala/models/play/files/MockClient.scala
+++ b/scala-generator/src/main/scala/models/play/files/MockClient.scala
@@ -3,20 +3,13 @@ package scala.models.play.files
 import io.apibuilder.generator.v0.models.InvocationForm
 
 object MockClient {
-    def contents(form: InvocationForm): String = {
-        val header = scala.models.ApidocComments(form.service.version, form.userAgent)
 
-        val gen = {
-            val scalaService = scala.generator.ScalaService(form.service)
-            val config = scala.generator.ScalaClientMethodConfigs.Play26(scalaService.namespaces.base, None)
+  def contents(form: InvocationForm): String = {
+    val scalaService = scala.generator.ScalaService(form.service)
+    val config = scala.generator.ScalaClientMethodConfigs.Play26(scalaService.namespaces.base, None)
 
-            new scala.generator.mock.MockClientGenerator(scalaService, form.userAgent, config)
-        }
+    new scala.generator.mock.MockClientGenerator(scalaService, form.userAgent, config)
+      .generateCode
+  }
 
-        s"""
-            ${header.toJavaString()}
-
-            ${gen.generateCode}
-        """
-    }
 }

--- a/scala-generator/src/main/scala/models/play/files/MockClient.scala
+++ b/scala-generator/src/main/scala/models/play/files/MockClient.scala
@@ -1,16 +1,22 @@
 package scala.models.play.files
 
-import io.apibuilder.generator.v0.models.{File, InvocationForm}
+import io.apibuilder.generator.v0.models.InvocationForm
 
 object MockClient {
-    def apply(form: InvocationForm): Either[Seq[String], File] =
-        scala.generator.mock.MockClientGenerator.Play26
-            .invoke(form)
-            .flatMap { files =>
-                files.headOption
-                    .toRight {
-                        val error = s"Service[${form.service.organization.key}/${form.service.application.key}] cannot generate play mock client"
-                        Seq(error)
-                    }
-            }
+    def contents(form: InvocationForm): String = {
+        val header = scala.models.ApidocComments(form.service.version, form.userAgent)
+
+        val gen = {
+            val scalaService = scala.generator.ScalaService(form.service)
+            val config = scala.generator.ScalaClientMethodConfigs.Play26(scalaService.namespaces.base, None)
+
+            new scala.generator.mock.MockClientGenerator(scalaService, form.userAgent, config)
+        }
+
+        s"""
+            ${header.toJavaString()}
+
+            ${gen.generateCode}
+        """
+    }
 }

--- a/scala-generator/src/main/scala/models/play/files/Models.scala
+++ b/scala-generator/src/main/scala/models/play/files/Models.scala
@@ -1,27 +1,13 @@
 package scala.models.play.files
 
-import io.apibuilder.generator.v0.models.{File, InvocationForm}
+import io.apibuilder.generator.v0.models.InvocationForm
 
 object Models {
-    def apply(form: InvocationForm): Either[Seq[String], File] =
+    def contents(form: InvocationForm): String = {
+        val scalaService = scala.generator.ScalaService(form.service)
         scala.generator.ScalaCaseClasses
-            .invoke(form, addHeader = true)
-            .flatMap { files =>
-                files.headOption
-                    .map { file =>
-                        generator.ServiceFileNames.toFile(
-                            form.service.namespace,
-                            form.service.organization.key,
-                            form.service.application.key,
-                            form.service.version,
-                            "Models",
-                            file.contents,
-                            Some("Scala")
-                        )
-                    }
-                    .toRight {
-                        val error = s"Service[${form.service.organization.key}/${form.service.application.key}] cannot generate play models"
-                        Seq(error)
-                    }
-            }
+            .generateCode(scalaService, form.userAgent)
+            .headOption
+            .fold("")(_.contents)
+    }
 }

--- a/scala-generator/src/main/scala/models/play/files/Models.scala
+++ b/scala-generator/src/main/scala/models/play/files/Models.scala
@@ -3,11 +3,13 @@ package scala.models.play.files
 import io.apibuilder.generator.v0.models.InvocationForm
 
 object Models {
-    def contents(form: InvocationForm): String = {
-        val scalaService = scala.generator.ScalaService(form.service)
-        scala.generator.ScalaCaseClasses
-            .generateCode(scalaService, form.userAgent)
-            .headOption
-            .fold("")(_.contents)
-    }
+
+  def contents(form: InvocationForm): String = {
+    val scalaService = scala.generator.ScalaService(form.service)
+    scala.generator.ScalaCaseClasses
+      .generateCode(scalaService, form.userAgent, false)
+      .headOption
+      .fold("")(_.contents)
+  }
+
 }

--- a/scala-generator/src/main/scala/models/play/files/ModelsBindables.scala
+++ b/scala-generator/src/main/scala/models/play/files/ModelsBindables.scala
@@ -1,6 +1,6 @@
 package scala.models.play.files
 
-import io.apibuilder.generator.v0.models.{File, InvocationForm}
+import io.apibuilder.generator.v0.models.InvocationForm
 
 object ModelsBindables {
     def contents(form: InvocationForm): String = {
@@ -26,23 +26,5 @@ object ModelsBindables {
 
             }
         """
-    }
-
-    def file(form: InvocationForm, contents: String): File =
-        generator.ServiceFileNames.toFile(
-            form.service.namespace,
-            form.service.organization.key,
-            form.service.application.key,
-            form.service.version,
-            "ModelsBindables",
-            contents,
-            Some("Scala")
-        )
-
-    def apply(form: InvocationForm): Either[Seq[String], File] = {
-        val contents = this.contents(form)
-        val file = this.file(form, contents)
-
-        Right(file)
     }
 }

--- a/scala-generator/src/main/scala/models/play/files/ModelsBindables.scala
+++ b/scala-generator/src/main/scala/models/play/files/ModelsBindables.scala
@@ -3,28 +3,25 @@ package scala.models.play.files
 import io.apibuilder.generator.v0.models.InvocationForm
 
 object ModelsBindables {
-    def contents(form: InvocationForm): String = {
-        val scalaService = scala.generator.ScalaService(form.service)
 
-        val header = scala.models.ApidocComments(form.service.version, form.userAgent)
+  def contents(form: InvocationForm): String = {
+    val scalaService = scala.generator.ScalaService(form.service)
+    val bindables = scala.models.Play2Bindables(scalaService)
+      .build
+      .split("\n")
+      .drop(1)
+      .dropRight(1)
+      .mkString("\n")
 
-        val bindables = scala.models.Play2Bindables(scalaService)
-            .build
-            .split("\n")
-            .drop(1)
-            .dropRight(1)
-            .mkString("\n")
+    s"""
+      package ${scalaService.namespaces.models}
 
-        s"""
-            ${header.toJavaString()}
+      package object bindables {
 
-            package ${scalaService.namespaces.models}
+        ${bindables}
 
-            package object bindables {
+      }
+    """
+  }
 
-                ${bindables}
-
-            }
-        """
-    }
 }

--- a/scala-generator/src/main/scala/models/play/files/ModelsBodyParsers.scala
+++ b/scala-generator/src/main/scala/models/play/files/ModelsBodyParsers.scala
@@ -4,49 +4,44 @@ import io.apibuilder.generator.v0.models.InvocationForm
 
 object ModelsBodyParsers {
 
-    val BadRequest = "_root_.play.api.mvc.Results.BadRequest"
-    val BodyParser = "_root_.play.api.mvc.BodyParser"
-    val ExecutionContext = "_root_.scala.concurrent.ExecutionContext"
-    val JsError = "_root_.play.api.libs.json.JsError"
-    val JsReads = "_root_.play.api.libs.json.Reads"
-    val JsValue = "_root_.play.api.libs.json.JsValue"
+	val BadRequest = "_root_.play.api.mvc.Results.BadRequest"
+	val BodyParser = "_root_.play.api.mvc.BodyParser"
+	val ExecutionContext = "_root_.scala.concurrent.ExecutionContext"
+	val JsError = "_root_.play.api.libs.json.JsError"
+	val JsReads = "_root_.play.api.libs.json.Reads"
+	val JsValue = "_root_.play.api.libs.json.JsValue"
 
-    def bodyParser(): String = s"""
-        private def bodyParser[A](parser: ${BodyParser}[${JsValue}])(implicit ec: ${ExecutionContext}, rds: ${JsReads}[A]): ${BodyParser}[A] =
-            parser.validate(_.validate[A].asEither.left.map(e => ${BadRequest}(${JsError}.toJson(e))))
-    """
+	def bodyParser(): String = s"""
+		private def bodyParser[A](parser: ${BodyParser}[${JsValue}])(implicit ec: ${ExecutionContext}, rds: ${JsReads}[A]): ${BodyParser}[A] =
+				parser.validate(_.validate[A].asEither.left.map(e => ${BadRequest}(${JsError}.toJson(e))))
+	"""
 
-    def bodyParser(enum: scala.generator.ScalaEnum): String = bodyParser(enum.name, enum.qualifiedName)
-    def bodyParser(model: scala.generator.ScalaModel): String = bodyParser(model.name, model.qualifiedName)
-    def bodyParser(union: scala.generator.ScalaUnion): String = bodyParser(union.name, union.qualifiedName)
-    def bodyParser(suffix: String, tpe: String): String = s"""
-        def bodyParser${suffix}(parser: ${BodyParser}[${JsValue}])(implicit ec: ${ExecutionContext}, rds: ${JsReads}[${tpe}]): ${BodyParser}[${tpe}] =
-            bodyParser[${tpe}](parser)
-    """
+	def bodyParser(enum: scala.generator.ScalaEnum): String = bodyParser(enum.name, enum.qualifiedName)
+	def bodyParser(model: scala.generator.ScalaModel): String = bodyParser(model.name, model.qualifiedName)
+	def bodyParser(union: scala.generator.ScalaUnion): String = bodyParser(union.name, union.qualifiedName)
+	def bodyParser(suffix: String, tpe: String): String = s"""
+		def bodyParser${suffix}(parser: ${BodyParser}[${JsValue}])(implicit ec: ${ExecutionContext}, rds: ${JsReads}[${tpe}]): ${BodyParser}[${tpe}] =
+				bodyParser[${tpe}](parser)
+	"""
 
-    def contents(form: InvocationForm): String = {
-        val scalaService = scala.generator.ScalaService(form.service)
+	def contents(form: InvocationForm): String = {
+		val scalaService = scala.generator.ScalaService(form.service)
+		val bodyParsers =
+			scalaService.enums.map(bodyParser) ++
+			scalaService.models.map(bodyParser) ++
+			scalaService.unions.map(bodyParser)
 
-        val header = scala.models.ApidocComments(form.service.version, form.userAgent)
+		s"""
+			package ${scalaService.namespaces.models}
 
-        val bodyParsers =
-          scalaService.enums.map(bodyParser) ++
-          scalaService.models.map(bodyParser) ++
-          scalaService.unions.map(bodyParser)
+			package object bodyparsers {
 
-        s"""
-            ${header.toJavaString()}
+				${bodyParser}
 
-            package ${scalaService.namespaces.models}
+				${bodyParsers.mkString("\n")}
 
-            package object bodyparsers {
-
-              ${bodyParser}
-
-              ${bodyParsers.mkString("\n")}
-
-            }
-        """
-    }
+			}
+		"""
+	}
 
 }

--- a/scala-generator/src/main/scala/models/play/files/ModelsBodyParsers.scala
+++ b/scala-generator/src/main/scala/models/play/files/ModelsBodyParsers.scala
@@ -1,0 +1,69 @@
+package scala.models.play.files
+
+import io.apibuilder.generator.v0.models.{File, InvocationForm}
+
+object ModelsBodyParsers {
+
+    val BadRequest = "_root_.play.api.mvc.Results.BadRequest"
+    val BodyParser = "_root_.play.api.mvc.BodyParser"
+    val ExecutionContext = "_root_.scala.concurrent.ExecutionContext"
+    val JsError = "_root_.play.api.libs.json.JsError"
+    val JsReads = "_root_.play.api.libs.json.Reads"
+    val JsValue = "_root_.play.api.libs.json.JsValue"
+
+    def bodyParser(): String = s"""
+        private def bodyParser[A](parser: ${BodyParser}[${JsValue}])(implicit ec: ${ExecutionContext}, rds: ${JsReads}[A]): ${BodyParser}[A] =
+            parser.validate(_.validate[A].asEither.left.map(e => ${BadRequest}(${JsError}.toJson(e))))
+    """
+
+    def bodyParser(enum: scala.generator.ScalaEnum): String = bodyParser(enum.name, enum.qualifiedName)
+    def bodyParser(model: scala.generator.ScalaModel): String = bodyParser(model.name, model.qualifiedName)
+    def bodyParser(union: scala.generator.ScalaUnion): String = bodyParser(union.name, union.qualifiedName)
+    def bodyParser(suffix: String, tpe: String): String = s"""
+        def bodyParser${suffix}(parser: ${BodyParser}[${JsValue}])(implicit ec: ${ExecutionContext}, rds: ${JsReads}[${tpe}]): ${BodyParser}[${tpe}] =
+            bodyParser[${tpe}](parser)
+    """
+
+    def contents(form: InvocationForm): String = {
+        val scalaService = scala.generator.ScalaService(form.service)
+
+        val header = scala.models.ApidocComments(form.service.version, form.userAgent)
+
+        val bodyParsers =
+          scalaService.enums.map(bodyParser) ++
+          scalaService.models.map(bodyParser) ++
+          scalaService.unions.map(bodyParser)
+
+        s"""
+            ${header.toJavaString()}
+
+            package ${scalaService.namespaces.models}
+
+            package object bodyparsers {
+
+              ${bodyParser}
+
+              ${bodyParsers.mkString("\n")}
+
+            }
+        """
+    }
+
+    def file(form: InvocationForm, contents: String): File =
+        generator.ServiceFileNames.toFile(
+            form.service.namespace,
+            form.service.organization.key,
+            form.service.application.key,
+            form.service.version,
+            "ModelsBodyParsers",
+            contents,
+            Some("Scala")
+        )
+
+    def apply(form: InvocationForm): Either[Seq[String], File] = {
+        val contents = this.contents(form)
+        val file = this.file(form, contents)
+
+        Right(file)
+    }
+}

--- a/scala-generator/src/main/scala/models/play/files/ModelsBodyParsers.scala
+++ b/scala-generator/src/main/scala/models/play/files/ModelsBodyParsers.scala
@@ -13,7 +13,7 @@ object ModelsBodyParsers {
 
 	def bodyParser(): String = s"""
 		private def bodyParser[A](parser: ${BodyParser}[${JsValue}])(implicit ec: ${ExecutionContext}, rds: ${JsReads}[A]): ${BodyParser}[A] =
-				parser.validate(_.validate[A].asEither.left.map(e => ${BadRequest}(${JsError}.toJson(e))))
+      parser.validate(_.validate[A].asEither.left.map(e => ${BadRequest}(${JsError}.toJson(e))))
 	"""
 
 	def bodyParser(enum: scala.generator.ScalaEnum): String = bodyParser(enum.name, enum.qualifiedName)
@@ -21,7 +21,7 @@ object ModelsBodyParsers {
 	def bodyParser(union: scala.generator.ScalaUnion): String = bodyParser(union.name, union.qualifiedName)
 	def bodyParser(suffix: String, tpe: String): String = s"""
 		def bodyParser${suffix}(parser: ${BodyParser}[${JsValue}])(implicit ec: ${ExecutionContext}, rds: ${JsReads}[${tpe}]): ${BodyParser}[${tpe}] =
-				bodyParser[${tpe}](parser)
+      bodyParser[${tpe}](parser)
 	"""
 
 	def contents(form: InvocationForm): String = {

--- a/scala-generator/src/main/scala/models/play/files/ModelsBodyParsers.scala
+++ b/scala-generator/src/main/scala/models/play/files/ModelsBodyParsers.scala
@@ -1,6 +1,6 @@
 package scala.models.play.files
 
-import io.apibuilder.generator.v0.models.{File, InvocationForm}
+import io.apibuilder.generator.v0.models.InvocationForm
 
 object ModelsBodyParsers {
 
@@ -49,21 +49,4 @@ object ModelsBodyParsers {
         """
     }
 
-    def file(form: InvocationForm, contents: String): File =
-        generator.ServiceFileNames.toFile(
-            form.service.namespace,
-            form.service.organization.key,
-            form.service.application.key,
-            form.service.version,
-            "ModelsBodyParsers",
-            contents,
-            Some("Scala")
-        )
-
-    def apply(form: InvocationForm): Either[Seq[String], File] = {
-        val contents = this.contents(form)
-        val file = this.file(form, contents)
-
-        Right(file)
-    }
 }

--- a/scala-generator/src/main/scala/models/play/files/ModelsJson.scala
+++ b/scala-generator/src/main/scala/models/play/files/ModelsJson.scala
@@ -1,6 +1,6 @@
 package scala.models.play.files
 
-import io.apibuilder.generator.v0.models.{File, InvocationForm}
+import io.apibuilder.generator.v0.models.InvocationForm
 import scala.generator.Namespaces
 
 object ModelsJson {
@@ -72,23 +72,5 @@ object ModelsJson {
 
             }
         """
-    }
-
-    def file(form: InvocationForm, contents: String): File =
-        generator.ServiceFileNames.toFile(
-            form.service.namespace,
-            form.service.organization.key,
-            form.service.application.key,
-            form.service.version,
-            "ModelsJson",
-            contents,
-            Some("Scala")
-        )
-
-    def apply(form: InvocationForm): Either[Seq[String], File] = {
-        val contents = this.contents(form)
-        val file = this.file(form, contents)
-
-        Right(file)
     }
 }

--- a/scala-generator/src/main/scala/models/play/files/ModelsJson.scala
+++ b/scala-generator/src/main/scala/models/play/files/ModelsJson.scala
@@ -5,42 +5,19 @@ import scala.generator.Namespaces
 
 object ModelsJson {
 
-  def uuidFormat(namespaces: Namespaces): String = s"""
-    private[${namespaces.last}] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
-
-    private[${namespaces.last}] implicit val jsonWritesUUID = new Writes[java.util.UUID] {
-        def writes(x: java.util.UUID) = JsString(x.toString)
-    }
+  def uuidFormat(): String = s"""
+    import play.api.libs.json.Reads.uuidReads
+    import play.api.libs.json.Writes.UuidWrites
   """
 
-  def jodaDateTimeFormat(namespaces: Namespaces): String = s"""
-    private[${namespaces.last}] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-        import org.joda.time.format.ISODateTimeFormat.dateTimeParser
-        dateTimeParser.parseDateTime(str)
-    }
-
-    private[${namespaces.last}] implicit val jsonWritesJodaDateTime = new Writes[org.joda.time.DateTime] {
-        def writes(x: org.joda.time.DateTime) = {
-            import org.joda.time.format.ISODateTimeFormat.dateTime
-            val str = dateTime.print(x)
-            JsString(str)
-        }
-    }
+  def jodaDateTimeFormat(): String = s"""
+    import play.api.libs.json.JodaReads.DefaultJodaDateTimeReads
+    import play.api.libs.json.JodaWrites.JodaDateTimeWrites
   """
 
-  def jodaLocalDateFormat(namespaces: Namespaces): String = s"""
-    private[${namespaces.last}] implicit val jsonReadsJodaLocalDate = __.read[String].map { str =>
-        import org.joda.time.format.ISODateTimeFormat.dateParser
-        dateParser.parseLocalDate(str)
-    }
-
-    private[${namespaces.last}] implicit val jsonWritesJodaLocalDate = new Writes[org.joda.time.LocalDate] {
-        def writes(x: org.joda.time.LocalDate) = {
-            import org.joda.time.format.ISODateTimeFormat.date
-            val str = date.print(x)
-            JsString(str)
-        }
-    }
+  def jodaLocalDateFormat(): String = s"""
+    import play.api.libs.json.JodaReads.DefaultJodaLocalDateReads
+    import play.api.libs.json.JodaWrites.DefaultJodaLocalDateWrites
   """
 
   def contents(form: InvocationForm): String = {
@@ -53,17 +30,17 @@ object ModelsJson {
 
       package object json {
 
-          import play.api.libs.json.{__, JsString, Writes}
-          import play.api.libs.functional.syntax._
+        import play.api.libs.json.{__, JsString, Writes}
+        import play.api.libs.functional.syntax._
 
-          ${imports.mkString("\n")}
+        ${uuidFormat()}
+        ${jodaDateTimeFormat()}
+        ${jodaLocalDateFormat()}
 
-          ${uuidFormat(scalaService.namespaces)}
-          ${jodaDateTimeFormat(scalaService.namespaces)}
-          ${jodaLocalDateFormat(scalaService.namespaces)}
+        ${imports.mkString("\n")}
 
-          ${gen.generateEnums()}
-          ${gen.generateModelsAndUnions()}
+        ${gen.generateEnums()}
+        ${gen.generateModelsAndUnions()}
 
       }
     """

--- a/scala-generator/src/main/scala/models/play/files/ModelsJson.scala
+++ b/scala-generator/src/main/scala/models/play/files/ModelsJson.scala
@@ -5,72 +5,68 @@ import scala.generator.Namespaces
 
 object ModelsJson {
 
-    def uuidFormat(namespaces: Namespaces): String = s"""
-        private[${namespaces.last}] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
+  def uuidFormat(namespaces: Namespaces): String = s"""
+    private[${namespaces.last}] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
 
-        private[${namespaces.last}] implicit val jsonWritesUUID = new Writes[java.util.UUID] {
-            def writes(x: java.util.UUID) = JsString(x.toString)
-        }
-    """
-
-    def jodaDateTimeFormat(namespaces: Namespaces): String = s"""
-        private[${namespaces.last}] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-            import org.joda.time.format.ISODateTimeFormat.dateTimeParser
-            dateTimeParser.parseDateTime(str)
-        }
-
-        private[${namespaces.last}] implicit val jsonWritesJodaDateTime = new Writes[org.joda.time.DateTime] {
-            def writes(x: org.joda.time.DateTime) = {
-                import org.joda.time.format.ISODateTimeFormat.dateTime
-                val str = dateTime.print(x)
-                JsString(str)
-            }
-        }
-    """
-
-    def jodaLocalDateFormat(namespaces: Namespaces): String = s"""
-        private[${namespaces.last}] implicit val jsonReadsJodaLocalDate = __.read[String].map { str =>
-            import org.joda.time.format.ISODateTimeFormat.dateParser
-            dateParser.parseLocalDate(str)
-        }
-
-        private[${namespaces.last}] implicit val jsonWritesJodaLocalDate = new Writes[org.joda.time.LocalDate] {
-            def writes(x: org.joda.time.LocalDate) = {
-                import org.joda.time.format.ISODateTimeFormat.date
-                val str = date.print(x)
-                JsString(str)
-            }
-        }
-    """
-
-    def contents(form: InvocationForm): String = {
-        val scalaService = scala.generator.ScalaService(form.service)
-
-        val header = scala.models.ApidocComments(form.service.version, form.userAgent)
-        val imports = scala.models.JsonImports(form.service)
-
-        val gen = scala.models.Play2Json(scalaService)
-
-        s"""
-            ${header.toJavaString()}
-
-            package ${scalaService.namespaces.models}
-
-            package object json {
-
-                import play.api.libs.json.{__, JsString, Writes}
-                import play.api.libs.functional.syntax._
-
-                ${imports.mkString("\n")}
-
-                ${uuidFormat(scalaService.namespaces)}
-                ${jodaDateTimeFormat(scalaService.namespaces)}
-                ${jodaLocalDateFormat(scalaService.namespaces)}
-
-                ${gen.generateEnums()}
-                ${gen.generateModelsAndUnions()}
-
-            }
-        """
+    private[${namespaces.last}] implicit val jsonWritesUUID = new Writes[java.util.UUID] {
+        def writes(x: java.util.UUID) = JsString(x.toString)
     }
+  """
+
+  def jodaDateTimeFormat(namespaces: Namespaces): String = s"""
+    private[${namespaces.last}] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
+        import org.joda.time.format.ISODateTimeFormat.dateTimeParser
+        dateTimeParser.parseDateTime(str)
+    }
+
+    private[${namespaces.last}] implicit val jsonWritesJodaDateTime = new Writes[org.joda.time.DateTime] {
+        def writes(x: org.joda.time.DateTime) = {
+            import org.joda.time.format.ISODateTimeFormat.dateTime
+            val str = dateTime.print(x)
+            JsString(str)
+        }
+    }
+  """
+
+  def jodaLocalDateFormat(namespaces: Namespaces): String = s"""
+    private[${namespaces.last}] implicit val jsonReadsJodaLocalDate = __.read[String].map { str =>
+        import org.joda.time.format.ISODateTimeFormat.dateParser
+        dateParser.parseLocalDate(str)
+    }
+
+    private[${namespaces.last}] implicit val jsonWritesJodaLocalDate = new Writes[org.joda.time.LocalDate] {
+        def writes(x: org.joda.time.LocalDate) = {
+            import org.joda.time.format.ISODateTimeFormat.date
+            val str = date.print(x)
+            JsString(str)
+        }
+    }
+  """
+
+  def contents(form: InvocationForm): String = {
+    val scalaService = scala.generator.ScalaService(form.service)
+    val imports = scala.models.JsonImports(form.service)
+    val gen = scala.models.Play2Json(scalaService)
+
+    s"""
+      package ${scalaService.namespaces.models}
+
+      package object json {
+
+          import play.api.libs.json.{__, JsString, Writes}
+          import play.api.libs.functional.syntax._
+
+          ${imports.mkString("\n")}
+
+          ${uuidFormat(scalaService.namespaces)}
+          ${jodaDateTimeFormat(scalaService.namespaces)}
+          ${jodaLocalDateFormat(scalaService.namespaces)}
+
+          ${gen.generateEnums()}
+          ${gen.generateModelsAndUnions()}
+
+      }
+    """
+  }
+
 }

--- a/scala-generator/src/main/scala/models/play/files/Routes.scala
+++ b/scala-generator/src/main/scala/models/play/files/Routes.scala
@@ -1,16 +1,14 @@
 package scala.models.play.files
 
-import io.apibuilder.generator.v0.models.{File, InvocationForm}
+import io.apibuilder.generator.v0.models.InvocationForm
 
 object Routes {
-    def apply(form: InvocationForm): Either[Seq[String], File] =
+
+    def contents(form: InvocationForm): String =
         scala.models.Play2RouteGenerator
             .invoke(form)
-            .flatMap { files =>
-                files.headOption
-                    .toRight {
-                        val error = s"Service[${form.service.organization.key}/${form.service.application.key}] cannot generate play routes"
-                        Seq(error)
-                    }
-            }
+            .toOption
+            .flatMap(_.headOption)
+            .fold("")(_.contents)
+
 }

--- a/scala-generator/src/main/scala/models/play/files/Routes.scala
+++ b/scala-generator/src/main/scala/models/play/files/Routes.scala
@@ -4,11 +4,14 @@ import io.apibuilder.generator.v0.models.InvocationForm
 
 object Routes {
 
-    def contents(form: InvocationForm): String =
-        scala.models.Play2RouteGenerator
-            .invoke(form)
-            .toOption
-            .flatMap(_.headOption)
-            .fold("")(_.contents)
+  def contents(form: InvocationForm): String = {
+    val header = scala.models.ApidocComments(form.service.version, form.userAgent).forPlayRoutes + "\n"
+    scala.models.Play2RouteGenerator
+      .invoke(form)
+      .toOption
+      .flatMap(_.headOption)
+      .fold("")(_.contents)
+      .replaceAll(header, "")
+  }
 
 }

--- a/scala-generator/src/test/scala/models/play/Helper.scala
+++ b/scala-generator/src/test/scala/models/play/Helper.scala
@@ -1,0 +1,10 @@
+package scala.models.play
+
+import org.scalatest.Matchers
+
+object Helpers extends Matchers {
+    def removeAllExtraWhiteSpaces(a: String): String = a.replaceAll(" +", " ").trim
+
+    def compareWithoutWhiteSpaces(a: String, b: String) =
+        removeAllExtraWhiteSpaces(a) should be(removeAllExtraWhiteSpaces(b))
+}

--- a/scala-generator/src/test/scala/models/play/Play26GeneratorSpec.scala
+++ b/scala-generator/src/test/scala/models/play/Play26GeneratorSpec.scala
@@ -1,12 +1,63 @@
 package scala.models.play
 
 import io.apibuilder.generator.v0.models.{File, InvocationForm}
+import io.apibuilder.spec.v0.models.{Application, Organization, Service}
 import org.scalatest.{FunSpec, Matchers}
+import scala.models.play.Helpers.compareWithoutWhiteSpaces
 
 class Play26GeneratorSpec extends FunSpec with Matchers {
-  it("format should ignore non scala files") {
-    val contents = ""
-    val file = File("", contents = contents)
-    Play26Generator.format(file) should be(Right(file))
+
+  it("prependHeader should prepend a header") {
+    val contents = "CONTENT"
+    val form = InvocationForm(Service(null, null, null, null, null, "", null, info = null))
+    val expected = s"""
+        HEADER
+
+        CONTENT
+    """
+    val result = Play26Generator.prependHeader(contents, form, _ => "HEADER")
+
+    compareWithoutWhiteSpaces(result, expected)
+  }
+
+  it("file should wrap generator.ServiceFileNames.toFile") {
+    val namespace = "namespace"
+    val organization = "organization"
+    val application = "application"
+    val version = "version"
+    val suffix = "suffix"
+    val contents = "contents"
+    val extension = Some("extension")
+
+    val expected = generator.ServiceFileNames.toFile(namespace, organization, application, version, suffix, contents, extension)
+    val result = Play26Generator.file(InvocationForm(Service(null, null, Organization(organization), Application(application), namespace, version, info = null)), suffix, contents, extension)
+
+    result should be(expected)
+  }
+
+  ignore("formatScala should format valid scala code") {
+    val contents = "case class Foo(bar: String)"
+    val result = Play26Generator.formatScala(contents)
+
+    result should be('right)
+  }
+
+  ignore("formatScala should fail to format invalid scala code") {
+    val contents = "Foo Bar"
+    val result = Play26Generator.formatScala(contents)
+
+    result should be('left)
+  }
+
+  it("formatRoutes should format routes") {
+    val contents = """
+    A
+    B
+    C
+    """
+    val expected = "A\nB\nC"
+    val result = Play26Generator.formatRoutes(contents)
+
+    result should be(expected)
   }
 }

--- a/scala-generator/src/test/scala/models/play/files/ModelsBodyParsersSpec.scala
+++ b/scala-generator/src/test/scala/models/play/files/ModelsBodyParsersSpec.scala
@@ -6,51 +6,50 @@ import scala.models.play.Helpers.compareWithoutWhiteSpaces
 import scala.generator.{ScalaEnum, ScalaModel, ScalaService, ScalaUnion}
 
 class ModelsBodyParsersSpec extends FunSpec with Matchers {
-    it("generates generic body parser") {
-        val expected = s"""
-            private def bodyParser[A](parser: ${ModelsBodyParsers.BodyParser}[${ModelsBodyParsers.JsValue}])(implicit ec: ${ModelsBodyParsers.ExecutionContext}, rds: ${ModelsBodyParsers.JsReads}[A]): ${ModelsBodyParsers.BodyParser}[A] =
-				parser.validate(_.validate[A].asEither.left.map(e => ${ModelsBodyParsers.BadRequest}(${ModelsBodyParsers.JsError}.toJson(e))))
-        """
+  it("generates generic body parser") {
+    val expected = s"""
+      private def bodyParser[A](parser: ${ModelsBodyParsers.BodyParser}[${ModelsBodyParsers.JsValue}])(implicit ec: ${ModelsBodyParsers.ExecutionContext}, rds: ${ModelsBodyParsers.JsReads}[A]): ${ModelsBodyParsers.BodyParser}[A] =
+        parser.validate(_.validate[A].asEither.left.map(e => ${ModelsBodyParsers.BadRequest}(${ModelsBodyParsers.JsError}.toJson(e))))
+    """
 
-        val result = ModelsBodyParsers.bodyParser()
+    val result = ModelsBodyParsers.bodyParser()
+    compareWithoutWhiteSpaces(expected, result)
+  }
 
-        compareWithoutWhiteSpaces(expected, result)
-    }
+  it("generates body parser given a name, and type") {
+    val name = "Foo"
+    val tpe = "Bar"
+    val expected = s"""
+      def bodyParser${name}(parser: ${ModelsBodyParsers.BodyParser}[${ModelsBodyParsers.JsValue}])(implicit ec: ${ModelsBodyParsers.ExecutionContext}, rds: ${ModelsBodyParsers.JsReads}[${tpe}]): ${ModelsBodyParsers.BodyParser}[${tpe}] =
+        bodyParser[${tpe}](parser)
+    """
 
-    it("generates body parser given a name, and type") {
-        val name = "Foo"
-        val tpe = "Bar"
-        val expected = s"""
-		    def bodyParser${name}(parser: ${ModelsBodyParsers.BodyParser}[${ModelsBodyParsers.JsValue}])(implicit ec: ${ModelsBodyParsers.ExecutionContext}, rds: ${ModelsBodyParsers.JsReads}[${tpe}]): ${ModelsBodyParsers.BodyParser}[${tpe}] =
-				bodyParser[${tpe}](parser)
-        """
+    val result = ModelsBodyParsers.bodyParser(name, tpe)
 
-        val result = ModelsBodyParsers.bodyParser(name, tpe)
+    compareWithoutWhiteSpaces(expected, result)
+  }
 
-        compareWithoutWhiteSpaces(expected, result)
-    }
+  it("generates body parser for enum based on name, and qualifiedName") {
+    val enum = new ScalaEnum(ScalaService(Service(null, "", null, null, "foo.bar", null, info = null)), Enum("Foo", null, values = Seq.empty))
+    val expected = ModelsBodyParsers.bodyParser(enum)
+    val result = ModelsBodyParsers.bodyParser(enum.name, enum.qualifiedName)
 
-    it("generates body parser for enum based on name, and qualifiedName") {
-        val enum = new ScalaEnum(ScalaService(Service(null, "", null, null, "foo.bar", null, info = null)), Enum("Foo", null, values = Seq.empty))
-        val expected = ModelsBodyParsers.bodyParser(enum)
-        val result = ModelsBodyParsers.bodyParser(enum.name, enum.qualifiedName)
+    compareWithoutWhiteSpaces(expected, result)
+  }
 
-        compareWithoutWhiteSpaces(expected, result)
-    }
+  it("generates body parser for model based on name, and qualifiedName") {
+    val model = new ScalaModel(ScalaService(Service(null, "", null, null, "foo.bar", null, info = null)), Model("Foo", "Foos", fields = Seq.empty))
+    val expected = ModelsBodyParsers.bodyParser(model)
+    val result = ModelsBodyParsers.bodyParser(model.name, model.qualifiedName)
 
-    it("generates body parser for model based on name, and qualifiedName") {
-        val model = new ScalaModel(ScalaService(Service(null, "", null, null, "foo.bar", null, info = null)), Model("Foo", "Foos", fields = Seq.empty))
-        val expected = ModelsBodyParsers.bodyParser(model)
-        val result = ModelsBodyParsers.bodyParser(model.name, model.qualifiedName)
+    compareWithoutWhiteSpaces(expected, result)
+  }
 
-        compareWithoutWhiteSpaces(expected, result)
-    }
+  it("generates body parser for union based on name, and qualifiedName") {
+    val union = new ScalaUnion(ScalaService(Service(null, "", null, null, "foo.bar", null, info = null)), Union("Foo", null, types = Seq.empty))
+    val expected = ModelsBodyParsers.bodyParser(union)
+    val result = ModelsBodyParsers.bodyParser(union.name, union.qualifiedName)
 
-    it("generates body parser for union based on name, and qualifiedName") {
-        val union = new ScalaUnion(ScalaService(Service(null, "", null, null, "foo.bar", null, info = null)), Union("Foo", null, types = Seq.empty))
-        val expected = ModelsBodyParsers.bodyParser(union)
-        val result = ModelsBodyParsers.bodyParser(union.name, union.qualifiedName)
-
-        compareWithoutWhiteSpaces(expected, result)
-    }
+    compareWithoutWhiteSpaces(expected, result)
+  }
 }

--- a/scala-generator/src/test/scala/models/play/files/ModelsBodyParsersSpec.scala
+++ b/scala-generator/src/test/scala/models/play/files/ModelsBodyParsersSpec.scala
@@ -1,0 +1,56 @@
+package scala.models.play.files
+
+import io.apibuilder.spec.v0.models.{Enum, Model, Service, Union}
+import org.scalatest.{FunSpec, Matchers}
+import scala.models.play.Helpers.compareWithoutWhiteSpaces
+import scala.generator.{ScalaEnum, ScalaModel, ScalaService, ScalaUnion}
+
+class ModelsBodyParsersSpec extends FunSpec with Matchers {
+    it("generates generic body parser") {
+        val expected = s"""
+            private def bodyParser[A](parser: ${ModelsBodyParsers.BodyParser}[${ModelsBodyParsers.JsValue}])(implicit ec: ${ModelsBodyParsers.ExecutionContext}, rds: ${ModelsBodyParsers.JsReads}[A]): ${ModelsBodyParsers.BodyParser}[A] =
+				parser.validate(_.validate[A].asEither.left.map(e => ${ModelsBodyParsers.BadRequest}(${ModelsBodyParsers.JsError}.toJson(e))))
+        """
+
+        val result = ModelsBodyParsers.bodyParser()
+
+        compareWithoutWhiteSpaces(expected, result)
+    }
+
+    it("generates body parser given a name, and type") {
+        val name = "Foo"
+        val tpe = "Bar"
+        val expected = s"""
+		    def bodyParser${name}(parser: ${ModelsBodyParsers.BodyParser}[${ModelsBodyParsers.JsValue}])(implicit ec: ${ModelsBodyParsers.ExecutionContext}, rds: ${ModelsBodyParsers.JsReads}[${tpe}]): ${ModelsBodyParsers.BodyParser}[${tpe}] =
+				bodyParser[${tpe}](parser)
+        """
+
+        val result = ModelsBodyParsers.bodyParser(name, tpe)
+
+        compareWithoutWhiteSpaces(expected, result)
+    }
+
+    it("generates body parser for enum based on name, and qualifiedName") {
+        val enum = new ScalaEnum(ScalaService(Service(null, "", null, null, "foo.bar", null, info = null)), Enum("Foo", null, values = Seq.empty))
+        val expected = ModelsBodyParsers.bodyParser(enum)
+        val result = ModelsBodyParsers.bodyParser(enum.name, enum.qualifiedName)
+
+        compareWithoutWhiteSpaces(expected, result)
+    }
+
+    it("generates body parser for model based on name, and qualifiedName") {
+        val model = new ScalaModel(ScalaService(Service(null, "", null, null, "foo.bar", null, info = null)), Model("Foo", "Foos", fields = Seq.empty))
+        val expected = ModelsBodyParsers.bodyParser(model)
+        val result = ModelsBodyParsers.bodyParser(model.name, model.qualifiedName)
+
+        compareWithoutWhiteSpaces(expected, result)
+    }
+
+    it("generates body parser for union based on name, and qualifiedName") {
+        val union = new ScalaUnion(ScalaService(Service(null, "", null, null, "foo.bar", null, info = null)), Union("Foo", null, types = Seq.empty))
+        val expected = ModelsBodyParsers.bodyParser(union)
+        val result = ModelsBodyParsers.bodyParser(union.name, union.qualifiedName)
+
+        compareWithoutWhiteSpaces(expected, result)
+    }
+}

--- a/scala-generator/src/test/scala/models/play/files/ModelsJsonSpec.scala
+++ b/scala-generator/src/test/scala/models/play/files/ModelsJsonSpec.scala
@@ -1,6 +1,7 @@
 package scala.models.play.files
 
 import org.scalatest.{FunSpec, Matchers}
+import scala.models.play.Helpers.compareWithoutWhiteSpaces
 
 class ModelsJsonSpec extends FunSpec with Matchers {
     it("generates reader, and writer for uuid") {
@@ -15,7 +16,7 @@ class ModelsJsonSpec extends FunSpec with Matchers {
 
         val result = ModelsJson.uuidFormat(namespaces)
 
-        result.replaceAll(" +", " ") should be(expected.replaceAll(" +", " "))
+        compareWithoutWhiteSpaces(expected, result)
     }
 
     it("generates reader, and writer for joda DateTime") {
@@ -37,7 +38,7 @@ class ModelsJsonSpec extends FunSpec with Matchers {
 
         val result = ModelsJson.jodaDateTimeFormat(namespaces)
 
-        result.replaceAll(" +", " ") should be(expected.replaceAll(" +", " "))
+        compareWithoutWhiteSpaces(expected, result)
     }
 
     it("generates reader, and writer for joda LocalDate") {
@@ -59,6 +60,6 @@ class ModelsJsonSpec extends FunSpec with Matchers {
 
         val result = ModelsJson.jodaLocalDateFormat(namespaces)
 
-        result.replaceAll(" +", " ") should be(expected.replaceAll(" +", " "))
+        compareWithoutWhiteSpaces(expected, result)
     }
 }

--- a/scala-generator/src/test/scala/models/play/files/ModelsJsonSpec.scala
+++ b/scala-generator/src/test/scala/models/play/files/ModelsJsonSpec.scala
@@ -4,62 +4,33 @@ import org.scalatest.{FunSpec, Matchers}
 import scala.models.play.Helpers.compareWithoutWhiteSpaces
 
 class ModelsJsonSpec extends FunSpec with Matchers {
-    it("generates reader, and writer for uuid") {
-        val namespaces = scala.generator.Namespaces("john.doe")
-        val expected = s"""
-            private[${namespaces.last}] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
+  it("generates reader, and writer for uuid") {
+    val expected = s"""
+      import play.api.libs.json.Reads.uuidReads
+      import play.api.libs.json.Writes.UuidWrites
+    """
 
-            private[${namespaces.last}] implicit val jsonWritesUUID = new Writes[java.util.UUID] {
-                def writes(x: java.util.UUID) = JsString(x.toString)
-            }
-        """
+    val result = ModelsJson.uuidFormat()
+    compareWithoutWhiteSpaces(expected, result)
+  }
 
-        val result = ModelsJson.uuidFormat(namespaces)
+  it("generates reader, and writer for joda DateTime") {
+    val expected = s"""
+      import play.api.libs.json.JodaReads.DefaultJodaDateTimeReads
+      import play.api.libs.json.JodaWrites.JodaDateTimeWrites
+    """
 
-        compareWithoutWhiteSpaces(expected, result)
-    }
+    val result = ModelsJson.jodaDateTimeFormat()
+    compareWithoutWhiteSpaces(expected, result)
+  }
 
-    it("generates reader, and writer for joda DateTime") {
-        val namespaces = scala.generator.Namespaces("john.doe")
-        val expected = s"""
-            private[${namespaces.last}] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-                import org.joda.time.format.ISODateTimeFormat.dateTimeParser
-                dateTimeParser.parseDateTime(str)
-            }
+  it("generates reader, and writer for joda LocalDate") {
+    val expected = s"""
+      import play.api.libs.json.JodaReads.DefaultJodaLocalDateReads
+      import play.api.libs.json.JodaWrites.DefaultJodaLocalDateWrites
+    """
 
-            private[${namespaces.last}] implicit val jsonWritesJodaDateTime = new Writes[org.joda.time.DateTime] {
-                def writes(x: org.joda.time.DateTime) = {
-                    import org.joda.time.format.ISODateTimeFormat.dateTime
-                    val str = dateTime.print(x)
-                    JsString(str)
-                }
-            }
-        """
-
-        val result = ModelsJson.jodaDateTimeFormat(namespaces)
-
-        compareWithoutWhiteSpaces(expected, result)
-    }
-
-    it("generates reader, and writer for joda LocalDate") {
-        val namespaces = scala.generator.Namespaces("john.doe")
-        val expected = s"""
-            private[${namespaces.last}] implicit val jsonReadsJodaLocalDate = __.read[String].map { str =>
-                import org.joda.time.format.ISODateTimeFormat.dateParser
-                dateParser.parseLocalDate(str)
-            }
-
-            private[${namespaces.last}] implicit val jsonWritesJodaLocalDate = new Writes[org.joda.time.LocalDate] {
-                def writes(x: org.joda.time.LocalDate) = {
-                    import org.joda.time.format.ISODateTimeFormat.date
-                    val str = date.print(x)
-                    JsString(str)
-                }
-            }
-        """
-
-        val result = ModelsJson.jodaLocalDateFormat(namespaces)
-
-        compareWithoutWhiteSpaces(expected, result)
-    }
+    val result = ModelsJson.jodaLocalDateFormat()
+    compareWithoutWhiteSpaces(expected, result)
+  }
 }


### PR DESCRIPTION
This is the third step in improving the play generator.

Add a `BodyParser` generator to validate, and type request bodies. This remove the need for the unsafe `request.body.as[T]`, or the verbose `request.body.validate[T]`.

Centralize generic boilerplate to encourage composition

For backwards compatibility, other play generators haven't been touched.