### PR TITLE
http4s expose error responses to client user

### DIFF
--- a/lib/src/test/resources/http4s/apidoc-api/015/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/015/BryzekApidocApiV0Client.scala.txt
@@ -1915,7 +1915,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1932,7 +1932,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1962,7 +1962,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.MoveForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1999,7 +1999,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Attribute]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2014,8 +2014,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.AttributeForm, io.apibuilder.api.v0.models.Attribute]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 401 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 401 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 401, 409"))
         }
       }
@@ -2028,8 +2028,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 401 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -2071,8 +2071,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Code]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Code]("io.apibuilder.api.v0.models.Code", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404, 409"))
         }
       }
@@ -2090,7 +2090,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.Domain, io.apibuilder.api.v0.models.Domain]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Domain]("io.apibuilder.api.v0.models.Domain", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2120,7 +2120,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.EmailVerificationConfirmationForm, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2159,7 +2159,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2174,7 +2174,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.GeneratorServiceForm, io.apibuilder.api.v0.models.GeneratorService]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2187,8 +2187,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 403 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 403 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 403, 404"))
         }
       }
@@ -2231,7 +2231,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorWithService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.GeneratorWithService]("io.apibuilder.api.v0.models.GeneratorWithService", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2290,7 +2290,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Item]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Item]("io.apibuilder.api.v0.models.Item", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2340,7 +2340,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.MembershipRequest]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.MembershipRequest]("io.apibuilder.api.v0.models.MembershipRequest", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2353,7 +2353,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2366,7 +2366,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2407,7 +2407,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Membership]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Membership]("io.apibuilder.api.v0.models.Membership", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2462,7 +2462,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Organization]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2477,7 +2477,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2493,7 +2493,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2540,7 +2540,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.AttributeValue]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2558,8 +2558,8 @@ def closeAsyncHttpClient(): Unit = {
         _executeRequest[io.apibuilder.api.v0.models.AttributeValueForm, io.apibuilder.api.v0.models.AttributeValue]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 201, 404, 409"))
         }
       }
@@ -2573,8 +2573,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 401 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -2591,7 +2591,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordResetRequest, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2608,7 +2608,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordReset, io.apibuilder.api.v0.models.PasswordResetSuccess]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.PasswordResetSuccess]("io.apibuilder.api.v0.models.PasswordResetSuccess", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2649,7 +2649,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Subscription]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2664,7 +2664,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.SubscriptionForm, io.apibuilder.api.v0.models.Subscription]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -2712,7 +2712,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.CleartextToken]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.CleartextToken]("io.apibuilder.api.v0.models.CleartextToken", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2727,7 +2727,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.TokenForm, io.apibuilder.api.v0.models.Token]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Token]("io.apibuilder.api.v0.models.Token", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -2774,7 +2774,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2794,7 +2794,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2809,7 +2809,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.UserForm, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2825,7 +2825,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.UserUpdateForm, io.apibuilder.api.v0.models.User]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2878,7 +2878,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Version]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2895,7 +2895,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2913,7 +2913,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2968,7 +2968,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Watch]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -3003,7 +3003,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.WatchForm, io.apibuilder.api.v0.models.Watch]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }

--- a/lib/src/test/resources/http4s/apidoc-api/015/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/015/BryzekApidocApiV0ClientOnly.scala.txt
@@ -113,7 +113,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -130,7 +130,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -160,7 +160,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.MoveForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -197,7 +197,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Attribute]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -212,8 +212,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.AttributeForm, io.apibuilder.api.v0.models.Attribute]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 401 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 401 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 401, 409"))
         }
       }
@@ -226,8 +226,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 401 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -269,8 +269,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Code]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Code]("io.apibuilder.api.v0.models.Code", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404, 409"))
         }
       }
@@ -288,7 +288,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.Domain, io.apibuilder.api.v0.models.Domain]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Domain]("io.apibuilder.api.v0.models.Domain", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -318,7 +318,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.EmailVerificationConfirmationForm, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -357,7 +357,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -372,7 +372,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.GeneratorServiceForm, io.apibuilder.api.v0.models.GeneratorService]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -385,8 +385,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 403 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 403 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 403, 404"))
         }
       }
@@ -429,7 +429,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorWithService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.GeneratorWithService]("io.apibuilder.api.v0.models.GeneratorWithService", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -488,7 +488,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Item]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Item]("io.apibuilder.api.v0.models.Item", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -538,7 +538,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.MembershipRequest]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.MembershipRequest]("io.apibuilder.api.v0.models.MembershipRequest", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -551,7 +551,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -564,7 +564,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -605,7 +605,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Membership]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Membership]("io.apibuilder.api.v0.models.Membership", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -660,7 +660,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Organization]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -675,7 +675,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -691,7 +691,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -738,7 +738,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.AttributeValue]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -756,8 +756,8 @@ def closeAsyncHttpClient(): Unit = {
         _executeRequest[io.apibuilder.api.v0.models.AttributeValueForm, io.apibuilder.api.v0.models.AttributeValue]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 201, 404, 409"))
         }
       }
@@ -771,8 +771,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 401 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -789,7 +789,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordResetRequest, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => scalaz.concurrent.Task.now(())
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -806,7 +806,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordReset, io.apibuilder.api.v0.models.PasswordResetSuccess]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.PasswordResetSuccess]("io.apibuilder.api.v0.models.PasswordResetSuccess", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -847,7 +847,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Subscription]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -862,7 +862,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.SubscriptionForm, io.apibuilder.api.v0.models.Subscription]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -910,7 +910,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.CleartextToken]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.CleartextToken]("io.apibuilder.api.v0.models.CleartextToken", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -925,7 +925,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.TokenForm, io.apibuilder.api.v0.models.Token]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Token]("io.apibuilder.api.v0.models.Token", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -972,7 +972,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -992,7 +992,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1007,7 +1007,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.UserForm, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1023,7 +1023,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.UserUpdateForm, io.apibuilder.api.v0.models.User]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1076,7 +1076,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Version]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -1093,7 +1093,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1111,7 +1111,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1166,7 +1166,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Watch]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -1201,7 +1201,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.WatchForm, io.apibuilder.api.v0.models.Watch]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => scalaz.concurrent.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }

--- a/lib/src/test/resources/http4s/apidoc-api/017/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/017/BryzekApidocApiV0Client.scala.txt
@@ -1915,7 +1915,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1932,7 +1932,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1962,7 +1962,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.MoveForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1999,7 +1999,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Attribute]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2014,8 +2014,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.AttributeForm, io.apibuilder.api.v0.models.Attribute]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 401 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 401 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 401, 409"))
         }
       }
@@ -2028,8 +2028,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 401 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -2071,8 +2071,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Code]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Code]("io.apibuilder.api.v0.models.Code", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404, 409"))
         }
       }
@@ -2090,7 +2090,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.Domain, io.apibuilder.api.v0.models.Domain]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Domain]("io.apibuilder.api.v0.models.Domain", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2120,7 +2120,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.EmailVerificationConfirmationForm, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2159,7 +2159,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2174,7 +2174,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.GeneratorServiceForm, io.apibuilder.api.v0.models.GeneratorService]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2187,8 +2187,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 403 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 403 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 403, 404"))
         }
       }
@@ -2231,7 +2231,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorWithService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.GeneratorWithService]("io.apibuilder.api.v0.models.GeneratorWithService", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2290,7 +2290,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Item]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Item]("io.apibuilder.api.v0.models.Item", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2340,7 +2340,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.MembershipRequest]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.MembershipRequest]("io.apibuilder.api.v0.models.MembershipRequest", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2353,7 +2353,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2366,7 +2366,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2407,7 +2407,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Membership]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Membership]("io.apibuilder.api.v0.models.Membership", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2462,7 +2462,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Organization]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2477,7 +2477,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2493,7 +2493,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2540,7 +2540,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.AttributeValue]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2558,8 +2558,8 @@ def closeAsyncHttpClient(): Unit = {
         _executeRequest[io.apibuilder.api.v0.models.AttributeValueForm, io.apibuilder.api.v0.models.AttributeValue]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 201, 404, 409"))
         }
       }
@@ -2573,8 +2573,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 401 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -2591,7 +2591,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordResetRequest, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2608,7 +2608,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordReset, io.apibuilder.api.v0.models.PasswordResetSuccess]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.PasswordResetSuccess]("io.apibuilder.api.v0.models.PasswordResetSuccess", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2649,7 +2649,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Subscription]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2664,7 +2664,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.SubscriptionForm, io.apibuilder.api.v0.models.Subscription]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -2712,7 +2712,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.CleartextToken]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.CleartextToken]("io.apibuilder.api.v0.models.CleartextToken", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2727,7 +2727,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.TokenForm, io.apibuilder.api.v0.models.Token]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Token]("io.apibuilder.api.v0.models.Token", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -2774,7 +2774,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2794,7 +2794,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2809,7 +2809,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.UserForm, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2825,7 +2825,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.UserUpdateForm, io.apibuilder.api.v0.models.User]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2878,7 +2878,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Version]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2895,7 +2895,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2913,7 +2913,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2968,7 +2968,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Watch]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -3003,7 +3003,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.WatchForm, io.apibuilder.api.v0.models.Watch]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }

--- a/lib/src/test/resources/http4s/apidoc-api/017/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/017/BryzekApidocApiV0ClientOnly.scala.txt
@@ -113,7 +113,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -130,7 +130,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -160,7 +160,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.MoveForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -197,7 +197,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Attribute]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -212,8 +212,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.AttributeForm, io.apibuilder.api.v0.models.Attribute]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 401 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 401 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 401, 409"))
         }
       }
@@ -226,8 +226,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 401 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -269,8 +269,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Code]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Code]("io.apibuilder.api.v0.models.Code", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404, 409"))
         }
       }
@@ -288,7 +288,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.Domain, io.apibuilder.api.v0.models.Domain]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Domain]("io.apibuilder.api.v0.models.Domain", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -318,7 +318,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.EmailVerificationConfirmationForm, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -357,7 +357,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -372,7 +372,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.GeneratorServiceForm, io.apibuilder.api.v0.models.GeneratorService]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -385,8 +385,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 403 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 403 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 403, 404"))
         }
       }
@@ -429,7 +429,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorWithService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.GeneratorWithService]("io.apibuilder.api.v0.models.GeneratorWithService", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -488,7 +488,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Item]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Item]("io.apibuilder.api.v0.models.Item", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -538,7 +538,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.MembershipRequest]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.MembershipRequest]("io.apibuilder.api.v0.models.MembershipRequest", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -551,7 +551,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -564,7 +564,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -605,7 +605,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Membership]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Membership]("io.apibuilder.api.v0.models.Membership", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -660,7 +660,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Organization]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -675,7 +675,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -691,7 +691,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -738,7 +738,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.AttributeValue]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -756,8 +756,8 @@ def closeAsyncHttpClient(): Unit = {
         _executeRequest[io.apibuilder.api.v0.models.AttributeValueForm, io.apibuilder.api.v0.models.AttributeValue]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 201, 404, 409"))
         }
       }
@@ -771,8 +771,8 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 401 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -789,7 +789,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordResetRequest, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => fs2.Task.now(())
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -806,7 +806,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordReset, io.apibuilder.api.v0.models.PasswordResetSuccess]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.PasswordResetSuccess]("io.apibuilder.api.v0.models.PasswordResetSuccess", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -847,7 +847,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Subscription]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -862,7 +862,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.SubscriptionForm, io.apibuilder.api.v0.models.Subscription]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -910,7 +910,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.CleartextToken]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.CleartextToken]("io.apibuilder.api.v0.models.CleartextToken", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -925,7 +925,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.TokenForm, io.apibuilder.api.v0.models.Token]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Token]("io.apibuilder.api.v0.models.Token", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -972,7 +972,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -992,7 +992,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1007,7 +1007,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.UserForm, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1023,7 +1023,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.UserUpdateForm, io.apibuilder.api.v0.models.User]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1076,7 +1076,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Version]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -1093,7 +1093,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1111,7 +1111,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1166,7 +1166,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Watch]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 404 => fs2.Task.fail(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => fs2.Task.fail(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -1201,7 +1201,7 @@ def closeAsyncHttpClient(): Unit = {
 
         _executeRequest[io.apibuilder.api.v0.models.WatchForm, io.apibuilder.api.v0.models.Watch]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 409 => fs2.Task.fail(new errors.ErrorsResponse(r))
+          case r if r.status.code == 409 => fs2.Task.fail(new io.apibuilder.api.v0.errors.ErrorsResponse(r))
           case r => fs2.Task.fail(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }

--- a/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0Client.scala.txt
@@ -3850,11 +3850,6 @@ formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
 
   package errors {
 
-    import io.apibuilder.api.v0.models.json._
-    import io.apibuilder.common.v0.models.json._
-    import io.apibuilder.generator.v0.models.json._
-    import io.apibuilder.spec.v0.models.json._
-
     final case class ErrorsResponse[F[_]: Sync](
       response: org.http4s.Response[F],
       message: Option[String] = None,

--- a/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0Client.scala.txt
@@ -1914,7 +1914,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1931,7 +1931,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1961,7 +1961,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.MoveForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1998,7 +1998,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Attribute]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2013,8 +2013,8 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.AttributeForm, io.apibuilder.api.v0.models.Attribute]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 401 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 401 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 401, 409"))
         }
       }
@@ -2027,8 +2027,8 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 401 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -2070,8 +2070,8 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Code]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Code]("io.apibuilder.api.v0.models.Code", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404, 409"))
         }
       }
@@ -2089,7 +2089,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.Domain, io.apibuilder.api.v0.models.Domain]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Domain]("io.apibuilder.api.v0.models.Domain", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2119,7 +2119,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.EmailVerificationConfirmationForm, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2158,7 +2158,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2173,7 +2173,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.GeneratorServiceForm, io.apibuilder.api.v0.models.GeneratorService]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2186,8 +2186,8 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 403 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 403 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 403, 404"))
         }
       }
@@ -2230,7 +2230,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorWithService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.GeneratorWithService]("io.apibuilder.api.v0.models.GeneratorWithService", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2289,7 +2289,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Item]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Item]("io.apibuilder.api.v0.models.Item", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2339,7 +2339,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.MembershipRequest]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.MembershipRequest]("io.apibuilder.api.v0.models.MembershipRequest", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2352,7 +2352,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2365,7 +2365,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2406,7 +2406,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Membership]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Membership]("io.apibuilder.api.v0.models.Membership", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2461,7 +2461,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Organization]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2476,7 +2476,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2492,7 +2492,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2539,7 +2539,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.AttributeValue]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2557,8 +2557,8 @@ import scala.language.higherKinds
         _executeRequest[io.apibuilder.api.v0.models.AttributeValueForm, io.apibuilder.api.v0.models.AttributeValue]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 201, 404, 409"))
         }
       }
@@ -2572,8 +2572,8 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 401 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -2590,7 +2590,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordResetRequest, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2607,7 +2607,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordReset, io.apibuilder.api.v0.models.PasswordResetSuccess]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.PasswordResetSuccess]("io.apibuilder.api.v0.models.PasswordResetSuccess", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2648,7 +2648,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Subscription]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2663,7 +2663,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.SubscriptionForm, io.apibuilder.api.v0.models.Subscription]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -2711,7 +2711,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.CleartextToken]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.CleartextToken]("io.apibuilder.api.v0.models.CleartextToken", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2726,7 +2726,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.TokenForm, io.apibuilder.api.v0.models.Token]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Token]("io.apibuilder.api.v0.models.Token", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -2773,7 +2773,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2793,7 +2793,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2808,7 +2808,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.UserForm, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2824,7 +2824,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.UserUpdateForm, io.apibuilder.api.v0.models.User]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2877,7 +2877,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Version]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2894,7 +2894,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2912,7 +2912,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2967,7 +2967,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Watch]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -3002,7 +3002,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.WatchForm, io.apibuilder.api.v0.models.Watch]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -3850,12 +3850,13 @@ formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
 
   package errors {
 
-    final case class ErrorsResponse[F[_]: Sync](
-      response: org.http4s.Response[F],
+    final case class ErrorsResponse(
+      headers: org.http4s.Headers,
+      status: Int,
       message: Option[String] = None,
       body: Seq[io.apibuilder.api.v0.models.Error]
-    ) extends Exception(message.getOrElse(response.status.code + ": " + response.body)){
-      lazy val errors = Sync[F].pure(body)
+    ) extends Exception(s"HTTP $status${message.fold("")(m => s": $m")}"){
+      lazy val errors = body
     }
 
     final case class UnitResponse(status: Int) extends Exception(s"HTTP $status")

--- a/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0Client.scala.txt
@@ -3076,19 +3076,6 @@ formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
 
       httpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }
-
-    object errors {
-
-    final case class ErrorsResponse(
-      response: org.http4s.Response[F],
-      message: Option[String] = None,
-      body: Seq[io.apibuilder.api.v0.models.Error]
-    ) extends Exception(message.getOrElse(response.status.code + ": " + response.body)){
-      lazy val errors = Sync[F].pure(body)
-    }
-
-    final case class UnitResponse(status: Int) extends Exception(s"HTTP $status")
-    }
   }
 
   object Client {
@@ -3862,6 +3849,21 @@ formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
   }
 
   package errors {
+
+    import io.apibuilder.api.v0.models.json._
+    import io.apibuilder.common.v0.models.json._
+    import io.apibuilder.generator.v0.models.json._
+    import io.apibuilder.spec.v0.models.json._
+
+    final case class ErrorsResponse[F[_]: Sync](
+      response: org.http4s.Response[F],
+      message: Option[String] = None,
+      body: Seq[io.apibuilder.api.v0.models.Error]
+    ) extends Exception(message.getOrElse(response.status.code + ": " + response.body)){
+      lazy val errors = Sync[F].pure(body)
+    }
+
+    final case class UnitResponse(status: Int) extends Exception(s"HTTP $status")
 
     final case class FailedRequest(responseCode: Int, message: String, requestUri: Option[_root_.java.net.URI] = None, parent: Exception = null) extends _root_.java.lang.Exception(s"HTTP $responseCode: $message", parent)
 

--- a/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0ClientOnly.scala.txt
@@ -2048,11 +2048,6 @@ formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
 
   package errors {
 
-    import io.apibuilder.api.v0.models.json._
-    import io.apibuilder.common.v0.models.json._
-    import io.apibuilder.generator.v0.models.json._
-    import io.apibuilder.spec.v0.models.json._
-
     final case class ErrorsResponse[F[_]: Sync](
       response: org.http4s.Response[F],
       message: Option[String] = None,

--- a/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0ClientOnly.scala.txt
@@ -112,7 +112,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -129,7 +129,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -159,7 +159,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.MoveForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -196,7 +196,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Attribute]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -211,8 +211,8 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.AttributeForm, io.apibuilder.api.v0.models.Attribute]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 401 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 401 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 401, 409"))
         }
       }
@@ -225,8 +225,8 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 401 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -268,8 +268,8 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Code]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Code]("io.apibuilder.api.v0.models.Code", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404, 409"))
         }
       }
@@ -287,7 +287,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.Domain, io.apibuilder.api.v0.models.Domain]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Domain]("io.apibuilder.api.v0.models.Domain", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -317,7 +317,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.EmailVerificationConfirmationForm, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -356,7 +356,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -371,7 +371,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.GeneratorServiceForm, io.apibuilder.api.v0.models.GeneratorService]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -384,8 +384,8 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 403 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 403 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 403, 404"))
         }
       }
@@ -428,7 +428,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorWithService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.GeneratorWithService]("io.apibuilder.api.v0.models.GeneratorWithService", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -487,7 +487,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Item]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Item]("io.apibuilder.api.v0.models.Item", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -537,7 +537,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.MembershipRequest]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.MembershipRequest]("io.apibuilder.api.v0.models.MembershipRequest", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -550,7 +550,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -563,7 +563,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -604,7 +604,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Membership]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Membership]("io.apibuilder.api.v0.models.Membership", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -659,7 +659,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Organization]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -674,7 +674,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -690,7 +690,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -737,7 +737,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.AttributeValue]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -755,8 +755,8 @@ import scala.language.higherKinds
         _executeRequest[io.apibuilder.api.v0.models.AttributeValueForm, io.apibuilder.api.v0.models.AttributeValue]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 201, 404, 409"))
         }
       }
@@ -770,8 +770,8 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 401 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -788,7 +788,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordResetRequest, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -805,7 +805,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordReset, io.apibuilder.api.v0.models.PasswordResetSuccess]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.PasswordResetSuccess]("io.apibuilder.api.v0.models.PasswordResetSuccess", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -846,7 +846,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Subscription]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -861,7 +861,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.SubscriptionForm, io.apibuilder.api.v0.models.Subscription]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -909,7 +909,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.CleartextToken]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.CleartextToken]("io.apibuilder.api.v0.models.CleartextToken", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -924,7 +924,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.TokenForm, io.apibuilder.api.v0.models.Token]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Token]("io.apibuilder.api.v0.models.Token", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -971,7 +971,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -991,7 +991,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1006,7 +1006,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.UserForm, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1022,7 +1022,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.UserUpdateForm, io.apibuilder.api.v0.models.User]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1075,7 +1075,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Version]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -1092,7 +1092,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1110,7 +1110,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1165,7 +1165,7 @@ import scala.language.higherKinds
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Watch]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -1200,7 +1200,7 @@ import scala.language.higherKinds
 
         _executeRequest[io.apibuilder.api.v0.models.WatchForm, io.apibuilder.api.v0.models.Watch]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -2048,12 +2048,13 @@ formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
 
   package errors {
 
-    final case class ErrorsResponse[F[_]: Sync](
-      response: org.http4s.Response[F],
+    final case class ErrorsResponse(
+      headers: org.http4s.Headers,
+      status: Int,
       message: Option[String] = None,
       body: Seq[io.apibuilder.api.v0.models.Error]
-    ) extends Exception(message.getOrElse(response.status.code + ": " + response.body)){
-      lazy val errors = Sync[F].pure(body)
+    ) extends Exception(s"HTTP $status${message.fold("")(m => s": $m")}"){
+      lazy val errors = body
     }
 
     final case class UnitResponse(status: Int) extends Exception(s"HTTP $status")

--- a/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0ClientOnly.scala.txt
@@ -1274,19 +1274,6 @@ formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
 
       httpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }
-
-    object errors {
-
-    final case class ErrorsResponse(
-      response: org.http4s.Response[F],
-      message: Option[String] = None,
-      body: Seq[io.apibuilder.api.v0.models.Error]
-    ) extends Exception(message.getOrElse(response.status.code + ": " + response.body)){
-      lazy val errors = Sync[F].pure(body)
-    }
-
-    final case class UnitResponse(status: Int) extends Exception(s"HTTP $status")
-    }
   }
 
   object Client {
@@ -2060,6 +2047,21 @@ formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
   }
 
   package errors {
+
+    import io.apibuilder.api.v0.models.json._
+    import io.apibuilder.common.v0.models.json._
+    import io.apibuilder.generator.v0.models.json._
+    import io.apibuilder.spec.v0.models.json._
+
+    final case class ErrorsResponse[F[_]: Sync](
+      response: org.http4s.Response[F],
+      message: Option[String] = None,
+      body: Seq[io.apibuilder.api.v0.models.Error]
+    ) extends Exception(message.getOrElse(response.status.code + ": " + response.body)){
+      lazy val errors = Sync[F].pure(body)
+    }
+
+    final case class UnitResponse(status: Int) extends Exception(s"HTTP $status")
 
     final case class FailedRequest(responseCode: Int, message: String, requestUri: Option[_root_.java.net.URI] = None, parent: Exception = null) extends _root_.java.lang.Exception(s"HTTP $responseCode: $message", parent)
 

--- a/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0Client.scala.txt
@@ -1913,7 +1913,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1930,7 +1930,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1960,7 +1960,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.MoveForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1997,7 +1997,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Attribute]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2012,8 +2012,8 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.AttributeForm, io.apibuilder.api.v0.models.Attribute]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 401 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 401 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 401, 409"))
         }
       }
@@ -2026,8 +2026,8 @@ import io.circe.syntax._
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 401 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -2069,8 +2069,8 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Code]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Code]("io.apibuilder.api.v0.models.Code", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404, 409"))
         }
       }
@@ -2088,7 +2088,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.Domain, io.apibuilder.api.v0.models.Domain]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Domain]("io.apibuilder.api.v0.models.Domain", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2118,7 +2118,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.EmailVerificationConfirmationForm, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2157,7 +2157,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2172,7 +2172,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.GeneratorServiceForm, io.apibuilder.api.v0.models.GeneratorService]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2185,8 +2185,8 @@ import io.circe.syntax._
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 403 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 403 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 403, 404"))
         }
       }
@@ -2229,7 +2229,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorWithService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.GeneratorWithService]("io.apibuilder.api.v0.models.GeneratorWithService", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2288,7 +2288,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Item]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Item]("io.apibuilder.api.v0.models.Item", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2338,7 +2338,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.MembershipRequest]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.MembershipRequest]("io.apibuilder.api.v0.models.MembershipRequest", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2351,7 +2351,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2364,7 +2364,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2405,7 +2405,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Membership]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Membership]("io.apibuilder.api.v0.models.Membership", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2460,7 +2460,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Organization]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2475,7 +2475,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2491,7 +2491,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2538,7 +2538,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.AttributeValue]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2556,8 +2556,8 @@ import io.circe.syntax._
         _executeRequest[io.apibuilder.api.v0.models.AttributeValueForm, io.apibuilder.api.v0.models.AttributeValue]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 201, 404, 409"))
         }
       }
@@ -2571,8 +2571,8 @@ import io.circe.syntax._
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 401 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -2589,7 +2589,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordResetRequest, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -2606,7 +2606,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordReset, io.apibuilder.api.v0.models.PasswordResetSuccess]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.PasswordResetSuccess]("io.apibuilder.api.v0.models.PasswordResetSuccess", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2647,7 +2647,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Subscription]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2662,7 +2662,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.SubscriptionForm, io.apibuilder.api.v0.models.Subscription]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -2710,7 +2710,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.CleartextToken]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.CleartextToken]("io.apibuilder.api.v0.models.CleartextToken", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2725,7 +2725,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.TokenForm, io.apibuilder.api.v0.models.Token]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Token]("io.apibuilder.api.v0.models.Token", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -2772,7 +2772,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2792,7 +2792,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2807,7 +2807,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.UserForm, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2823,7 +2823,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.UserUpdateForm, io.apibuilder.api.v0.models.User]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2876,7 +2876,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Version]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -2893,7 +2893,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2911,7 +2911,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -2966,7 +2966,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Watch]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -3001,7 +3001,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.WatchForm, io.apibuilder.api.v0.models.Watch]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -3849,12 +3849,13 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
 
   package errors {
 
-    final case class ErrorsResponse[F[_]: Sync](
-      response: org.http4s.Response[F],
+    final case class ErrorsResponse(
+      headers: org.http4s.Headers,
+      status: Int,
       message: Option[String] = None,
       body: Seq[io.apibuilder.api.v0.models.Error]
-    ) extends Exception(message.getOrElse(response.status.code + ": " + response.body)){
-      lazy val errors = Sync[F].pure(body)
+    ) extends Exception(s"HTTP $status${message.fold("")(m => s": $m")}"){
+      lazy val errors = body
     }
 
     final case class UnitResponse(status: Int) extends Exception(s"HTTP $status")

--- a/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0Client.scala.txt
@@ -3849,11 +3849,6 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
 
   package errors {
 
-    import io.apibuilder.api.v0.models.json._
-    import io.apibuilder.common.v0.models.json._
-    import io.apibuilder.generator.v0.models.json._
-    import io.apibuilder.spec.v0.models.json._
-
     final case class ErrorsResponse[F[_]: Sync](
       response: org.http4s.Response[F],
       message: Option[String] = None,

--- a/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0Client.scala.txt
@@ -3075,19 +3075,6 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
 
       httpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }
-
-    object errors {
-
-    final case class ErrorsResponse(
-      response: org.http4s.Response[F],
-      message: Option[String] = None,
-      body: Seq[io.apibuilder.api.v0.models.Error]
-    ) extends Exception(message.getOrElse(response.status.code + ": " + response.body)){
-      lazy val errors = Sync[F].pure(body)
-    }
-
-    final case class UnitResponse(status: Int) extends Exception(s"HTTP $status")
-    }
   }
 
   object Client {
@@ -3861,6 +3848,21 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
   }
 
   package errors {
+
+    import io.apibuilder.api.v0.models.json._
+    import io.apibuilder.common.v0.models.json._
+    import io.apibuilder.generator.v0.models.json._
+    import io.apibuilder.spec.v0.models.json._
+
+    final case class ErrorsResponse[F[_]: Sync](
+      response: org.http4s.Response[F],
+      message: Option[String] = None,
+      body: Seq[io.apibuilder.api.v0.models.Error]
+    ) extends Exception(message.getOrElse(response.status.code + ": " + response.body)){
+      lazy val errors = Sync[F].pure(body)
+    }
+
+    final case class UnitResponse(status: Int) extends Exception(s"HTTP $status")
 
     final case class FailedRequest(responseCode: Int, message: String, requestUri: Option[_root_.java.net.URI] = None, parent: Exception = null) extends _root_.java.lang.Exception(s"HTTP $responseCode: $message", parent)
 

--- a/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0ClientOnly.scala.txt
@@ -2047,11 +2047,6 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
 
   package errors {
 
-    import io.apibuilder.api.v0.models.json._
-    import io.apibuilder.common.v0.models.json._
-    import io.apibuilder.generator.v0.models.json._
-    import io.apibuilder.spec.v0.models.json._
-
     final case class ErrorsResponse[F[_]: Sync](
       response: org.http4s.Response[F],
       message: Option[String] = None,

--- a/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0ClientOnly.scala.txt
@@ -111,7 +111,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -128,7 +128,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.ApplicationForm, io.apibuilder.api.v0.models.Application]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -158,7 +158,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.MoveForm, io.apibuilder.api.v0.models.Application]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Application]("io.apibuilder.api.v0.models.Application", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -195,7 +195,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Attribute]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -210,8 +210,8 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.AttributeForm, io.apibuilder.api.v0.models.Attribute]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Attribute]("io.apibuilder.api.v0.models.Attribute", r)
-          case r if r.status.code == 401 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 401 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 401, 409"))
         }
       }
@@ -224,8 +224,8 @@ import io.circe.syntax._
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 401 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -267,8 +267,8 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Code]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Code]("io.apibuilder.api.v0.models.Code", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404, 409"))
         }
       }
@@ -286,7 +286,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.Domain, io.apibuilder.api.v0.models.Domain]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Domain]("io.apibuilder.api.v0.models.Domain", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -316,7 +316,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.EmailVerificationConfirmationForm, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -355,7 +355,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -370,7 +370,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.GeneratorServiceForm, io.apibuilder.api.v0.models.GeneratorService]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.GeneratorService]("io.apibuilder.api.v0.models.GeneratorService", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -383,8 +383,8 @@ import io.circe.syntax._
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 403 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 403 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 403, 404"))
         }
       }
@@ -427,7 +427,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.GeneratorWithService]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.GeneratorWithService]("io.apibuilder.api.v0.models.GeneratorWithService", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -486,7 +486,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Item]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Item]("io.apibuilder.api.v0.models.Item", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -536,7 +536,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.MembershipRequest]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.MembershipRequest]("io.apibuilder.api.v0.models.MembershipRequest", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -549,7 +549,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -562,7 +562,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, Unit]("POST", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -603,7 +603,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Membership]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Membership]("io.apibuilder.api.v0.models.Membership", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -658,7 +658,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Organization]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -673,7 +673,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -689,7 +689,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.OrganizationForm, io.apibuilder.api.v0.models.Organization]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Organization]("io.apibuilder.api.v0.models.Organization", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -736,7 +736,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.AttributeValue]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -754,8 +754,8 @@ import io.circe.syntax._
         _executeRequest[io.apibuilder.api.v0.models.AttributeValueForm, io.apibuilder.api.v0.models.AttributeValue]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.AttributeValue]("io.apibuilder.api.v0.models.AttributeValue", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 201, 404, 409"))
         }
       }
@@ -769,8 +769,8 @@ import io.circe.syntax._
 
         _executeRequest[Unit, Unit]("DELETE", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 401 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 401 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 401, 404"))
         }
       }
@@ -787,7 +787,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordResetRequest, Unit]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 204 => Sync[F].pure(())
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 204, 409"))
         }
       }
@@ -804,7 +804,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.PasswordReset, io.apibuilder.api.v0.models.PasswordResetSuccess]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.PasswordResetSuccess]("io.apibuilder.api.v0.models.PasswordResetSuccess", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -845,7 +845,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Subscription]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -860,7 +860,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.SubscriptionForm, io.apibuilder.api.v0.models.Subscription]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Subscription]("io.apibuilder.api.v0.models.Subscription", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -908,7 +908,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.CleartextToken]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.CleartextToken]("io.apibuilder.api.v0.models.CleartextToken", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -923,7 +923,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.TokenForm, io.apibuilder.api.v0.models.Token]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Token]("io.apibuilder.api.v0.models.Token", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -970,7 +970,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -990,7 +990,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1005,7 +1005,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.UserForm, io.apibuilder.api.v0.models.User]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1021,7 +1021,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.UserUpdateForm, io.apibuilder.api.v0.models.User]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.User]("io.apibuilder.api.v0.models.User", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1074,7 +1074,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Version]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -1091,7 +1091,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1109,7 +1109,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.VersionForm, io.apibuilder.api.v0.models.Version]("PUT", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Version]("io.apibuilder.api.v0.models.Version", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 409"))
         }
       }
@@ -1164,7 +1164,7 @@ import io.circe.syntax._
 
         _executeRequest[Unit, io.apibuilder.api.v0.models.Watch]("GET", path = urlPath, requestHeaders = requestHeaders) {
           case r if r.status.code == 200 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 404 => Sync[F].raiseError(new errors.UnitResponse(r.status.code))
+          case r if r.status.code == 404 => Sync[F].raiseError(new io.apibuilder.api.v0.errors.UnitResponse(r.status.code))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 200, 404"))
         }
       }
@@ -1199,7 +1199,7 @@ import io.circe.syntax._
 
         _executeRequest[io.apibuilder.api.v0.models.WatchForm, io.apibuilder.api.v0.models.Watch]("POST", path = urlPath, body = payload, formBody = formPayload, requestHeaders = requestHeaders) {
           case r if r.status.code == 201 => _root_.io.apibuilder.api.v0.Client.parseJson[F, io.apibuilder.api.v0.models.Watch]("io.apibuilder.api.v0.models.Watch", r)
-          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new errors.ErrorsResponse(r, None, body)))
+          case r if r.status.code == 409 => _root_.io.apibuilder.api.v0.Client.parseJson[F, Seq[io.apibuilder.api.v0.models.Error]]("Seq[io.apibuilder.api.v0.models.Error]", r).flatMap(body => Sync[F].raiseError(new io.apibuilder.api.v0.errors.ErrorsResponse(r.headers, r.status.code, None, body)))
           case r => Sync[F].raiseError(new io.apibuilder.api.v0.errors.FailedRequest(r.status.code, s"Unsupported response code[${r.status.code}]. Expected: 201, 409"))
         }
       }
@@ -2047,12 +2047,13 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
 
   package errors {
 
-    final case class ErrorsResponse[F[_]: Sync](
-      response: org.http4s.Response[F],
+    final case class ErrorsResponse(
+      headers: org.http4s.Headers,
+      status: Int,
       message: Option[String] = None,
       body: Seq[io.apibuilder.api.v0.models.Error]
-    ) extends Exception(message.getOrElse(response.status.code + ": " + response.body)){
-      lazy val errors = Sync[F].pure(body)
+    ) extends Exception(s"HTTP $status${message.fold("")(m => s": $m")}"){
+      lazy val errors = body
     }
 
     final case class UnitResponse(status: Int) extends Exception(s"HTTP $status")

--- a/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0ClientOnly.scala.txt
@@ -1273,19 +1273,6 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
 
       httpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }
-
-    object errors {
-
-    final case class ErrorsResponse(
-      response: org.http4s.Response[F],
-      message: Option[String] = None,
-      body: Seq[io.apibuilder.api.v0.models.Error]
-    ) extends Exception(message.getOrElse(response.status.code + ": " + response.body)){
-      lazy val errors = Sync[F].pure(body)
-    }
-
-    final case class UnitResponse(status: Int) extends Exception(s"HTTP $status")
-    }
   }
 
   object Client {
@@ -2059,6 +2046,21 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
   }
 
   package errors {
+
+    import io.apibuilder.api.v0.models.json._
+    import io.apibuilder.common.v0.models.json._
+    import io.apibuilder.generator.v0.models.json._
+    import io.apibuilder.spec.v0.models.json._
+
+    final case class ErrorsResponse[F[_]: Sync](
+      response: org.http4s.Response[F],
+      message: Option[String] = None,
+      body: Seq[io.apibuilder.api.v0.models.Error]
+    ) extends Exception(message.getOrElse(response.status.code + ": " + response.body)){
+      lazy val errors = Sync[F].pure(body)
+    }
+
+    final case class UnitResponse(status: Int) extends Exception(s"HTTP $status")
 
     final case class FailedRequest(responseCode: Int, message: String, requestUri: Option[_root_.java.net.URI] = None, parent: Exception = null) extends _root_.java.lang.Exception(s"HTTP $responseCode: $message", parent)
 

--- a/lib/src/test/resources/http4s/date-time/020/ApibuilderTimeTypesV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/date-time/020/ApibuilderTimeTypesV0Client.scala.txt
@@ -270,11 +270,6 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
 
       httpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }
-
-    object errors {
-
-
-    }
   }
 
   object Client {

--- a/lib/src/test/resources/http4s/date-time/020_joda/ApibuilderTimeTypesV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/date-time/020_joda/ApibuilderTimeTypesV0Client.scala.txt
@@ -270,11 +270,6 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
 
       httpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }
-
-    object errors {
-
-
-    }
   }
 
   object Client {

--- a/scala-generator/src/main/scala/models/generator/ScalaClientMethodConfig.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientMethodConfig.scala
@@ -274,7 +274,7 @@ private lazy val defaultAsyncHttpClient = PooledHttp1Client()
 
   case class Http4s018(namespace: String, baseUrl: Option[String]) extends Http4s {
     override val asyncType = "F"
-    override def asyncTypeParam(constraint: Option[String] = None) = Some(s"F[_]${constraint.map(c => s": $c").getOrElse("")}")
+    override def asyncTypeParam(constraint: Option[String] = None) = Some(s"$asyncType[_]${constraint.map(c => s": $c").getOrElse("")}")
     override val leftType = "Left"
     override val rightType = "Right"
     override val monadTransformerInvoke = "value"
@@ -321,7 +321,7 @@ implicit def circeJsonDecoder[${asyncTypeParam(Some("Sync")).map(_+", ").getOrEl
 
   case class Http4s020(namespace: String, baseUrl: Option[String]) extends Http4s {
     override val asyncType = "F"
-    override def asyncTypeParam(constraint: Option[String] = None) = Some(s"F[_]${constraint.map(c => s": $c").getOrElse("")}")
+    override def asyncTypeParam(constraint: Option[String] = None) = Some(s"$asyncType[_]${constraint.map(c => s": $c").getOrElse("")}")
     override val leftType = "Left"
     override val rightType = "Right"
     override val monadTransformerInvoke = "value"

--- a/scala-generator/src/main/scala/models/generator/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientMethodGenerator.scala
@@ -76,8 +76,11 @@ class ScalaClientMethodGenerator(
       Some("package errors {"),
       modelErrorClasses() match {
         case Nil => None
-        case classes => {
-          Some(JsonImports(ssd.service).mkString("\n").indent(2) + "\n\n" + classes.mkString("\n\n").indent(2))
+        case classes => Some {
+          val jsonImports =
+            if (includeJsonImportsInErrorsPackage) JsonImports(ssd.service).mkString("\n").indent(2) + "\n\n"
+            else ""
+          jsonImports + classes.mkString("\n\n").indent(2)
         }
       },
       Some(failedRequestClass().indent(2)),
@@ -99,6 +102,8 @@ class ScalaClientMethodGenerator(
       errorTypeClass(response)
     }.distinct.sorted
   }
+
+  protected def includeJsonImportsInErrorsPackage: Boolean = true
 
   protected def errorTypeClass(response: ScalaResponse): String = {
     require(!response.isSuccess)

--- a/scala-generator/src/main/scala/models/http4s/Http4sClient.scala
+++ b/scala-generator/src/main/scala/models/http4s/Http4sClient.scala
@@ -86,7 +86,7 @@ ${headerString.indent(6)}
       ${config.reqAndMaybeAuthAndBody}
 
       ${config.httpClient}.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
-    }${methodGenerator.modelErrors().indent(4)}
+    }
   }
 
 ${Http4sScalaClientCommon(config).indent(2)}

--- a/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
@@ -3,7 +3,6 @@ package scala.models.http4s
 import io.apibuilder.spec.v0.models.{ResponseCodeInt, ResponseCodeOption, ResponseCodeUndefinedType}
 
 import scala.generator._
-import scala.models.JsonImports
 
 class ScalaClientMethodGenerator (
   config: ScalaClientMethodConfig,
@@ -204,9 +203,16 @@ class ScalaClientMethodGenerator (
 
   override protected def modelErrorClasses(): Seq[String] =
     config match {
-      case _ @ (_:ScalaClientMethodConfigs.Http4s017 | _:ScalaClientMethodConfigs.Http4s015) => super.modelErrorClasses()
+      case _:ScalaClientMethodConfigs.Http4s017 | _:ScalaClientMethodConfigs.Http4s015 => super.modelErrorClasses()
       case _ => errorClasses()
     }
+
+  override protected def includeJsonImportsInErrorsPackage: Boolean = {
+    config match {
+      case _:ScalaClientMethodConfigs.Http4s017 | _:ScalaClientMethodConfigs.Http4s015 => true
+      case _ => false
+    }
+  }
 }
 
 class ScalaClientMethod(

--- a/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
@@ -194,7 +194,7 @@ class ScalaClientMethodGenerator (
         val body = variableName.map(v => s"{\n  lazy val $v = ${http4sConfig.wrappedAsyncType("Sync").getOrElse(http4sConfig.asyncType)}.${http4sConfig.asyncSuccess}(body)\n}").getOrElse("")
 
         Seq(
-          s"final case class $className(",
+          s"final case class $className${config.asyncTypeParam(Some("Sync")).map(p => s"[$p]").getOrElse("")}(",
           s"  response: ${config.responseClass},",
           s"  message: Option[String] = None" + variableName.map(v => s",\n  body: $responseDataType").getOrElse(""),
           s""") extends Exception(message.getOrElse(response.${config.responseStatusMethod} + ": " + response.${config.responseBodyMethod}))$body"""
@@ -205,15 +205,8 @@ class ScalaClientMethodGenerator (
   override protected def modelErrorClasses(): Seq[String] =
     config match {
       case _ @ (_:ScalaClientMethodConfigs.Http4s017 | _:ScalaClientMethodConfigs.Http4s015) => super.modelErrorClasses()
-      case _ => Seq()
+      case _ => errorClasses()
     }
-
-  def modelErrors(): String =
-    config match {
-      case _ @ (_:ScalaClientMethodConfigs.Http4s017 | _:ScalaClientMethodConfigs.Http4s015) => ""
-      case _ => s"\n\nobject errors {\n\n${errorClasses().mkString("\n\n")}\n}"
-    }
-
 }
 
 class ScalaClientMethod(


### PR DESCRIPTION
Fixes #510.

Moves error classes to `package errors` like it's for Play Client generators. This requires _(a)sync type with the constraint_ to be added (changing error types to type constructors -- like it's done for `circeJsonDecoder` and `parseJson` within `object Client`).

**UPDATE**:
This PR is to be further modified (to drop `F` from Error responses). Please see discussion below.
