### PR TITLE
Kotlin: import class change

### DIFF
--- a/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinUtil.scala
+++ b/kotlin-generator/src/main/scala/models/generator/kotlin/KotlinUtil.scala
@@ -104,7 +104,10 @@ trait KotlinUtil {
   }
 
   def isModelNameWithPackage(modelName: String): Boolean = {
-    modelName.toLowerCase.equals(modelName) && modelName.contains(".")
+    modelName.contains(".") && {
+      val packageName = modelName.substring(0, modelName.lastIndexOf("."))
+      packageName.toLowerCase.equals(packageName)
+    }
   }
 
   def capitalizeModelName(modelName: String): String ={

--- a/kotlin-generator/src/test/scala/models/generator/kotlin/KotlinUtilTest.scala
+++ b/kotlin-generator/src/test/scala/models/generator/kotlin/KotlinUtilTest.scala
@@ -104,6 +104,7 @@ class KotlinUtilTest
   "isModelNameWithPackage" should "return correctly" in {
     isModelNameWithPackage("abc") should be(false)
     isModelNameWithPackage("io.apibuilder.common.v0.models.reference") should be(true)
+    isModelNameWithPackage("io.apibuilder.common.v0.models.testReference") should be (true)
   }
 
   "capitalizeModelNameWithPackage" should "capitalize last word" in {


### PR DESCRIPTION
Fixed Kotlin generator's `isModelNameWithPackage` to ensure only the package name is in lower case, excluding the class name after the last period.

For example:
`testModel: com.test.model.testModel` would be generated into

Before:
`ComTestModelTestModel`

After:
`com.test.model.TestModel`