### PR TITLE
[Play] Always add the discriminator when serializing to Json

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -195,7 +195,11 @@ package io.apibuilder.example.union.types.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.example.union.types.v0.models.Bar(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "bar").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.example.union.types.v0.models.Bar(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }
@@ -225,7 +229,11 @@ package io.apibuilder.example.union.types.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.example.union.types.v0.models.Foo(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "foo").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.example.union.types.v0.models.Foo(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }

--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -259,7 +259,15 @@ package io.apibuilder.example.union.types.v0.models {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
         "email" -> play.api.libs.json.JsString(obj.email)
-      )
+      ) ++ play.api.libs.json.Json.obj("discriminator" -> "guest_user")
+    }
+
+    implicit def jsonWritesApidocExampleUnionTypesGuestUser: play.api.libs.json.Writes[GuestUser] = {
+      new play.api.libs.json.Writes[io.apibuilder.example.union.types.v0.models.GuestUser] {
+        def writes(obj: io.apibuilder.example.union.types.v0.models.GuestUser) = {
+          jsObjectGuestUser(obj)
+        }
+      }
     }
 
     implicit def jsonReadsApidocExampleUnionTypesRegisteredUser: play.api.libs.json.Reads[RegisteredUser] = {
@@ -275,7 +283,15 @@ package io.apibuilder.example.union.types.v0.models {
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
         "email" -> play.api.libs.json.JsString(obj.email),
         "preference" -> jsObjectFoobar(obj.preference)
-      )
+      ) ++ play.api.libs.json.Json.obj("discriminator" -> "registered_user")
+    }
+
+    implicit def jsonWritesApidocExampleUnionTypesRegisteredUser: play.api.libs.json.Writes[RegisteredUser] = {
+      new play.api.libs.json.Writes[io.apibuilder.example.union.types.v0.models.RegisteredUser] {
+        def writes(obj: io.apibuilder.example.union.types.v0.models.RegisteredUser) = {
+          jsObjectRegisteredUser(obj)
+        }
+      }
     }
 
     implicit def jsonReadsApidocExampleUnionTypesUserUuid: play.api.libs.json.Reads[UserUuid] = {
@@ -321,8 +337,8 @@ package io.apibuilder.example.union.types.v0.models {
 
     def jsObjectUser(obj: io.apibuilder.example.union.types.v0.models.User): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.example.union.types.v0.models.RegisteredUser => jsObjectRegisteredUser(x) ++ play.api.libs.json.Json.obj("discriminator" -> "registered_user")
-        case x: io.apibuilder.example.union.types.v0.models.GuestUser => jsObjectGuestUser(x) ++ play.api.libs.json.Json.obj("discriminator" -> "guest_user")
+        case x: io.apibuilder.example.union.types.v0.models.RegisteredUser => jsObjectRegisteredUser(x)
+        case x: io.apibuilder.example.union.types.v0.models.GuestUser => jsObjectGuestUser(x)
         case x: io.apibuilder.example.union.types.v0.models.UserUuid => play.api.libs.json.Json.obj("discriminator" -> "uuid", "value" -> play.api.libs.json.JsString(x.value.toString))
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -195,7 +195,11 @@ package io.apibuilder.example.union.types.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.example.union.types.v0.models.Bar(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "bar").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.example.union.types.v0.models.Bar(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }
@@ -225,7 +229,11 @@ package io.apibuilder.example.union.types.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.example.union.types.v0.models.Foo(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "foo").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.example.union.types.v0.models.Foo(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -259,7 +259,15 @@ package io.apibuilder.example.union.types.v0.models {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
         "email" -> play.api.libs.json.JsString(obj.email)
-      )
+      ) ++ play.api.libs.json.Json.obj("discriminator" -> "guest_user")
+    }
+
+    implicit def jsonWritesApidocExampleUnionTypesGuestUser: play.api.libs.json.Writes[GuestUser] = {
+      new play.api.libs.json.Writes[io.apibuilder.example.union.types.v0.models.GuestUser] {
+        def writes(obj: io.apibuilder.example.union.types.v0.models.GuestUser) = {
+          jsObjectGuestUser(obj)
+        }
+      }
     }
 
     implicit def jsonReadsApidocExampleUnionTypesRegisteredUser: play.api.libs.json.Reads[RegisteredUser] = {
@@ -275,7 +283,15 @@ package io.apibuilder.example.union.types.v0.models {
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
         "email" -> play.api.libs.json.JsString(obj.email),
         "preference" -> jsObjectFoobar(obj.preference)
-      )
+      ) ++ play.api.libs.json.Json.obj("discriminator" -> "registered_user")
+    }
+
+    implicit def jsonWritesApidocExampleUnionTypesRegisteredUser: play.api.libs.json.Writes[RegisteredUser] = {
+      new play.api.libs.json.Writes[io.apibuilder.example.union.types.v0.models.RegisteredUser] {
+        def writes(obj: io.apibuilder.example.union.types.v0.models.RegisteredUser) = {
+          jsObjectRegisteredUser(obj)
+        }
+      }
     }
 
     implicit def jsonReadsApidocExampleUnionTypesUserUuid: play.api.libs.json.Reads[UserUuid] = {
@@ -321,8 +337,8 @@ package io.apibuilder.example.union.types.v0.models {
 
     def jsObjectUser(obj: io.apibuilder.example.union.types.v0.models.User): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.example.union.types.v0.models.RegisteredUser => jsObjectRegisteredUser(x) ++ play.api.libs.json.Json.obj("discriminator" -> "registered_user")
-        case x: io.apibuilder.example.union.types.v0.models.GuestUser => jsObjectGuestUser(x) ++ play.api.libs.json.Json.obj("discriminator" -> "guest_user")
+        case x: io.apibuilder.example.union.types.v0.models.RegisteredUser => jsObjectRegisteredUser(x)
+        case x: io.apibuilder.example.union.types.v0.models.GuestUser => jsObjectGuestUser(x)
         case x: io.apibuilder.example.union.types.v0.models.UserUuid => play.api.libs.json.Json.obj("discriminator" -> "uuid", "value" -> play.api.libs.json.JsString(x.value.toString))
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")

--- a/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
+++ b/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
@@ -595,7 +595,11 @@ package com.gilt.quality.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(com.gilt.quality.v0.models.ExternalServiceName(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "external_service_name").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(com.gilt.quality.v0.models.ExternalServiceName(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }
@@ -625,7 +629,11 @@ package com.gilt.quality.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(com.gilt.quality.v0.models.Publication(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "publication").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(com.gilt.quality.v0.models.Publication(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }
@@ -655,7 +663,11 @@ package com.gilt.quality.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(com.gilt.quality.v0.models.Response(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "response").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(com.gilt.quality.v0.models.Response(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }
@@ -685,7 +697,11 @@ package com.gilt.quality.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(com.gilt.quality.v0.models.Severity(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "severity").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(com.gilt.quality.v0.models.Severity(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }
@@ -715,7 +731,11 @@ package com.gilt.quality.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(com.gilt.quality.v0.models.Task(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "task").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(com.gilt.quality.v0.models.Task(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }

--- a/lib/src/test/resources/generators/play-26-apidoc-api.txt
+++ b/lib/src/test/resources/generators/play-26-apidoc-api.txt
@@ -766,7 +766,11 @@ package io.apibuilder.api.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.OriginalType(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "original_type").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.OriginalType(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }
@@ -796,7 +800,11 @@ package io.apibuilder.api.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.Publication(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "publication").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.Publication(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }
@@ -826,7 +834,11 @@ package io.apibuilder.api.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.Visibility(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "visibility").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.Visibility(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }

--- a/lib/src/test/resources/generators/play-26-apidoc-api.txt
+++ b/lib/src/test/resources/generators/play-26-apidoc-api.txt
@@ -927,7 +927,15 @@ package io.apibuilder.api.v0.models {
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
         "organization" -> io.apibuilder.common.v0.models.json.jsObjectReference(obj.organization),
         "key" -> play.api.libs.json.JsString(obj.key)
-      )
+      ) ++ play.api.libs.json.Json.obj("type" -> "application_summary")
+    }
+
+    implicit def jsonWritesApidocApiApplicationSummary: play.api.libs.json.Writes[ApplicationSummary] = {
+      new play.api.libs.json.Writes[io.apibuilder.api.v0.models.ApplicationSummary] {
+        def writes(obj: io.apibuilder.api.v0.models.ApplicationSummary) = {
+          jsObjectApplicationSummary(obj)
+        }
+      }
     }
 
     implicit def jsonReadsApidocApiAttribute: play.api.libs.json.Reads[Attribute] = {
@@ -1155,7 +1163,15 @@ package io.apibuilder.api.v0.models {
     def jsObjectDiffBreaking(obj: io.apibuilder.api.v0.models.DiffBreaking): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "description" -> play.api.libs.json.JsString(obj.description)
-      )
+      ) ++ play.api.libs.json.Json.obj("type" -> "diff_breaking")
+    }
+
+    implicit def jsonWritesApidocApiDiffBreaking: play.api.libs.json.Writes[DiffBreaking] = {
+      new play.api.libs.json.Writes[io.apibuilder.api.v0.models.DiffBreaking] {
+        def writes(obj: io.apibuilder.api.v0.models.DiffBreaking) = {
+          jsObjectDiffBreaking(obj)
+        }
+      }
     }
 
     implicit def jsonReadsApidocApiDiffNonBreaking: play.api.libs.json.Reads[DiffNonBreaking] = {
@@ -1165,7 +1181,15 @@ package io.apibuilder.api.v0.models {
     def jsObjectDiffNonBreaking(obj: io.apibuilder.api.v0.models.DiffNonBreaking): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "description" -> play.api.libs.json.JsString(obj.description)
-      )
+      ) ++ play.api.libs.json.Json.obj("type" -> "diff_non_breaking")
+    }
+
+    implicit def jsonWritesApidocApiDiffNonBreaking: play.api.libs.json.Writes[DiffNonBreaking] = {
+      new play.api.libs.json.Writes[io.apibuilder.api.v0.models.DiffNonBreaking] {
+        def writes(obj: io.apibuilder.api.v0.models.DiffNonBreaking) = {
+          jsObjectDiffNonBreaking(obj)
+        }
+      }
     }
 
     implicit def jsonReadsApidocApiDomain: play.api.libs.json.Reads[Domain] = {
@@ -1942,8 +1966,8 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectDiff(obj: io.apibuilder.api.v0.models.Diff): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.api.v0.models.DiffBreaking => jsObjectDiffBreaking(x) ++ play.api.libs.json.Json.obj("type" -> "diff_breaking")
-        case x: io.apibuilder.api.v0.models.DiffNonBreaking => jsObjectDiffNonBreaking(x) ++ play.api.libs.json.Json.obj("type" -> "diff_non_breaking")
+        case x: io.apibuilder.api.v0.models.DiffBreaking => jsObjectDiffBreaking(x)
+        case x: io.apibuilder.api.v0.models.DiffNonBreaking => jsObjectDiffNonBreaking(x)
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
         }
@@ -1969,7 +1993,7 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectItemDetail(obj: io.apibuilder.api.v0.models.ItemDetail): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.api.v0.models.ApplicationSummary => jsObjectApplicationSummary(x) ++ play.api.libs.json.Json.obj("type" -> "application_summary")
+        case x: io.apibuilder.api.v0.models.ApplicationSummary => jsObjectApplicationSummary(x)
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
         }

--- a/lib/src/test/resources/generators/play-27-apidoc-api.txt
+++ b/lib/src/test/resources/generators/play-27-apidoc-api.txt
@@ -766,7 +766,11 @@ package io.apibuilder.api.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.OriginalType(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "original_type").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.OriginalType(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }
@@ -796,7 +800,11 @@ package io.apibuilder.api.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.Publication(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "publication").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.Publication(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }
@@ -826,7 +834,11 @@ package io.apibuilder.api.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.Visibility(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "visibility").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.Visibility(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }

--- a/lib/src/test/resources/generators/play-27-apidoc-api.txt
+++ b/lib/src/test/resources/generators/play-27-apidoc-api.txt
@@ -927,7 +927,15 @@ package io.apibuilder.api.v0.models {
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
         "organization" -> io.apibuilder.common.v0.models.json.jsObjectReference(obj.organization),
         "key" -> play.api.libs.json.JsString(obj.key)
-      )
+      ) ++ play.api.libs.json.Json.obj("type" -> "application_summary")
+    }
+
+    implicit def jsonWritesApidocApiApplicationSummary: play.api.libs.json.Writes[ApplicationSummary] = {
+      new play.api.libs.json.Writes[io.apibuilder.api.v0.models.ApplicationSummary] {
+        def writes(obj: io.apibuilder.api.v0.models.ApplicationSummary) = {
+          jsObjectApplicationSummary(obj)
+        }
+      }
     }
 
     implicit def jsonReadsApidocApiAttribute: play.api.libs.json.Reads[Attribute] = {
@@ -1155,7 +1163,15 @@ package io.apibuilder.api.v0.models {
     def jsObjectDiffBreaking(obj: io.apibuilder.api.v0.models.DiffBreaking): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "description" -> play.api.libs.json.JsString(obj.description)
-      )
+      ) ++ play.api.libs.json.Json.obj("type" -> "diff_breaking")
+    }
+
+    implicit def jsonWritesApidocApiDiffBreaking: play.api.libs.json.Writes[DiffBreaking] = {
+      new play.api.libs.json.Writes[io.apibuilder.api.v0.models.DiffBreaking] {
+        def writes(obj: io.apibuilder.api.v0.models.DiffBreaking) = {
+          jsObjectDiffBreaking(obj)
+        }
+      }
     }
 
     implicit def jsonReadsApidocApiDiffNonBreaking: play.api.libs.json.Reads[DiffNonBreaking] = {
@@ -1165,7 +1181,15 @@ package io.apibuilder.api.v0.models {
     def jsObjectDiffNonBreaking(obj: io.apibuilder.api.v0.models.DiffNonBreaking): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "description" -> play.api.libs.json.JsString(obj.description)
-      )
+      ) ++ play.api.libs.json.Json.obj("type" -> "diff_non_breaking")
+    }
+
+    implicit def jsonWritesApidocApiDiffNonBreaking: play.api.libs.json.Writes[DiffNonBreaking] = {
+      new play.api.libs.json.Writes[io.apibuilder.api.v0.models.DiffNonBreaking] {
+        def writes(obj: io.apibuilder.api.v0.models.DiffNonBreaking) = {
+          jsObjectDiffNonBreaking(obj)
+        }
+      }
     }
 
     implicit def jsonReadsApidocApiDomain: play.api.libs.json.Reads[Domain] = {
@@ -1942,8 +1966,8 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectDiff(obj: io.apibuilder.api.v0.models.Diff): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.api.v0.models.DiffBreaking => jsObjectDiffBreaking(x) ++ play.api.libs.json.Json.obj("type" -> "diff_breaking")
-        case x: io.apibuilder.api.v0.models.DiffNonBreaking => jsObjectDiffNonBreaking(x) ++ play.api.libs.json.Json.obj("type" -> "diff_non_breaking")
+        case x: io.apibuilder.api.v0.models.DiffBreaking => jsObjectDiffBreaking(x)
+        case x: io.apibuilder.api.v0.models.DiffNonBreaking => jsObjectDiffNonBreaking(x)
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
         }
@@ -1969,7 +1993,7 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectItemDetail(obj: io.apibuilder.api.v0.models.ItemDetail): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.api.v0.models.ApplicationSummary => jsObjectApplicationSummary(x) ++ play.api.libs.json.Json.obj("type" -> "application_summary")
+        case x: io.apibuilder.api.v0.models.ApplicationSummary => jsObjectApplicationSummary(x)
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
         }

--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -164,7 +164,11 @@ package io.apibuilder.reference.api.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.reference.api.v0.models.AgeGroup(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "age_group").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.reference.api.v0.models.AgeGroup(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -164,7 +164,11 @@ package io.apibuilder.reference.api.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.reference.api.v0.models.AgeGroup(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "age_group").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.reference.api.v0.models.AgeGroup(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -165,7 +165,11 @@ package io.apibuilder.reference.api.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.reference.api.v0.models.AgeGroup(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "age_group").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.reference.api.v0.models.AgeGroup(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -165,7 +165,11 @@ package io.apibuilder.reference.api.v0.models {
           case _ => {
             (js \ "value").validate[String] match {
               case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.reference.api.v0.models.AgeGroup(v))
-              case err: play.api.libs.json.JsError => err
+              case err: play.api.libs.json.JsError =>
+                (js \ "age_group").validate[String] match {
+                  case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(io.apibuilder.reference.api.v0.models.AgeGroup(v))
+                  case err: play.api.libs.json.JsError => err
+                }
             }
           }
         }

--- a/lib/src/test/resources/play2enums-json-example.txt
+++ b/lib/src/test/resources/play2enums-json-example.txt
@@ -5,7 +5,11 @@ implicit val jsonReadsAPIBuilderTestAgeGroup = new play.api.libs.json.Reads[test
       case _ => {
         (js \ "value").validate[String] match {
           case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(test.apidoc.apidoctest.v0.models.AgeGroup(v))
-          case err: play.api.libs.json.JsError => err
+          case err: play.api.libs.json.JsError =>
+            (js \ "age_group").validate[String] match {
+              case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(test.apidoc.apidoctest.v0.models.AgeGroup(v))
+              case err: play.api.libs.json.JsError => err
+            }
         }
       }
     }
@@ -35,7 +39,11 @@ implicit val jsonReadsAPIBuilderTestGenre = new play.api.libs.json.Reads[test.ap
       case _ => {
         (js \ "value").validate[String] match {
           case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(test.apidoc.apidoctest.v0.models.Genre(v))
-          case err: play.api.libs.json.JsError => err
+          case err: play.api.libs.json.JsError =>
+            (js \ "genre").validate[String] match {
+              case play.api.libs.json.JsSuccess(v, _) => play.api.libs.json.JsSuccess(test.apidoc.apidoctest.v0.models.Genre(v))
+              case err: play.api.libs.json.JsError => err
+            }
         }
       }
     }

--- a/lib/src/test/resources/scala-union-models-json.txt
+++ b/lib/src/test/resources/scala-union-models-json.txt
@@ -18,6 +18,14 @@ def jsObjectGuestUser(obj: test.apidoc.apidoctest.v0.models.GuestUser): play.api
   })
 }
 
+implicit def jsonWritesAPIBuilderTestGuestUser: play.api.libs.json.Writes[GuestUser] = {
+  new play.api.libs.json.Writes[test.apidoc.apidoctest.v0.models.GuestUser] {
+    def writes(obj: test.apidoc.apidoctest.v0.models.GuestUser) = {
+      jsObjectGuestUser(obj)
+    }
+  }
+}
+
 implicit def jsonReadsAPIBuilderTestRegisteredUser: play.api.libs.json.Reads[RegisteredUser] = {
   for {
     id <- (__ \ "id").read[Long]
@@ -36,6 +44,14 @@ def jsObjectRegisteredUser(obj: test.apidoc.apidoctest.v0.models.RegisteredUser)
     case None => play.api.libs.json.Json.obj()
     case Some(x) => play.api.libs.json.Json.obj("name" -> play.api.libs.json.JsString(x))
   })
+}
+
+implicit def jsonWritesAPIBuilderTestRegisteredUser: play.api.libs.json.Writes[RegisteredUser] = {
+  new play.api.libs.json.Writes[test.apidoc.apidoctest.v0.models.RegisteredUser] {
+    def writes(obj: test.apidoc.apidoctest.v0.models.RegisteredUser) = {
+      jsObjectRegisteredUser(obj)
+    }
+  }
 }
 
 implicit def jsonReadsAPIBuilderTestUser: play.api.libs.json.Reads[User] = {

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -179,7 +179,15 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
       ) ++ (obj.email match {
         case None => play.api.libs.json.Json.obj()
         case Some(x) => play.api.libs.json.Json.obj("email" -> play.api.libs.json.JsString(x))
-      })
+      }) ++ play.api.libs.json.Json.obj("discriminator" -> "guest_user")
+    }
+
+    implicit def jsonWritesApidocExampleUnionTypesDiscriminatorGuestUser: play.api.libs.json.Writes[GuestUser] = {
+      new play.api.libs.json.Writes[io.apibuilder.example.union.types.discriminator.v0.models.GuestUser] {
+        def writes(obj: io.apibuilder.example.union.types.discriminator.v0.models.GuestUser) = {
+          jsObjectGuestUser(obj)
+        }
+      }
     }
 
     implicit def jsonReadsApidocExampleUnionTypesDiscriminatorRegisteredUser: play.api.libs.json.Reads[RegisteredUser] = {
@@ -193,7 +201,15 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
       play.api.libs.json.Json.obj(
         "id" -> play.api.libs.json.JsString(obj.id),
         "email" -> play.api.libs.json.JsString(obj.email)
-      )
+      ) ++ play.api.libs.json.Json.obj("discriminator" -> "registered_user")
+    }
+
+    implicit def jsonWritesApidocExampleUnionTypesDiscriminatorRegisteredUser: play.api.libs.json.Writes[RegisteredUser] = {
+      new play.api.libs.json.Writes[io.apibuilder.example.union.types.discriminator.v0.models.RegisteredUser] {
+        def writes(obj: io.apibuilder.example.union.types.discriminator.v0.models.RegisteredUser) = {
+          jsObjectRegisteredUser(obj)
+        }
+      }
     }
 
     implicit def jsonReadsApidocExampleUnionTypesDiscriminatorUserString: play.api.libs.json.Reads[UserString] = {
@@ -214,8 +230,8 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
 
     def jsObjectUser(obj: io.apibuilder.example.union.types.discriminator.v0.models.User): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.example.union.types.discriminator.v0.models.RegisteredUser => jsObjectRegisteredUser(x) ++ play.api.libs.json.Json.obj("discriminator" -> "registered_user")
-        case x: io.apibuilder.example.union.types.discriminator.v0.models.GuestUser => jsObjectGuestUser(x) ++ play.api.libs.json.Json.obj("discriminator" -> "guest_user")
+        case x: io.apibuilder.example.union.types.discriminator.v0.models.RegisteredUser => jsObjectRegisteredUser(x)
+        case x: io.apibuilder.example.union.types.discriminator.v0.models.GuestUser => jsObjectGuestUser(x)
         case x: io.apibuilder.example.union.types.discriminator.v0.models.SystemUser => play.api.libs.json.Json.obj("discriminator" -> "system_user", "value" -> play.api.libs.json.JsString(x.toString))
         case x: io.apibuilder.example.union.types.discriminator.v0.models.UserString => play.api.libs.json.Json.obj("discriminator" -> "string", "value" -> play.api.libs.json.JsString(x.value))
         case other => {

--- a/lib/src/test/resources/union-types-discriminator-service-play-27.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-27.txt
@@ -379,6 +379,7 @@ package io.apibuilder.example.union.types.discriminator.v0 {
   }
 
   class Client(
+    ws: play.api.libs.ws.WSClient,
     val baseUrl: String,
     auth: scala.Option[io.apibuilder.example.union.types.discriminator.v0.Authorization] = None,
     defaultHeaders: Seq[(String, String)] = Nil
@@ -426,13 +427,12 @@ package io.apibuilder.example.union.types.discriminator.v0 {
     }
 
     def _requestHolder(path: String): play.api.libs.ws.WSRequest = {
-      import play.api.Play.current
 
-      val holder = play.api.libs.ws.WS.url(baseUrl + path).withHeaders(
+      val holder = ws.url(baseUrl + path).addHttpHeaders(
         "User-Agent" -> Constants.UserAgent,
         "X-Apidoc-Version" -> Constants.Version,
         "X-Apidoc-Version-Major" -> Constants.VersionMajor.toString
-      ).withHeaders(defaultHeaders : _*)
+      ).addHttpHeaders(defaultHeaders : _*)
       auth.fold(holder) {
         case Authorization.Basic(username, password) => {
           holder.withAuth(username, password.getOrElse(""), play.api.libs.ws.WSAuthScheme.BASIC)
@@ -462,28 +462,28 @@ package io.apibuilder.example.union.types.discriminator.v0 {
     ): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).get()
+          _logRequest("GET", _requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*)).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("POST", _requestHolder(path).addHttpHeaders(_withJsonContentType(requestHeaders):_*).addQueryStringParameters(queryParameters:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withHeaders(_withJsonContentType(requestHeaders):_*).withQueryString(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("PUT", _requestHolder(path).addHttpHeaders(_withJsonContentType(requestHeaders):_*).addQueryStringParameters(queryParameters:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("PATCH", _requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).delete()
+          _logRequest("DELETE", _requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*)).delete()
         }
          case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).head()
+          _logRequest("HEAD", _requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*)).head()
         }
          case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*)).options()
+          _logRequest("OPTIONS", _requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*)).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withHeaders(requestHeaders:_*).withQueryString(queryParameters:_*))
+          _logRequest(method, _requestHolder(path).addHttpHeaders(requestHeaders:_*).addQueryStringParameters(queryParameters:_*))
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/scala-generator/src/main/scala/models/Play2Json.scala
+++ b/scala-generator/src/main/scala/models/Play2Json.scala
@@ -349,6 +349,8 @@ case class Play2Json(
 
     val (optionalFields, requiredFields) = model.fields.partition { f => isOption(f.datatype) }
 
+    val discriminatorOpt = getDiscriminator(model)
+
     val base = Seq(
       Seq(
         s"def $method(obj: ${model.qualifiedName}): play.api.libs.json.JsObject = {",
@@ -367,24 +369,36 @@ case class Play2Json(
             fields.map { field =>
               getJsonObject(field.originalName, field.datatype, s"obj.${field.name}").obj
             }.mkString("(", ") ++\n(", ")")
-          }
+          },
+          discriminatorOpt.map(createJsonObject)
         ).flatten.mkString(" ++ ").indent(2),
         "}"
       ).mkString("\n")
     ).mkString("\n\n")
 
-    ssd.unionsForModel(model) match {
-      case Nil => {
-        Seq(
-          base,
-          play2JsonCommon.implicitWriter(model.name, model.qualifiedName, method)
-        ).mkString("\n\n")
-      }
-      case _ => {
-        // Let the implicit for the associated union handle the serialization
-        base
-      }
-    }
+    Seq(
+      base,
+      play2JsonCommon.implicitWriter(model.name, model.qualifiedName, method)
+    ).mkString("\n\n")
+  }
+
+  private[this] def getDiscriminator(model: ScalaModel): Option[Discriminator] =
+    getDiscriminator(model, ssd.unionAndTypesForModel(model))
+
+  private[this] def getDiscriminator(
+    model: ScalaModel,
+    unionAndTypes: Seq[(ScalaUnion, ScalaUnionType)]
+  ): Option[Discriminator] = {
+    val discriminatorNameValues =
+      unionAndTypes
+      .map { case (union, unionType) => (union.discriminator, unionType.discriminatorName) }
+      .distinct
+
+    if (discriminatorNameValues.size > 1) {
+      val nvs = discriminatorNameValues.map { case (n, v) => (n.getOrElse("''"), v) }.mkString(", ")
+      sys.error(s"Model ${model.qualifiedName} must have a unique discriminator name and values. Found: $nvs")
+    } else
+      discriminatorNameValues.headOption.flatMap { case (name, v) => name.map(Discriminator(_, v)) }
   }
 
   private[this] def nilToOption[T](values: Seq[T]): Option[Seq[T]] = {
@@ -471,9 +485,11 @@ case class Play2Json(
     )
   }
 
-  private[this] def createJsonObject(name: String, value: String): String = {
+  private[this] def createJsonObject(discriminator: Discriminator): String =
+    createJsonObject(discriminator.name, s""""${discriminator.value}"""")
+
+  private[this] def createJsonObject(name: String, value: String): String =
     s"""play.api.libs.json.Json.obj("$name" -> $value)"""
-  }
 
   /**
    * Assumes all primitives are wrapped in primitive wrappers
@@ -513,13 +529,13 @@ case class Play2Json(
         }
       }
       case ScalaPrimitive.Model(ns, name) => {
-        mergeDiscriminator(play2JsonCommon.toJsonObjectMethodName(ns, name) + s"($varName)", discriminator)
+        play2JsonCommon.toJsonObjectMethodName(ns, name) + s"($varName)"
       }
       case ScalaPrimitive.Union(ns, name) => {
-        mergeDiscriminator(play2JsonCommon.toJsonObjectMethodName(ns, name) + s"($varName)", discriminator)
+        play2JsonCommon.toJsonObjectMethodName(ns, name) + s"($varName)"
       }
       case ScalaDatatype.List(_) | ScalaDatatype.Map(_) | ScalaDatatype.Option(_) | ScalaPrimitive.Unit => {
-        mergeDiscriminator(s"play.api.libs.json.Json.toJson($varName)", discriminator)
+        s"play.api.libs.json.Json.toJson($varName)"
       }
     }
   }
@@ -534,20 +550,6 @@ case class Play2Json(
       }
       case Some(disc) => {
         s"""play.api.libs.json.Json.obj("${disc.name}" -> "${disc.value}", "${PrimitiveWrapper.FieldName}" -> $value)"""
-      }
-    }
-  }
-
-  private[this] def mergeDiscriminator(
-    value: String,
-    discriminator: Option[Discriminator]
-  ): String = {
-    discriminator match {
-      case None => {
-        value
-      }
-      case Some(disc) => {
-        s"$value ++ " + createJsonObject(disc.name, s""""${disc.value}"""")
       }
     }
   }

--- a/scala-generator/src/main/scala/models/generator/ScalaService.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaService.scala
@@ -62,17 +62,18 @@ class ScalaService(
   def unionsForModel(model: ScalaModel): Seq[ScalaUnion] =
     unionAndTypesForModel(model).map { case (u, _) => u }
 
-  def unionAndTypesForModel(model: ScalaModel): Seq[(ScalaUnion, ScalaUnionType)] = {
+  def unionAndTypesForModel(model: ScalaModel): Seq[(ScalaUnion, ScalaUnionType)] =
     unions.flatMap { u =>
       u.types.find(_.model.map(_.fullName).contains(model.qualifiedName)).map(u -> _)
     }
-  }
 
-  def unionsForEnum(enum: ScalaEnum): Seq[ScalaUnion] = {
-    unions.filter { u =>
-      u.types.flatMap(_.enum.map(_.fullName)).contains(enum.qualifiedName)
+  def unionsForEnum(enum: ScalaEnum): Seq[ScalaUnion] =
+    unionsAndTypesForEnum(enum).map { case (u, _) => u }
+
+  def unionsAndTypesForEnum(enum: ScalaEnum): Seq[(ScalaUnion, ScalaUnionType)] =
+    unions.flatMap { u =>
+      u.types.find(_.enum.map(_.fullName).contains(enum.qualifiedName)).map(u -> _)
     }
-  }
 
   def unionsForUnion(union: ScalaUnion): Seq[ScalaUnion] = {
     unions.filter { u =>

--- a/scala-generator/src/main/scala/models/generator/ScalaService.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaService.scala
@@ -59,9 +59,12 @@ class ScalaService(
     convertObjectType(scalaTypeResolver.scalaDatatype(t))
   }
 
-  def unionsForModel(model: ScalaModel): Seq[ScalaUnion] = {
-    unions.filter { u =>
-      u.types.flatMap(_.model.map(_.fullName)).contains(model.qualifiedName)
+  def unionsForModel(model: ScalaModel): Seq[ScalaUnion] =
+    unionAndTypesForModel(model).map { case (u, _) => u }
+
+  def unionAndTypesForModel(model: ScalaModel): Seq[(ScalaUnion, ScalaUnionType)] = {
+    unions.flatMap { u =>
+      u.types.find(_.model.map(_.fullName).contains(model.qualifiedName)).map(u -> _)
     }
   }
 

--- a/scala-generator/src/test/scala/models/ExampleUnionTypesWithDiscriminatorSpec.scala
+++ b/scala-generator/src/test/scala/models/ExampleUnionTypesWithDiscriminatorSpec.scala
@@ -17,4 +17,14 @@ class ExampleUnionTypesWithDiscriminatorSpec extends FunSpec with Matchers {
     }
   }
 
+  it("generates expected code for play 2.7 client") {
+    Play27ClientGenerator.invoke(InvocationForm(service = service)) match {
+      case Left(errors) => fail(errors.mkString(", "))
+      case Right(sourceFiles) => {
+        sourceFiles.size shouldBe 1
+        models.TestHelper.assertEqualsFile("/union-types-discriminator-service-play-27.txt", sourceFiles.head.contents)
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Four changes:

 - always write a model in a union type with its discriminator
 - always write an enum in a union type with its discriminator
 - always generate the implicit writer for the models in a union type 
 - add a fallback read for enum types, in case they are part of a union type without a discriminator

This is a preliminary change to providing a Play 2.8 generator, where `Writes` is no longer contravariant, but invariant.

This change is related to the validation: https://github.com/apicollective/apibuilder/pull/819