### PR TITLE
Fix http4s clients for ver. 0.15, 0.17 (Sync[F])

### DIFF
--- a/lib/src/test/resources/http4s/apidoc-api/015/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/015/BryzekApidocApiV0Client.scala.txt
@@ -3071,9 +3071,9 @@ def closeAsyncHttpClient(): Unit = {
         case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
 
-      val reqAndMaybeAuthAndBody = if (formBody.nonEmpty) {
-formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
-} else body.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
+      val reqAndMaybeAuthAndBody =
+        if (formBody.nonEmpty) formBody.fold(scalaz.concurrent.Task.now(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
+        else body.fold(scalaz.concurrent.Task.now(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
 
       asyncHttpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }

--- a/lib/src/test/resources/http4s/apidoc-api/015/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/015/BryzekApidocApiV0ClientOnly.scala.txt
@@ -1269,9 +1269,9 @@ def closeAsyncHttpClient(): Unit = {
         case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
 
-      val reqAndMaybeAuthAndBody = if (formBody.nonEmpty) {
-formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
-} else body.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
+      val reqAndMaybeAuthAndBody =
+        if (formBody.nonEmpty) formBody.fold(scalaz.concurrent.Task.now(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
+        else body.fold(scalaz.concurrent.Task.now(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
 
       asyncHttpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }

--- a/lib/src/test/resources/http4s/apidoc-api/017/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/017/BryzekApidocApiV0Client.scala.txt
@@ -3071,9 +3071,9 @@ def closeAsyncHttpClient(): Unit = {
         case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
 
-      val reqAndMaybeAuthAndBody = if (formBody.nonEmpty) {
-formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
-} else body.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
+      val reqAndMaybeAuthAndBody =
+        if (formBody.nonEmpty) formBody.fold(fs2.Task.now(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
+        else body.fold(fs2.Task.now(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
 
       asyncHttpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }

--- a/lib/src/test/resources/http4s/apidoc-api/017/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/017/BryzekApidocApiV0ClientOnly.scala.txt
@@ -1269,9 +1269,9 @@ def closeAsyncHttpClient(): Unit = {
         case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
 
-      val reqAndMaybeAuthAndBody = if (formBody.nonEmpty) {
-formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
-} else body.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
+      val reqAndMaybeAuthAndBody =
+        if (formBody.nonEmpty) formBody.fold(fs2.Task.now(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
+        else body.fold(fs2.Task.now(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
 
       asyncHttpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }

--- a/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0Client.scala.txt
@@ -3070,9 +3070,9 @@ import scala.language.higherKinds
         case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
 
-      val reqAndMaybeAuthAndBody = if (formBody.nonEmpty) {
-formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
-} else body.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
+      val reqAndMaybeAuthAndBody =
+        if (formBody.nonEmpty) formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
+        else body.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
 
       httpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }

--- a/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0ClientOnly.scala.txt
@@ -1268,9 +1268,9 @@ import scala.language.higherKinds
         case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
 
-      val reqAndMaybeAuthAndBody = if (formBody.nonEmpty) {
-formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
-} else body.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
+      val reqAndMaybeAuthAndBody =
+        if (formBody.nonEmpty) formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
+        else body.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
 
       httpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }

--- a/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0Client.scala.txt
@@ -3069,9 +3069,9 @@ import io.circe.syntax._
         case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
 
-      val reqAndMaybeAuthAndBody = if (formBody.nonEmpty) {
-formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
-} else body.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
+      val reqAndMaybeAuthAndBody =
+        if (formBody.nonEmpty) formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
+        else body.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
 
       httpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }

--- a/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0ClientOnly.scala.txt
@@ -1267,9 +1267,9 @@ import io.circe.syntax._
         case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
 
-      val reqAndMaybeAuthAndBody = if (formBody.nonEmpty) {
-formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
-} else body.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
+      val reqAndMaybeAuthAndBody =
+        if (formBody.nonEmpty) formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
+        else body.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
 
       httpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }

--- a/lib/src/test/resources/http4s/date-time/020/ApibuilderTimeTypesV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/date-time/020/ApibuilderTimeTypesV0Client.scala.txt
@@ -264,9 +264,9 @@ import io.circe.syntax._
         case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
 
-      val reqAndMaybeAuthAndBody = if (formBody.nonEmpty) {
-formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
-} else body.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
+      val reqAndMaybeAuthAndBody =
+        if (formBody.nonEmpty) formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
+        else body.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
 
       httpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }

--- a/lib/src/test/resources/http4s/date-time/020_joda/ApibuilderTimeTypesV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/date-time/020_joda/ApibuilderTimeTypesV0Client.scala.txt
@@ -264,9 +264,9 @@ import io.circe.syntax._
         case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
 
-      val reqAndMaybeAuthAndBody = if (formBody.nonEmpty) {
-formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
-} else body.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
+      val reqAndMaybeAuthAndBody =
+        if (formBody.nonEmpty) formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
+        else body.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
 
       httpClient.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }

--- a/scala-generator/src/main/scala/models/generator/mock/MockClientGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/mock/MockClientGenerator.scala
@@ -151,7 +151,7 @@ class MockClientGenerator(
       s"trait Mock${resource.plural} extends ${ssd.namespaces.base}.${resource.plural} {",
       generator.methods(resource).map { m =>
         Seq(
-          m.interface + s" = ${config.wrappedAsyncType("Sync").getOrElse(config.asyncType)}.${config.asyncSuccess} {",
+          m.interface + s" = ${config.asyncSuccessInvoke} {",
           mockImplementation(m).indent(2),
           "}"
         ).mkString("\n")

--- a/scala-generator/src/main/scala/models/http4s/Http4sClient.scala
+++ b/scala-generator/src/main/scala/models/http4s/Http4sClient.scala
@@ -83,7 +83,7 @@ ${headerString.indent(6)}
         case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
 
-      ${config.reqAndMaybeAuthAndBody}
+${config.reqAndMaybeAuthAndBody.indent(6)}
 
       ${config.httpClient}.fetch(modifyRequest(reqAndMaybeAuthAndBody))(handler)
     }

--- a/scala-generator/src/main/scala/models/http4s/Http4sScalaClientCommon.scala
+++ b/scala-generator/src/main/scala/models/http4s/Http4sScalaClientCommon.scala
@@ -24,7 +24,7 @@ object Http4sScalaClientCommon extends ScalaClientCommon {
         |    className: String,
         |    r: ${config.responseClass}
         |  )(implicit decoder: io.circe.Decoder[T]): ${http4sConfig.asyncType}[T] = r.attemptAs[T].${http4sConfig.monadTransformerInvoke}.flatMap {
-        |    case ${http4sConfig.rightType}(value) => ${http4sConfig.wrappedAsyncType("Sync").getOrElse(http4sConfig.asyncType)}.${http4sConfig.asyncSuccess}(value)
+        |    case ${http4sConfig.rightType}(value) => ${http4sConfig.asyncSuccessInvoke}(value)
         |    case ${http4sConfig.leftType}(error) => ${http4sConfig.wrappedAsyncType("Sync").getOrElse(http4sConfig.asyncType)}.${http4sConfig.asyncFailure}(new ${Namespaces(config.namespace).errors}.FailedRequest(r.${config.responseStatusMethod}, s"Invalid json for class[" + className + "]", None, error))
         |  }
         |}""".stripMargin.trim

--- a/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/http4s/ScalaClientMethodGenerator.scala
@@ -127,14 +127,14 @@ class ScalaClientMethodGenerator (
               if (response.isSuccess) {
                 if (featureMigration.hasImplicit404s && response.isOption) {
                   if (response.isUnit) {
-                    Some(s"case r if r.${config.responseStatusMethod} == $statusCode => ${http4sConfig.wrappedAsyncType("Sync").getOrElse(http4sConfig.asyncType)}.${http4sConfig.asyncSuccess}(Some(()))")
+                    Some(s"case r if r.${config.responseStatusMethod} == $statusCode => ${http4sConfig.asyncSuccessInvoke}(Some(()))")
                   } else {
                     val json = config.toJson("r", response.datatype.name)
-                    Some(s"case r if r.${config.responseStatusMethod} == $statusCode => ${http4sConfig.wrappedAsyncType("Sync").getOrElse(http4sConfig.asyncType)}.${http4sConfig.asyncSuccess}(Some($json))")
+                    Some(s"case r if r.${config.responseStatusMethod} == $statusCode => ${http4sConfig.asyncSuccessInvoke}(Some($json))")
                   }
 
                 } else if (response.isUnit) {
-                  Some(s"case r if r.${config.responseStatusMethod} == $statusCode => ${http4sConfig.wrappedAsyncType("Sync").getOrElse(http4sConfig.asyncType)}.${http4sConfig.asyncSuccess}(())")
+                  Some(s"case r if r.${config.responseStatusMethod} == $statusCode => ${http4sConfig.asyncSuccessInvoke}(())")
 
                 } else {
                   val json = config.toJson("r", response.datatype.name)


### PR DESCRIPTION
Fixes #512.

As only http4s 0.18, 0.20 is aware of `Sync[F]`.

Also fix formatting, and de-dupe code.

Tested locally, and proposed changes compile just fine now.