### PR TITLE
Add controller specific execution context

### DIFF
--- a/scala-generator/src/main/scala/models/Play26Controllers.scala
+++ b/scala-generator/src/main/scala/models/Play26Controllers.scala
@@ -50,11 +50,12 @@ object Play26Controllers extends CodeGenerator {
       }
     """
 
+  def executionContextName(resource: ScalaResource) = s"${resource.plural}ExecutionContext"
   def executionContext(resource: ScalaResource) =
     s"""
       @javax.inject.Singleton
-      class ${resource.plural}ExecutionContext @javax.inject.Inject()(system: akka.actor.ActorSystem)
-        extends play.api.libs.concurrent.CustomExecutionContext(system, "${resource.namespaces.controllers}.${controllerName(resource)}")
+      class ${executionContextName(resource)} @javax.inject.Inject()(system: akka.actor.ActorSystem)
+        extends play.api.libs.concurrent.CustomExecutionContext(system, "${resource.namespaces.controllers}.${executionContextName(resource)}")
     """
 
   def responseToPlay(operation: ScalaOperation, response: ScalaResponse) =
@@ -90,14 +91,13 @@ object Play26Controllers extends CodeGenerator {
     """
   }
 
-  def controllerName(resource: ScalaResource) = s"${resource.plural}Controller"
   def controller(resource: ScalaResource) =
     s"""
       ${executionContext(resource)}
 
       ${responses(resource)}
 
-      trait ${controllerName(resource)} extends ${responsesName(resource)} with play.api.mvc.BaseController {
+      trait ${resource.plural}Controller extends ${responsesName(resource)} with play.api.mvc.BaseController {
         ${resource.operations.map(controllerMethod).mkString("\n\n")}
       }
     """

--- a/scala-generator/src/main/scala/models/generator/Namespaces.scala
+++ b/scala-generator/src/main/scala/models/generator/Namespaces.scala
@@ -27,6 +27,7 @@ case class Namespaces(original: String) {
   val anorm: String = Seq(base, "anorm").mkString(".")
   val anormParsers: String = Seq(anorm, Namespaces.Parsers).mkString(".")
   val anormConversions: String = Seq(anorm, Namespaces.Conversions).mkString(".")
+  val controllers: String = Seq(base, "controllers").mkString(".")
   val errors: String = Seq(base, "errors").mkString(".")
 
   val mock: String = Seq(base, "mock").mkString(".")

--- a/scala-generator/src/test/scala/models/Play26ControllersSpec.scala
+++ b/scala-generator/src/test/scala/models/Play26ControllersSpec.scala
@@ -26,9 +26,11 @@ class Play26ControllersSpec extends FunSpec with Matchers {
   }
 
   def importCount(service: Service): Int = count("import ".r, service)
-  def controllerCount(service: Service): Int = count("play\\.api\\.mvc\\.BaseController".r, service)
+  def executionContextCount(service: Service): Int = count("class [^ ]+ExecutionContext".r, service)
+  def responseTraitCount(service: Service): Int = count("trait [^ ]+Responses".r, service)
   def responseCount(service: Service): Int = count("sealed trait [^ ]+".r, service)
   def responseImplementationCount(service: Service): Int = count("case (class|object) HTTP[0-9]+".r, service)
+  def controllerCount(service: Service): Int = count("play\\.api\\.mvc\\.BaseController".r, service)
   def methodFinalCount(service: Service): Int = count("play\\.api\\.mvc\\.Action".r, service)
   def methodAbstractCount(service: Service): Int = count("scala\\.concurrent\\.Future".r, service)
 
@@ -50,8 +52,12 @@ class Play26ControllersSpec extends FunSpec with Matchers {
           assert(importCount(service) == 1 + service.imports.size)
         }
 
-        it("generates all controllers") {
-          assert(controllerCount(service) == service.resources.size)
+        it("generates all execution context") {
+          assert(executionContextCount(service) == service.resources.size)
+        }
+
+        it("generates all responses trait") {
+          assert(responseTraitCount(service) == service.resources.size)
         }
 
         it("generates all responses") {
@@ -60,6 +66,10 @@ class Play26ControllersSpec extends FunSpec with Matchers {
 
         it("generates all response implementations") {
           assert(responseImplementationCount(service) == service.resources.flatMap(_.operations).flatMap(_.responses).size)
+        }
+
+        it("generates all controllers") {
+          assert(controllerCount(service) == service.resources.size)
         }
 
         it("generates all methods final") {


### PR DESCRIPTION
Following some [good practices from Play](https://www.playframework.com/documentation/2.8.x/ScalaAsync), this PR adds a [CustomExecutionContext](https://www.playframework.com/documentation/2.8.x/api/scala/play/api/libs/concurrent/CustomExecutionContext.html). 

```scala
@Singleton
class HealthchecksExecutionContext @Inject() (system: ActorSystem)
    extends CustomExecutionContext(system, "....controllers.HealthchecksController")
```

This execution context can be injected into the controller implementation. 
```scala
@Singleton
class Healthchecks @Inject()(implicit ec: HealthchecksExecutionContext)  
  extends HealthchecksController {}
```

>**WARNING**
>**If the  execution context is injected**, a configuration is required.
>Otherwise, an error will be thrown at runtime 🤢 
>```
>Error injecting constructor, akka.ConfigurationException: Dispatcher [NAME] not configured
>```
>Any test with a [ServerProvider](https://www.playframework.com/documentation/2.8.x/api/scala/org/scalatestplus/play/ServerProvider.html) will throw this error. Don't forget to write at least one test with OneServerPerSuite, OneServerPerTest, or ConfiguredServer.


