### PR TITLE
Scala-generator: Keep response headers case insensitve

### DIFF
--- a/lib/src/test/resources/generators/play-26-envelope.txt
+++ b/lib/src/test/resources/generators/play-26-envelope.txt
@@ -282,9 +282,9 @@ package io.gregor.time.types.v0 {
     override val headers: ResponseHeaders,
   ) extends Response[T]
 
-  case class ResponseHeaders(all: Map[String, Seq[String]]) {
+  case class ResponseHeaders(all: Map[String, scala.collection.Seq[String]]) {
     def get(name: String): _root_.scala.Option[String] = getAll(name).headOption
-    def getAll(name: String): _root_.scala.Seq[String] = all.getOrElse(name, Nil)
+    def getAll(name: String): _root_.scala.collection.Seq[String] = all.getOrElse(name, Nil)
   }
 
   class Client(
@@ -411,7 +411,7 @@ package io.gregor.time.types.v0 {
       ResponseImpl(
         body = parseJson(className, r, f),
         status = r.status,
-        headers = ResponseHeaders(r.headers.map { case (k, v) => k -> v.toSeq }),
+        headers = ResponseHeaders(r.headers),
       )
     }
 

--- a/scala-generator/src/main/scala/models/generator/ScalaClientCommon.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientCommon.scala
@@ -41,9 +41,9 @@ case class ${name}Impl[T](
   override val headers: ResponseHeaders,
 ) extends $name[T]
 
-case class ResponseHeaders(all: Map[String, Seq[String]]) {
+case class ResponseHeaders(all: Map[String, scala.collection.Seq[String]]) {
   def get(name: String): _root_.scala.Option[String] = getAll(name).headOption
-  def getAll(name: String): _root_.scala.Seq[String] = all.getOrElse(name, Nil)
+  def getAll(name: String): _root_.scala.collection.Seq[String] = all.getOrElse(name, Nil)
 }
 """.trim
   }
@@ -79,7 +79,7 @@ case class ResponseHeaders(all: Map[String, Seq[String]]) {
            |  ResponseImpl(
            |    body = parseJson(className, r, f),
            |    status = r.status,
-           |    headers = ResponseHeaders(r.headers.map { case (k, v) => k -> v.toSeq }),
+           |    headers = ResponseHeaders(r.headers),
            |  )
            |}
            |""".stripMargin.indentString(2) + "\n\n"

--- a/scala-generator/src/main/scala/models/generator/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientMethodGenerator.scala
@@ -276,7 +276,7 @@ class ScalaClientMethodGenerator(
   private[this] def unitResponse: String = {
     config.responseEnvelopeClassName match {
       case None => "()"
-      case Some(envelopeName) => s"${envelopeName}Impl" + "(body = (), status = r.status, headers = ResponseHeaders(r.headers.map { case (k, v) => k -> v.toSeq }))"
+      case Some(envelopeName) => s"${envelopeName}Impl" + "(body = (), status = r.status, headers = ResponseHeaders(r.headers))"
     }
   }
 


### PR DESCRIPTION
The Map returned from `WSClient` `.headers` is case insensitive. In an attempt to update this to scala 2.13, we copied the map into a new one that was not case insensitive. This PR should fix it.