### PR TITLE
http4s: improve formatting around Client object

### DIFF
--- a/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0Client.scala.txt
@@ -3094,9 +3094,7 @@ formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
   object Client {
     import cats.effect._
 
-
     implicit def circeJsonDecoder[F[_]: Sync, A](implicit decoder: io.circe.Decoder[A]) = org.http4s.circe.jsonOf[F, A]
-
 
     def parseJson[F[_]: Sync, T](
       className: String,

--- a/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/018/BryzekApidocApiV0ClientOnly.scala.txt
@@ -1292,9 +1292,7 @@ formBody.fold(Sync[F].pure(reqAndMaybeAuth))(reqAndMaybeAuth.withBody)
   object Client {
     import cats.effect._
 
-
     implicit def circeJsonDecoder[F[_]: Sync, A](implicit decoder: io.circe.Decoder[A]) = org.http4s.circe.jsonOf[F, A]
-
 
     def parseJson[F[_]: Sync, T](
       className: String,

--- a/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0Client.scala.txt
@@ -3093,9 +3093,7 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
   object Client {
     import cats.effect._
 
-
     implicit def circeJsonDecoder[F[_]: Sync, A](implicit decoder: io.circe.Decoder[A]) = org.http4s.circe.jsonOf[F, A]
-
 
     def parseJson[F[_]: Sync, T](
       className: String,

--- a/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0ClientOnly.scala.txt
+++ b/lib/src/test/resources/http4s/apidoc-api/020/BryzekApidocApiV0ClientOnly.scala.txt
@@ -1291,9 +1291,7 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
   object Client {
     import cats.effect._
 
-
     implicit def circeJsonDecoder[F[_]: Sync, A](implicit decoder: io.circe.Decoder[A]) = org.http4s.circe.jsonOf[F, A]
-
 
     def parseJson[F[_]: Sync, T](
       className: String,

--- a/lib/src/test/resources/http4s/date-time/020/ApibuilderTimeTypesV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/date-time/020/ApibuilderTimeTypesV0Client.scala.txt
@@ -280,9 +280,7 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
   object Client {
     import cats.effect._
 
-
     implicit def circeJsonDecoder[F[_]: Sync, A](implicit decoder: io.circe.Decoder[A]) = org.http4s.circe.jsonOf[F, A]
-
 
     def parseJson[F[_]: Sync, T](
       className: String,

--- a/lib/src/test/resources/http4s/date-time/020_joda/ApibuilderTimeTypesV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/date-time/020_joda/ApibuilderTimeTypesV0Client.scala.txt
@@ -280,9 +280,7 @@ formBody.fold(reqAndMaybeAuth)(reqAndMaybeAuth.withEntity)
   object Client {
     import cats.effect._
 
-
     implicit def circeJsonDecoder[F[_]: Sync, A](implicit decoder: io.circe.Decoder[A]) = org.http4s.circe.jsonOf[F, A]
-
 
     def parseJson[F[_]: Sync, T](
       className: String,

--- a/scala-generator/src/main/scala/models/generator/ScalaClientMethodConfig.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientMethodConfig.scala
@@ -277,9 +277,9 @@ private lazy val defaultAsyncHttpClient = PooledHttp1Client()
     override val monadTransformerInvoke = "value"
     override val responseClass = s"org.http4s.Response[$asyncType]"
     override val extraClientCtorArgs: Option[String] = Some(s",\n  httpClient: org.http4s.client.Client[$asyncType]")
-    override val extraClientObjectMethods = Some(s"""
-implicit def circeJsonDecoder[${asyncTypeParam(Some("Sync")).map(_+", ").getOrElse("")}A](implicit decoder: io.circe.Decoder[A]) = org.http4s.circe.jsonOf[$asyncType, A]
-      """)
+    override val extraClientObjectMethods = Some(
+      s"""implicit def circeJsonDecoder[${asyncTypeParam(Some("Sync")).map(_+", ").getOrElse("")}A](implicit decoder: io.circe.Decoder[A]) = org.http4s.circe.jsonOf[$asyncType, A]"""
+    )
     override val asyncSuccess: String = "pure"
     override def asyncFailure: String = "raiseError"
     override def requestClass: String = s"org.http4s.Request[$asyncType]"
@@ -323,9 +323,9 @@ implicit def circeJsonDecoder[${asyncTypeParam(Some("Sync")).map(_+", ").getOrEl
     override val monadTransformerInvoke = "value"
     override val responseClass = s"org.http4s.Response[$asyncType]"
     override val extraClientCtorArgs: Option[String] = Some(s",\n  httpClient: org.http4s.client.Client[$asyncType]")
-    override val extraClientObjectMethods = Some(s"""
-implicit def circeJsonDecoder[${asyncTypeParam(Some("Sync")).map(_+", ").getOrElse("")}A](implicit decoder: io.circe.Decoder[A]) = org.http4s.circe.jsonOf[$asyncType, A]
-      """)
+    override val extraClientObjectMethods = Some(
+      s"""implicit def circeJsonDecoder[${asyncTypeParam(Some("Sync")).map(_+", ").getOrElse("")}A](implicit decoder: io.circe.Decoder[A]) = org.http4s.circe.jsonOf[$asyncType, A]"""
+    )
     override val asyncSuccess: String = "pure"
     override def asyncFailure: String = "raiseError"
     override def requestClass: String = s"org.http4s.Request[$asyncType]"


### PR DESCRIPTION
Minor: removes double-empty lines from inside of `object Client`.