### PR TITLE
Postman Generator enhancements and fixes

### DIFF
--- a/postman-generator/src/main/scala/examples/RandomStringGenerator.scala
+++ b/postman-generator/src/main/scala/examples/RandomStringGenerator.scala
@@ -1,21 +1,19 @@
 package examples
 
-import scala.util.Random
+import java.util.UUID
+
 import scala.util.hashing.MurmurHash3
 
 trait RandomStringGenerator {
   def generate(seed: String): String
 }
 
-object ScalaRandomStringGenerator extends RandomStringGenerator {
+object UuidRandomStringGenerator extends RandomStringGenerator {
 
   override def generate(seed: String): String = {
-    val string = randomStringStream.take(6).mkString
-    s"lorem_ipsum_$string"
+    UUID.randomUUID().toString.toLowerCase.takeRight(12)
   }
 
-  private def randomStringStream: Stream[Char] =
-    Random.alphanumeric.dropWhile(_.isDigit)
 }
 
 object MurmurRandomStringGenerator extends RandomStringGenerator {

--- a/postman-generator/src/main/scala/generator/DependantOperationResolver.scala
+++ b/postman-generator/src/main/scala/generator/DependantOperationResolver.scala
@@ -68,7 +68,7 @@ object DependantOperationResolver extends Logging {
       extendedAttribute = attribute.toExtended
     } yield extendedAttribute
 
-    val allAttributes = nestedAttributesFromResourceRefs ++ attributesFromResources ++ attributesFromModel
+    val allAttributes = (nestedAttributesFromResourceRefs ++ attributesFromResources ++ attributesFromModel).distinct
 
     for {
       attribute <- allAttributes

--- a/postman-generator/src/main/scala/generator/PostmanCollectionGenerator.scala
+++ b/postman-generator/src/main/scala/generator/PostmanCollectionGenerator.scala
@@ -1,6 +1,6 @@
 package generator
 
-import examples.{ExampleJson, RandomStringGenerator, ScalaRandomStringGenerator, Selection}
+import examples.{ExampleJson, RandomStringGenerator, UuidRandomStringGenerator, Selection}
 import generator.Heuristics.PathVariable
 import io.apibuilder.generator.v0.models.{File, InvocationForm}
 import io.apibuilder.spec.v0.models._
@@ -152,4 +152,4 @@ class PostmanCollectionGenerator(randomStringGenerator: RandomStringGenerator) e
   }
 }
 
-object PostmanCollectionGeneratorImpl extends PostmanCollectionGenerator(ScalaRandomStringGenerator)
+object PostmanCollectionGeneratorImpl extends PostmanCollectionGenerator(UuidRandomStringGenerator)

--- a/postman-generator/src/main/scala/generator/SetupCleanupFolderBuilder.scala
+++ b/postman-generator/src/main/scala/generator/SetupCleanupFolderBuilder.scala
@@ -40,7 +40,7 @@ object SetupCleanupFolderBuilder {
     }
 
     val setupSteps = setupItemToCleanupItemOpts.map(_._1)
-    val cleanupSteps = setupItemToCleanupItemOpts.flatMap(_._2)
+    val cleanupSteps = setupItemToCleanupItemOpts.flatMap(_._2).reverse
 
     val setupFolderOpt = wrapInFolder(setupSteps, PostmanGeneratorConstants.EntitiesSetup)
     val cleanupFolderOpt = wrapInFolder(cleanupSteps, PostmanGeneratorConstants.EntitiesCleanup)


### PR DESCRIPTION
various fixes regarding setup/cleanup steps and random string generator

to be specific:
- ExampleJson mechanism now supports `example` and `default` values for fields with an enum type (previously it returned a random enum value for such a fields)
- ExampleJson mechanism now supports `value-substitute` attribute for different values than plain strings (so it can be used on enums for example)
- dependant entities setup steps are now deduplicated
- dependant entities cleanup steps are now reversed
- random string generator returns a string that is built from hex characters only (previously it returned stuff like `lorem_ipsum_x6D7yzI`)