### PR TITLE
Postman Generator: support for object reference attributes bound to an operation

### DIFF
--- a/postman-generator/src/test/resources/apibuilder/test-service-operation-deps.json
+++ b/postman-generator/src/test/resources/apibuilder/test-service-operation-deps.json
@@ -1,0 +1,307 @@
+{
+  "apidoc": {
+    "version": "1.0.0"
+  },
+  "organization": {
+    "key": "ecorp"
+  },
+  "application": {
+    "key": "service-with-operation-deps"
+  },
+  "namespace": "io.ecorp.api.v0",
+  "version": "0.0.1",
+  "info": {},
+  "name": "library",
+  "base_url": "https://api.ecorp.io",
+  "headers": [],
+  "imports": [],
+  "enums": [],
+  "unions": [],
+  "models": [
+    {
+      "name": "book",
+      "plural": "books",
+      "fields": [
+        {
+          "name": "library_id",
+          "type": "string",
+          "required": true,
+          "attributes": []
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": true,
+          "attributes": [],
+          "example": "Bible"
+        }
+      ],
+      "attributes": [],
+      "description": "A book model"
+    },
+    {
+      "name": "library",
+      "plural": "libraries",
+      "fields": [
+        {
+          "name": "id",
+          "type": "string",
+          "required": true,
+          "attributes": [],
+          "example": "lib-324324"
+        }
+      ],
+      "attributes": [],
+      "description": "A library model"
+    },
+    {
+      "name": "library_form",
+      "plural": "library_forms",
+      "fields": [
+        {
+          "name": "id",
+          "type": "string",
+          "required": true,
+          "attributes": [],
+          "description": "New library's id."
+        }
+      ],
+      "attributes": [],
+      "description": "Represents a form to create a library."
+    },
+    {
+      "name": "book_form",
+      "plural": "book_forms",
+      "fields": [
+        {
+          "name": "library_id",
+          "type": "string",
+          "required": true,
+          "attributes": [
+            {
+              "name": "object-reference",
+              "value": {
+                "related_service_namespace": "io.ecorp.api.v0",
+                "resource_type": "library",
+                "operation_method": "POST",
+                "operation_path": "/libraries",
+                "identifier_field": "id",
+                "delete_operation_path": "/libraries/:id"
+              }
+            }
+          ],
+          "annotations": [],
+          "description": "Corresponds with the library id to which this book belongs"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": true,
+          "attributes": [],
+          "description": "Book title"
+        }
+      ],
+      "attributes": [],
+      "description": "Represents the form to create an item in a pricebook."
+    }
+  ],
+  "resources": [
+    {
+      "type": "book",
+      "plural": "books",
+      "path": "/:library/books",
+      "attributes": [
+        {
+          "name": "object-reference",
+          "value": {
+            "related_service_namespace": "io.ecorp.api.v0",
+            "resource_type": "libraries",
+            "operation_method": "POST",
+            "operation_path": "/libraries",
+            "identifier_field": "id",
+            "delete_operation_path": "/libraries/:id"
+          }
+        }
+      ],
+      "operations": [
+        {
+          "method": "POST",
+          "description": "Create a book",
+          "path": "/:library/books",
+          "attributes": [],
+          "parameters": [],
+          "body": {
+            "type": "book_form",
+            "attributes": []
+          },
+          "responses": [
+            {
+              "headers": [],
+              "code": {
+                "integer": {
+                  "value": 202
+                }
+              },
+              "type": "book"
+            }
+          ]
+        },
+        {
+          "method": "GET",
+          "description": "Get books",
+          "path": "/:library/books",
+          "attributes": [],
+          "parameters": [],
+          "responses": [
+            {
+              "headers": [],
+              "code": {
+                "integer": {
+                  "value": 200
+                }
+              },
+              "type": "[book]"
+            }
+          ]
+        },
+        {
+          "method": "GET",
+          "description": "Get a book",
+          "path": "/:library/books/:book_id",
+          "attributes": [
+            {
+              "name": "object-reference",
+              "value": {
+                "related_service_namespace": "io.ecorp.api.v0",
+                "resource_type": "book",
+                "operation_method": "POST",
+                "operation_path": "/:library/books",
+                "identifier_field": "library_id",
+                "delete_operation_path": "/:library/books/:book_id"
+              }
+            }
+          ],
+          "parameters": [
+            {
+              "name": "id",
+              "type": "string",
+              "location": "Path",
+              "required": true
+            }
+          ],
+          "responses": [
+            {
+              "headers": [],
+              "code": {
+                "integer": {
+                  "value": 200
+                }
+              },
+              "type": "book"
+            }
+          ]
+        },
+        {
+          "method": "DELETE",
+          "description": "Delete a book",
+          "path": "/:library/books/:book_id",
+          "attributes": [
+            {
+              "name": "object-reference",
+              "value": {
+                "related_service_namespace": "io.ecorp.api.v0",
+                "resource_type": "book",
+                "operation_method": "POST",
+                "operation_path": "/:library/books",
+                "identifier_field": "library_id",
+                "delete_operation_path": "/:library/books/:book_id"
+              }
+            }
+          ],
+          "parameters": [],
+          "responses": [
+            {
+              "headers": [],
+              "code": {
+                "integer": {
+                  "value": 204
+                }
+              },
+              "type": "unit"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "plural": "libraries",
+      "path": "/libraries",
+      "parameters": [],
+      "attributes": [],
+      "operations": [
+        {
+          "method": "POST",
+          "description": "Create library",
+          "path": "/libraries",
+          "attributes": [],
+          "parameters": [],
+          "responses": [
+            {
+              "headers": [],
+              "code": {
+                "integer": {
+                  "value": 202
+                }
+              },
+              "type": "library"
+            }
+          ],
+          "body": {
+            "type": "library_form",
+            "attributes": []
+          }
+        },
+        {
+          "method": "DELETE",
+          "description": "Delete library",
+          "path": "/libraries/:id",
+          "attributes": [
+            {
+              "name": "object-reference",
+              "value": {
+                "related_service_namespace": "io.ecorp.api.v0",
+                "resource_type": "library",
+                "operation_method": "POST",
+                "operation_path": "/libraries",
+                "identifier_field": "id",
+                "delete_operation_path": "/libraries/:id"
+              }
+            }
+          ],
+          "parameters": [],
+          "responses": [
+            {
+              "headers": [],
+              "code": {
+                "integer": {
+                  "value": 204
+                }
+              },
+              "type": "unit"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "attributes": [
+    {
+      "name": "postman-basic-auth",
+      "value": {
+        "username": "{{MY_TOKEN}}",
+        "password": ""
+      }
+    }
+  ]
+}

--- a/postman-generator/src/test/resources/postman/expected-operation-deps.json
+++ b/postman-generator/src/test/resources/postman/expected-operation-deps.json
@@ -1,0 +1,978 @@
+{
+  "item": [
+    {
+      "item": [
+        {
+          "request": {
+            "method": "POST",
+            "description": {
+              "content": "Create library"
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Required to send JSON body"
+                },
+                "value": "application/json",
+                "key": "Content-Type"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"id\" : \"lorem_ipsum_163079\"\n}"
+            },
+            "url": {
+              "path": [
+                "libraries"
+              ],
+              "query": [],
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "variable": [],
+              "raw": "{{BASE_URL}}/libraries"
+            }
+          },
+          "response": [
+            {
+              "originalRequest": {
+                "method": "POST",
+                "description": {
+                  "content": "Create library"
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Required to send JSON body"
+                    },
+                    "value": "application/json",
+                    "key": "Content-Type"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"id\" : \"lorem_ipsum_163079\"\n}"
+                },
+                "url": {
+                  "path": [
+                    "libraries"
+                  ],
+                  "query": [],
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "variable": [],
+                  "raw": "{{BASE_URL}}/libraries"
+                }
+              },
+              "code": 202,
+              "name": "Example 202 - library",
+              "header": [],
+              "body": "{\n  \"id\" : \"lib-324324\"\n}"
+            }
+          ],
+          "name": "POST /libraries",
+          "description": {
+            "content": "Create library"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"POST requests should return 2xx\", function () {",
+                  "    pm.response.to.be.success;",
+                  "});",
+                  "var jsonData = JSON.parse(responseBody);",
+                  "var id = jsonData.id;",
+                  "if (id != null) pm.environment.set(\"library#id\", id);"
+                ]
+              }
+            }
+          ],
+          "type": "item"
+        },
+        {
+          "request": {
+            "method": "POST",
+            "description": {
+              "content": "Create a book"
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Required to send JSON body"
+                },
+                "value": "application/json",
+                "key": "Content-Type"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"library_id\" : \"{{library#id}}\",\n  \"title\" : \"lorem_ipsum_217364\"\n}"
+            },
+            "url": {
+              "path": [
+                ":library",
+                "books"
+              ],
+              "query": [],
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "variable": [],
+              "raw": "{{BASE_URL}}/:library/books"
+            }
+          },
+          "response": [
+            {
+              "originalRequest": {
+                "method": "POST",
+                "description": {
+                  "content": "Create a book"
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Required to send JSON body"
+                    },
+                    "value": "application/json",
+                    "key": "Content-Type"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"library_id\" : \"{{library#id}}\",\n  \"title\" : \"lorem_ipsum_217364\"\n}"
+                },
+                "url": {
+                  "path": [
+                    ":library",
+                    "books"
+                  ],
+                  "query": [],
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "variable": [],
+                  "raw": "{{BASE_URL}}/:library/books"
+                }
+              },
+              "code": 202,
+              "name": "Example 202 - book",
+              "header": [],
+              "body": "{\n  \"library_id\" : \"lorem_ipsum_220950\",\n  \"title\" : \"Bible\"\n}"
+            }
+          ],
+          "name": "POST /:library/books",
+          "description": {
+            "content": "Create a book"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"POST requests should return 2xx\", function () {",
+                  "    pm.response.to.be.success;",
+                  "});",
+                  "var jsonData = JSON.parse(responseBody);",
+                  "var id = jsonData.library_id;",
+                  "if (id != null) pm.environment.set(\"book_id\", id);"
+                ]
+              }
+            }
+          ],
+          "type": "item"
+        },
+        {
+          "request": {
+            "method": "POST",
+            "description": {
+              "content": "Create library"
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Required to send JSON body"
+                },
+                "value": "application/json",
+                "key": "Content-Type"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"id\" : \"lorem_ipsum_163079\"\n}"
+            },
+            "url": {
+              "path": [
+                "libraries"
+              ],
+              "query": [],
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "variable": [],
+              "raw": "{{BASE_URL}}/libraries"
+            }
+          },
+          "response": [
+            {
+              "originalRequest": {
+                "method": "POST",
+                "description": {
+                  "content": "Create library"
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Required to send JSON body"
+                    },
+                    "value": "application/json",
+                    "key": "Content-Type"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"id\" : \"lorem_ipsum_163079\"\n}"
+                },
+                "url": {
+                  "path": [
+                    "libraries"
+                  ],
+                  "query": [],
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "variable": [],
+                  "raw": "{{BASE_URL}}/libraries"
+                }
+              },
+              "code": 202,
+              "name": "Example 202 - library",
+              "header": [],
+              "body": "{\n  \"id\" : \"lib-324324\"\n}"
+            }
+          ],
+          "name": "POST /libraries",
+          "description": {
+            "content": "Create library"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"POST requests should return 2xx\", function () {",
+                  "    pm.response.to.be.success;",
+                  "});",
+                  "var jsonData = JSON.parse(responseBody);",
+                  "var id = jsonData.id;",
+                  "if (id != null) pm.environment.set(\"id\", id);"
+                ]
+              }
+            }
+          ],
+          "type": "item"
+        }
+      ],
+      "name": "Entities Setup",
+      "type": "folder"
+    },
+    {
+      "item": [
+        {
+          "request": {
+            "method": "POST",
+            "description": {
+              "content": "Create a book"
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Required to send JSON body"
+                },
+                "value": "application/json",
+                "key": "Content-Type"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"library_id\" : \"{{library#id}}\",\n  \"title\" : \"lorem_ipsum_217364\"\n}"
+            },
+            "url": {
+              "path": [
+                ":library",
+                "books"
+              ],
+              "query": [],
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "variable": [],
+              "raw": "{{BASE_URL}}/:library/books"
+            }
+          },
+          "response": [
+            {
+              "originalRequest": {
+                "method": "POST",
+                "description": {
+                  "content": "Create a book"
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Required to send JSON body"
+                    },
+                    "value": "application/json",
+                    "key": "Content-Type"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"library_id\" : \"{{library#id}}\",\n  \"title\" : \"lorem_ipsum_217364\"\n}"
+                },
+                "url": {
+                  "path": [
+                    ":library",
+                    "books"
+                  ],
+                  "query": [],
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "variable": [],
+                  "raw": "{{BASE_URL}}/:library/books"
+                }
+              },
+              "code": 202,
+              "name": "Example 202 - book",
+              "header": [],
+              "body": "{\n  \"library_id\" : \"lorem_ipsum_220950\",\n  \"title\" : \"Bible\"\n}"
+            }
+          ],
+          "name": "POST /:library/books",
+          "description": {
+            "content": "Create a book"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"POST requests should return 2xx\", function () {",
+                  "    pm.response.to.be.success;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "type": "item"
+        },
+        {
+          "request": {
+            "method": "GET",
+            "description": {
+              "content": "Get books"
+            },
+            "header": [],
+            "url": {
+              "path": [
+                ":library",
+                "books"
+              ],
+              "query": [],
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "variable": [],
+              "raw": "{{BASE_URL}}/:library/books"
+            }
+          },
+          "response": [
+            {
+              "originalRequest": {
+                "method": "GET",
+                "description": {
+                  "content": "Get books"
+                },
+                "header": [],
+                "url": {
+                  "path": [
+                    ":library",
+                    "books"
+                  ],
+                  "query": [],
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "variable": [],
+                  "raw": "{{BASE_URL}}/:library/books"
+                }
+              },
+              "code": 200,
+              "name": "Example 200 - [book]",
+              "header": [],
+              "body": "[ {\n  \"library_id\" : \"lorem_ipsum_220950\",\n  \"title\" : \"Bible\"\n} ]"
+            }
+          ],
+          "name": "GET /:library/books",
+          "description": {
+            "content": "Get books"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"GET requests should return 2xx\", function () {",
+                  "    pm.response.to.be.success;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "type": "item"
+        },
+        {
+          "request": {
+            "method": "GET",
+            "description": {
+              "content": "Get a book"
+            },
+            "header": [],
+            "url": {
+              "path": [
+                ":library",
+                "books",
+                ":book_id"
+              ],
+              "query": [],
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "variable": [
+                {
+                  "description": {
+                    "content": "Type: string  | Required: true"
+                  },
+                  "disabled": false,
+                  "value": "{{id}}",
+                  "key": "id"
+                }
+              ],
+              "raw": "{{BASE_URL}}/:library/books/:book_id"
+            }
+          },
+          "response": [
+            {
+              "originalRequest": {
+                "method": "GET",
+                "description": {
+                  "content": "Get a book"
+                },
+                "header": [],
+                "url": {
+                  "path": [
+                    ":library",
+                    "books",
+                    ":book_id"
+                  ],
+                  "query": [],
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "variable": [
+                    {
+                      "description": {
+                        "content": "Type: string  | Required: true"
+                      },
+                      "disabled": false,
+                      "value": "{{id}}",
+                      "key": "id"
+                    }
+                  ],
+                  "raw": "{{BASE_URL}}/:library/books/:book_id"
+                }
+              },
+              "code": 200,
+              "name": "Example 200 - book",
+              "header": [],
+              "body": "{\n  \"library_id\" : \"lorem_ipsum_220950\",\n  \"title\" : \"Bible\"\n}"
+            }
+          ],
+          "name": "GET /:library/books/:book_id",
+          "description": {
+            "content": "Get a book"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"GET requests should return 2xx\", function () {",
+                  "    pm.response.to.be.success;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "type": "item"
+        },
+        {
+          "request": {
+            "method": "DELETE",
+            "description": {
+              "content": "Delete a book"
+            },
+            "header": [],
+            "url": {
+              "path": [
+                ":library",
+                "books",
+                ":book_id"
+              ],
+              "query": [],
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "variable": [],
+              "raw": "{{BASE_URL}}/:library/books/:book_id"
+            }
+          },
+          "response": [
+            {
+              "originalRequest": {
+                "method": "DELETE",
+                "description": {
+                  "content": "Delete a book"
+                },
+                "header": [],
+                "url": {
+                  "path": [
+                    ":library",
+                    "books",
+                    ":book_id"
+                  ],
+                  "query": [],
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "variable": [],
+                  "raw": "{{BASE_URL}}/:library/books/:book_id"
+                }
+              },
+              "code": 204,
+              "name": "Example 204 - unit",
+              "header": []
+            }
+          ],
+          "name": "DELETE /:library/books/:book_id",
+          "description": {
+            "content": "Delete a book"
+          },
+          "type": "item"
+        }
+      ],
+      "name": "books",
+      "type": "folder"
+    },
+    {
+      "item": [
+        {
+          "request": {
+            "method": "POST",
+            "description": {
+              "content": "Create library"
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Required to send JSON body"
+                },
+                "value": "application/json",
+                "key": "Content-Type"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"id\" : \"lorem_ipsum_163079\"\n}"
+            },
+            "url": {
+              "path": [
+                "libraries"
+              ],
+              "query": [],
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "variable": [],
+              "raw": "{{BASE_URL}}/libraries"
+            }
+          },
+          "response": [
+            {
+              "originalRequest": {
+                "method": "POST",
+                "description": {
+                  "content": "Create library"
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Required to send JSON body"
+                    },
+                    "value": "application/json",
+                    "key": "Content-Type"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"id\" : \"lorem_ipsum_163079\"\n}"
+                },
+                "url": {
+                  "path": [
+                    "libraries"
+                  ],
+                  "query": [],
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "variable": [],
+                  "raw": "{{BASE_URL}}/libraries"
+                }
+              },
+              "code": 202,
+              "name": "Example 202 - library",
+              "header": [],
+              "body": "{\n  \"id\" : \"lib-324324\"\n}"
+            }
+          ],
+          "name": "POST /libraries",
+          "description": {
+            "content": "Create library"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"POST requests should return 2xx\", function () {",
+                  "    pm.response.to.be.success;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "type": "item"
+        },
+        {
+          "request": {
+            "method": "DELETE",
+            "description": {
+              "content": "Delete library"
+            },
+            "header": [],
+            "url": {
+              "path": [
+                "libraries",
+                ":id"
+              ],
+              "query": [],
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "variable": [],
+              "raw": "{{BASE_URL}}/libraries/:id"
+            }
+          },
+          "response": [
+            {
+              "originalRequest": {
+                "method": "DELETE",
+                "description": {
+                  "content": "Delete library"
+                },
+                "header": [],
+                "url": {
+                  "path": [
+                    "libraries",
+                    ":id"
+                  ],
+                  "query": [],
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "variable": [],
+                  "raw": "{{BASE_URL}}/libraries/:id"
+                }
+              },
+              "code": 204,
+              "name": "Example 204 - unit",
+              "header": []
+            }
+          ],
+          "name": "DELETE /libraries/:id",
+          "description": {
+            "content": "Delete library"
+          },
+          "type": "item"
+        }
+      ],
+      "name": "libraries",
+      "type": "folder"
+    },
+    {
+      "item": [
+        {
+          "request": {
+            "method": "DELETE",
+            "description": {
+              "content": "Delete library"
+            },
+            "header": [],
+            "url": {
+              "path": [
+                "libraries",
+                ":id"
+              ],
+              "query": [],
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "variable": [
+                {
+                  "description": {
+                    "content": "Type: string  | Required: true"
+                  },
+                  "disabled": false,
+                  "value": "{{id}}",
+                  "key": "id"
+                }
+              ],
+              "raw": "{{BASE_URL}}/libraries/:id"
+            }
+          },
+          "response": [
+            {
+              "originalRequest": {
+                "method": "DELETE",
+                "description": {
+                  "content": "Delete library"
+                },
+                "header": [],
+                "url": {
+                  "path": [
+                    "libraries",
+                    ":id"
+                  ],
+                  "query": [],
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "variable": [
+                    {
+                      "description": {
+                        "content": "Type: string  | Required: true"
+                      },
+                      "disabled": false,
+                      "value": "{{id}}",
+                      "key": "id"
+                    }
+                  ],
+                  "raw": "{{BASE_URL}}/libraries/:id"
+                }
+              },
+              "code": 204,
+              "name": "Example 204 - unit",
+              "header": []
+            }
+          ],
+          "name": "DELETE /libraries/:id",
+          "description": {
+            "content": "Delete library"
+          },
+          "type": "item"
+        },
+        {
+          "request": {
+            "method": "DELETE",
+            "description": {
+              "content": "Delete a book"
+            },
+            "header": [],
+            "url": {
+              "path": [
+                ":library",
+                "books",
+                ":book_id"
+              ],
+              "query": [],
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "variable": [
+                {
+                  "description": {
+                    "content": "Type: string  | Required: true"
+                  },
+                  "disabled": false,
+                  "value": "{{book_id}}",
+                  "key": "book_id"
+                }
+              ],
+              "raw": "{{BASE_URL}}/:library/books/:book_id"
+            }
+          },
+          "response": [
+            {
+              "originalRequest": {
+                "method": "DELETE",
+                "description": {
+                  "content": "Delete a book"
+                },
+                "header": [],
+                "url": {
+                  "path": [
+                    ":library",
+                    "books",
+                    ":book_id"
+                  ],
+                  "query": [],
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "variable": [
+                    {
+                      "description": {
+                        "content": "Type: string  | Required: true"
+                      },
+                      "disabled": false,
+                      "value": "{{book_id}}",
+                      "key": "book_id"
+                    }
+                  ],
+                  "raw": "{{BASE_URL}}/:library/books/:book_id"
+                }
+              },
+              "code": 204,
+              "name": "Example 204 - unit",
+              "header": []
+            }
+          ],
+          "name": "DELETE /:library/books/:book_id",
+          "description": {
+            "content": "Delete a book"
+          },
+          "type": "item"
+        },
+        {
+          "request": {
+            "method": "DELETE",
+            "description": {
+              "content": "Delete library"
+            },
+            "header": [],
+            "url": {
+              "path": [
+                "libraries",
+                ":id"
+              ],
+              "query": [],
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "variable": [
+                {
+                  "description": {
+                    "content": "Type: string  | Required: true"
+                  },
+                  "disabled": false,
+                  "value": "{{library#id}}",
+                  "key": "id"
+                }
+              ],
+              "raw": "{{BASE_URL}}/libraries/:id"
+            }
+          },
+          "response": [
+            {
+              "originalRequest": {
+                "method": "DELETE",
+                "description": {
+                  "content": "Delete library"
+                },
+                "header": [],
+                "url": {
+                  "path": [
+                    "libraries",
+                    ":id"
+                  ],
+                  "query": [],
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "variable": [
+                    {
+                      "description": {
+                        "content": "Type: string  | Required: true"
+                      },
+                      "disabled": false,
+                      "value": "{{library#id}}",
+                      "key": "id"
+                    }
+                  ],
+                  "raw": "{{BASE_URL}}/libraries/:id"
+                }
+              },
+              "code": 204,
+              "name": "Example 204 - unit",
+              "header": []
+            }
+          ],
+          "name": "DELETE /libraries/:id",
+          "description": {
+            "content": "Delete library"
+          },
+          "type": "item"
+        }
+      ],
+      "name": "Entities Cleanup",
+      "type": "folder"
+    }
+  ],
+  "auth": {
+    "type": "basic",
+    "basic": [
+      {
+        "value": "{{MY_TOKEN}}",
+        "key": "username"
+      },
+      {
+        "value": "",
+        "key": "password"
+      }
+    ]
+  },
+  "variable": [
+    {
+      "type": "string",
+      "value": "https://api.ecorp.io",
+      "key": "BASE_URL"
+    }
+  ],
+  "event": [],
+  "info": {
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "name": "library",
+    "description": {},
+    "version": "0.0.1"
+  }
+}

--- a/postman-generator/src/test/scala/generator/FileInputOutputGeneratorTests.scala
+++ b/postman-generator/src/test/scala/generator/FileInputOutputGeneratorTests.scala
@@ -2,7 +2,7 @@ package generator
 
 import io.apibuilder.generator.v0.models.InvocationForm
 import models.TestHelper._
-import org.scalatest.WordSpec
+import org.scalatest.{Assertion, WordSpec}
 import play.api.libs.json._
 import testUtils.TestPostmanCollectionGenerator
 
@@ -11,24 +11,32 @@ import scala.io.Source
 class FileInputOutputGeneratorTests extends WordSpec {
 
   "Postman Generator" should {
-    "successfully generate postman collection from test-service-1.json" in {
-
-      val resourceUrl = getClass.getResource("/postman/expected-1.json")
-      val expectedJson = Json.parse(
-        Source.fromURL(resourceUrl).mkString
-      ).as[JsValue]
-
-      val inputFile = Source.fromURL(getClass.getResource("/apibuilder/test-service-1.json")).mkString
-      val parsedService = service(inputFile)
-
-      val invocationForm = InvocationForm(parsedService, importedServices = None)
-      val result = TestPostmanCollectionGenerator.invoke(invocationForm)
-
-      val files = result.getOrElse(fail("Generator invoke failure"))
-      val str = files.head.contents
-      val outputJsonCollection = Json.parse(str)
-
-      outputJsonCollection shouldEqual expectedJson
+    "successfully generate a postman collection from test-service-1.json" in {
+      generateCollectionAndVerify("/apibuilder/test-service-1.json", "/postman/expected-1.json")
     }
+
+    "successfully generate a postman collection from test-service-operation-deps.json" in {
+      generateCollectionAndVerify("/apibuilder/test-service-operation-deps.json", "/postman/expected-operation-deps.json")
+    }
+
+  }
+
+  private def generateCollectionAndVerify(servicePath: String, expectedCollectionPath: String): Assertion = {
+    val resourceUrl = getClass.getResource(expectedCollectionPath)
+    val expectedJson = Json.parse(
+      Source.fromURL(resourceUrl).mkString
+    ).as[JsValue]
+
+    val inputFile = Source.fromURL(getClass.getResource(servicePath)).mkString
+    val parsedService = service(inputFile)
+
+    val invocationForm = InvocationForm(parsedService, importedServices = None)
+    val result = TestPostmanCollectionGenerator.invoke(invocationForm)
+
+    val files = result.getOrElse(fail("Generator invoke failure"))
+    val str = files.head.contents
+    val outputJsonCollection = Json.parse(str)
+
+    outputJsonCollection shouldEqual expectedJson
   }
 }


### PR DESCRIPTION
It adds the support of `object-reference` attribute on the operation level.
Works similarly to resource-based object references. 
We read the operation path, look for path params and finally create Setup steps using the attributes.