### PR TITLE
Play typed controller v2

### DIFF
--- a/generator/app/controllers/Generators.scala
+++ b/generator/app/controllers/Generators.scala
@@ -221,13 +221,13 @@ object Generators {
     ),
     CodeGenTarget(
       metaData = Generator(
-        key = "play_2_x_controllers",
-        name = "Play 2.x controllers",
+        key = "play_2_6_controllers",
+        name = "Play 2.6 controllers",
         description = Some("""Generate Play Controllers for the resources."""),
         language = Some("Scala")
       ),
       status = lib.generator.Status.InDevelopment,
-      codeGenerator = Some(scala.models.Play2Controllers)
+      codeGenerator = Some(scala.models.Play26Controllers)
     ),
     CodeGenTarget(
       metaData = Generator(

--- a/scala-generator/src/main/scala/models/Play26Controllers.scala
+++ b/scala-generator/src/main/scala/models/Play26Controllers.scala
@@ -77,7 +77,7 @@ object Play26Controllers extends CodeGenerator {
   def controller(resource: ScalaResource) =
     s"""
       trait ${resource.plural}Controller extends play.api.mvc.BaseController {
-        ${resource.operations.map(controllerMethod).mkString("\n")}
+        ${resource.operations.map(controllerMethod).mkString("\n\n")}
       }
     """
 

--- a/scala-generator/src/main/scala/models/Play26Controllers.scala
+++ b/scala-generator/src/main/scala/models/Play26Controllers.scala
@@ -7,7 +7,7 @@ import io.apibuilder.generator.v0.models.{File, InvocationForm}
 import io.apibuilder.spec.v0.models._
 import scala.generator._
 
-object Play2Controllers extends CodeGenerator {
+object Play26Controllers extends CodeGenerator {
 
   def importJson(`import`: Import) =
     s"import ${`import`.namespace}.models.json._"

--- a/scala-generator/src/main/scala/models/Play2Controllers.scala
+++ b/scala-generator/src/main/scala/models/Play2Controllers.scala
@@ -9,27 +9,6 @@ import scala.generator._
 
 object Play2Controllers extends CodeGenerator {
 
-  def moduleBindExample(resource: ScalaResource) =
-    s"bind(classOf[controllers.${serviceName(resource)}]).to(classOf[controllers.${serviceName(resource)}Impl])"
-
-  def moduleExample(resources: Seq[ScalaResource]) =
-  s"""
-    /*
-     * Play Framework - dependency injection example
-     *
-     * class Module extends com.google.inject.AbstractModule {
-     *   override def configure() = {
-     *     ${resources.map(moduleBindExample).mkString("\n *     ")}
-     *
-     *     ()
-     *   }
-     * }
-     *
-     *
-     * For more information: https://www.playframework.com/documentation/2.0.x/ScalaDependencyInjection
-     */
-  """
-
   def importJson(`import`: Import) =
     s"import ${`import`.namespace}.models.json._"
 
@@ -39,6 +18,8 @@ object Play2Controllers extends CodeGenerator {
       ${ssd.service.imports.map(importJson).mkString("\n")}
     """
 
+  def responseEnumName(operation: ScalaOperation) = s"${operation.name.capitalize}"
+
   def responseObjectCode(response: ScalaResponse) = response.code match {
     case ResponseCodeInt(code) => Some(code)
     case _ => None
@@ -46,81 +27,57 @@ object Play2Controllers extends CodeGenerator {
 
   def responseObjectName(response: ScalaResponse) = responseObjectCode(response).map(code => s"HTTP${code}")
 
-  def responseObject(resource: ScalaResource, operation: ScalaOperation, response: ScalaResponse) = (responseObjectName(response), response.isUnit) match {
-    case (Some(name), true) => Some(s"case object ${name} extends ${responsesTraitName(resource, operation)}")
-    case (Some(name), false) => Some(s"case class ${name}(body: ${response.datatype.name}) extends ${responsesTraitName(resource, operation)}")
+  def responseObject(operation: ScalaOperation, response: ScalaResponse) = (responseObjectName(response), response.isUnit) match {
+    case (Some(name), true) => Some(s"case object ${name} extends ${responseEnumName(operation)}")
+    case (Some(name), false) => Some(s"case class ${name}(body: ${response.datatype.name}) extends ${responseEnumName(operation)}")
     case _ => None
   }
 
-  def responsesTraitName(resource: ScalaResource, operation: ScalaOperation) = s"${resource.plural}${operation.name.capitalize}Responses"
-  def responsesTraitAndObject(resource: ScalaResource, operation: ScalaOperation) =
+  def responses(operation: ScalaOperation) =
     s"""
-      trait ${responsesTraitName(resource, operation)}
-      object ${responsesTraitName(resource, operation)} {
-        ${operation.responses.flatMap(responseObject(resource, operation, _)).mkString("\n")}
+      sealed trait ${responseEnumName(operation)} extends Product with Serializable
+      object ${responseEnumName(operation)} {
+        ${operation.responses.flatMap(responseObject(operation, _)).mkString("\n")}
       }
     """
 
-  def responses(resources: Seq[ScalaResource]) =
-    resources
-      .flatMap(r => r.operations.map((r, _)))
-      .map { case (r, o) => responsesTraitAndObject(r, o) }
-      .mkString("\n\n")
-
-  def serviceName(resource: ScalaResource) = s"${resource.plural}Service"
-  def serviceMethod(resource: ScalaResource, operation: ScalaOperation) = {
-    val parameters =
-      List(s"""request: play.api.mvc.Request[${operation.body.fold("play.api.mvc.AnyContent")(_.datatype.name)}]""") ++
-      operation.parameters.map(p => s"${p.name}: ${p.datatype.name}") ++
-      operation.body.map(body => s"body: ${body.datatype.name}").toList
-
-    s"""def ${operation.name}(${parameters.mkString(", ")}): scala.concurrent.Future[${responsesTraitName(resource, operation)}]"""
-  }
-
-  def service(resource: ScalaResource) =
-    s"""
-      trait ${serviceName(resource)} {
-        ${resource.operations.map(serviceMethod(resource, _)).mkString("\n")}
-      }
-    """
-
-  def services(resources: Seq[ScalaResource]) = resources.map(service).mkString("\n\n")
-
-  def controllerMethodResponse(resource: ScalaResource, operation: ScalaOperation, response: ScalaResponse) =
+  def responseToPlay(operation: ScalaOperation, response: ScalaResponse) =
     (responseObjectName(response), responseObjectCode(response), response.isUnit) match {
-      case (Some(name), Some(code), true) => Some(s"case ${responsesTraitName(resource, operation)}.${name} => Status(${code})(play.api.mvc.Results.EmptyContent())")
-      case (Some(name), Some(code), false) => Some(s"case ${responsesTraitName(resource, operation)}.${name}(body) => Status(${code})(play.api.libs.json.Json.toJson(body))")
+      case (Some(name), Some(code), true) => Some(s"case ${responseEnumName(operation)}.${name} => Status(${code})(play.api.mvc.Results.EmptyContent())")
+      case (Some(name), Some(code), false) => Some(s"case ${responseEnumName(operation)}.${name}(body) => Status(${code})(play.api.libs.json.Json.toJson(body))")
       case _ => None
     }
 
-  def controllerMethod(resource: ScalaResource, operation: ScalaOperation) = {
+  def controllerMethod(operation: ScalaOperation) = {
     val bodyParser = operation.body.fold("")(body => s"(parse.json[${body.datatype.name}])")
 
-    val parameters =
+    val parameterNames =
       List("request") ++
       operation.parameters.map(_.name) ++
       operation.body.map(_ => "request.body").toList
 
+    val parameterNameAndTypes =
+      List(s"""request: play.api.mvc.Request[${operation.body.fold("play.api.mvc.AnyContent")(_.datatype.name)}]""") ++
+      operation.parameters.map(p => s"${p.name}: ${p.datatype.name}") ++
+      operation.body.map(body => s"body: ${body.datatype.name}").toList
+
     s"""
-      def ${operation.name}(${operation.parameters.map(p => s"${p.name}: ${p.datatype.name}").mkString(", ")}): play.api.mvc.Handler = Action.async${bodyParser} { request =>
-        service.${operation.name}(${parameters.mkString(", ")}).map {
-          ${operation.responses.flatMap(controllerMethodResponse(resource, operation, _)).mkString("\n")}
-        }(executor)
+      ${responses(operation)}
+
+      def ${operation.name}(${parameterNameAndTypes.mkString(", ")}): scala.concurrent.Future[${responseEnumName(operation)}]
+      final def ${operation.name}(${operation.parameters.map(p => s"${p.name}: ${p.datatype.name}").mkString(", ")}): play.api.mvc.Handler = Action.async${bodyParser} { request =>
+        ${operation.name}(${parameterNames.mkString(", ")})
+          .map {
+            ${operation.responses.flatMap(responseToPlay(operation, _)).mkString("\n")}
+          }(defaultExecutionContext)
       }
     """
   }
 
   def controller(resource: ScalaResource) =
     s"""
-      @javax.inject.Singleton
-      class ${resource.plural} @javax.inject.Inject()(
-          service: ${serviceName(resource)},
-          cc: play.api.mvc.ControllerComponents,
-          executor: scala.concurrent.ExecutionContext,
-        ) extends play.api.mvc.AbstractController(cc) {
-
-        ${resource.operations.map(controllerMethod(resource, _)).mkString("\n")}
-
+      trait ${resource.plural}Controller extends play.api.mvc.BaseController {
+        ${resource.operations.map(controllerMethod).mkString("\n")}
       }
     """
 
@@ -129,15 +86,9 @@ object Play2Controllers extends CodeGenerator {
   def fileContents(form: InvocationForm, ssd: ScalaService): String =
     s"""
       ${ApidocComments(form.service.version, form.userAgent).toJavaString()}
-      package controllers
-
-      ${moduleExample(ssd.resources)}
+      package ${ssd.namespaces.base}.controllers
 
       ${imports(ssd)}
-
-      ${responses(ssd.resources)}
-
-      ${services(ssd.resources)}
 
       ${controllers(ssd.resources)}
     """

--- a/scala-generator/src/test/scala/models/Play26ControllersSpec.scala
+++ b/scala-generator/src/test/scala/models/Play26ControllersSpec.scala
@@ -6,10 +6,10 @@ import models.TestHelper._
 import org.scalatest.{FunSpec, Matchers}
 import scala.util.matching.Regex
 
-class Play2ControllersSpec extends FunSpec with Matchers {
+class Play26ControllersSpec extends FunSpec with Matchers {
 
   def fileContent(service: Service): File =
-    Play2Controllers.invoke(InvocationForm(service))
+    Play26Controllers.invoke(InvocationForm(service))
       .fold(
         { msgs => Left(new Throwable(s"Generated errors: ${msgs.mkString("\n  - ", "\n  - ", "")}")) },
         {

--- a/scala-generator/src/test/scala/models/Play2ControllersSpec.scala
+++ b/scala-generator/src/test/scala/models/Play2ControllersSpec.scala
@@ -26,12 +26,11 @@ class Play2ControllersSpec extends FunSpec with Matchers {
   }
 
   def importCount(service: Service): Int = count("import ".r, service)
-  def responseCount(service: Service): Int = count("trait [^ ]+Responses".r, service)
+  def controllerCount(service: Service): Int = count("play\\.api\\.mvc\\.BaseController".r, service)
+  def responseCount(service: Service): Int = count("sealed trait [^ ]+".r, service)
   def responseImplementationCount(service: Service): Int = count("case (class|object) HTTP[0-9]+".r, service)
-  def serviceCount(service: Service): Int = count("trait [^ ]+Service".r, service)
-  def serviceMethodCount(service: Service): Int = count("scala\\.concurrent\\.Future".r, service)
-  def controllerCount(service: Service): Int = count("@javax\\.inject\\.Singleton".r, service)
-  def controllerMethodCount(service: Service): Int = count("Action\\.async".r, service)
+  def methodFinalCount(service: Service): Int = count("play\\.api\\.mvc\\.Handler".r, service)
+  def methodAbstractCount(service: Service): Int = count("scala\\.concurrent\\.Future".r, service)
 
   describe("for all services") {
     List(
@@ -39,7 +38,7 @@ class Play2ControllersSpec extends FunSpec with Matchers {
       referenceApiService,
       referenceWithImportsApiService,
       generatorApiService,
-      // apidocApiService,
+      apidocApiService,
       dateTimeService,
       builtInTypesService,
       generatorApiServiceWithUnionAndDescriminator,
@@ -51,6 +50,10 @@ class Play2ControllersSpec extends FunSpec with Matchers {
           assert(importCount(service) == 1 + service.imports.size)
         }
 
+        it("generates all controllers") {
+          assert(controllerCount(service) == service.resources.size)
+        }
+
         it("generates all responses") {
           assert(responseCount(service) == service.resources.flatMap(_.operations).size)
         }
@@ -59,20 +62,12 @@ class Play2ControllersSpec extends FunSpec with Matchers {
           assert(responseImplementationCount(service) == service.resources.flatMap(_.operations).flatMap(_.responses).size)
         }
 
-        it("generates all services") {
-          assert(serviceCount(service) == service.resources.size)
+        it("generates all methods final") {
+          assert(methodFinalCount(service) == service.resources.flatMap(_.operations).size)
         }
 
-        it("generates all service methods") {
-          assert(serviceMethodCount(service) == service.resources.flatMap(_.operations).size)
-        }
-
-        it("generates all controllers") {
-          assert(controllerCount(service) == service.resources.size)
-        }
-
-        it("generates all controller methods") {
-          assert(controllerMethodCount(service) == service.resources.flatMap(_.operations).size)
+        it("generates all methods abstract") {
+          assert(methodAbstractCount(service) == service.resources.flatMap(_.operations).size)
         }
       }
     }


### PR DESCRIPTION
Responds to limits and criticism from https://github.com/flowcommerce/user/pull/575

```scala
/**
  * Generated by API Builder - https://www.apibuilder.io
  * Service version: 0.7.58
  */
package io.flow.healthcheck.v0.controllers

import io.flow.healthcheck.v0.models.json._
import io.flow.error.v0.models.json._

trait HealthchecksController extends play.api.mvc.BaseController {

  sealed trait GetHealthcheck extends Product with Serializable
  object GetHealthcheck {
    case class HTTP200(body: io.flow.healthcheck.v0.models.Healthcheck) extends GetHealthcheck
    case class HTTP422(body: io.flow.error.v0.models.GenericError) extends GetHealthcheck
  }

  def getHealthcheck(request: play.api.mvc.Request[play.api.mvc.AnyContent]): scala.concurrent.Future[GetHealthcheck]
  final def getHealthcheck(): play.api.mvc.Handler = Action.async { request =>
    getHealthcheck(request)
      .map {
        case GetHealthcheck.HTTP200(body) => Status(200)(play.api.libs.json.Json.toJson(body))
        case GetHealthcheck.HTTP422(body) => Status(422)(play.api.libs.json.Json.toJson(body))
      }(defaultExecutionContext)
  }

}
```