### PR TITLE
Scala: preserve time zone info when parsing DateTime

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -168,7 +168,7 @@ package io.apibuilder.example.union.types.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -168,7 +168,7 @@ package io.apibuilder.example.union.types.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -424,7 +424,7 @@ package io.apibuilder.example.union.types.v0 {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/collection-json-defaults-ahc-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ahc-client.txt
@@ -38,7 +38,7 @@ package com.gilt.test.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {

--- a/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
@@ -38,7 +38,7 @@ package com.gilt.test.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {

--- a/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
@@ -38,7 +38,7 @@ package com.gilt.test.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -149,7 +149,7 @@ package com.gilt.test.v0 {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/play-2-bindable-joda-date-time.txt
+++ b/lib/src/test/resources/generators/play-2-bindable-joda-date-time.txt
@@ -34,7 +34,7 @@ object Bindables {
 
   object ApibuilderTypes {
     val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-      override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+      override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
       override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
       override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
     }

--- a/lib/src/test/resources/generators/play-2-bindable-reference-api-object.txt
+++ b/lib/src/test/resources/generators/play-2-bindable-reference-api-object.txt
@@ -48,7 +48,7 @@ object Bindables {
 
   object ApibuilderTypes {
     val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-      override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+      override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
       override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
       override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
     }

--- a/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
+++ b/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
@@ -569,7 +569,7 @@ package com.gilt.quality.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {

--- a/lib/src/test/resources/generators/play-22-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-22-built-in-types.txt
@@ -80,7 +80,7 @@ package apibuilder.models {
     }
 
     private[apibuilder] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[apibuilder] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -361,7 +361,7 @@ package apibuilder {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/play-23-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-23-built-in-types.txt
@@ -80,7 +80,7 @@ package apibuilder.models {
     }
 
     private[apibuilder] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[apibuilder] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -361,7 +361,7 @@ package apibuilder {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/play-24-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-24-built-in-types.txt
@@ -80,7 +80,7 @@ package apibuilder.models {
     }
 
     private[apibuilder] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[apibuilder] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -361,7 +361,7 @@ package apibuilder {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/play-25-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-25-built-in-types.txt
@@ -80,7 +80,7 @@ package apibuilder.models {
     }
 
     private[apibuilder] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[apibuilder] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -361,7 +361,7 @@ package apibuilder {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/play-26-apidoc-api.txt
+++ b/lib/src/test/resources/generators/play-26-apidoc-api.txt
@@ -739,7 +739,7 @@ package io.apibuilder.api.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -2091,7 +2091,7 @@ package io.apibuilder.api.v0 {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/play-26-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-26-built-in-types.txt
@@ -80,7 +80,7 @@ package apibuilder.models {
     }
 
     private[apibuilder] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[apibuilder] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -361,7 +361,7 @@ package apibuilder {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/play-26-envelope.txt
+++ b/lib/src/test/resources/generators/play-26-envelope.txt
@@ -80,7 +80,7 @@ package io.gregor.time.types.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -197,7 +197,7 @@ package io.gregor.time.types.v0 {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/play-27-apidoc-api.txt
+++ b/lib/src/test/resources/generators/play-27-apidoc-api.txt
@@ -739,7 +739,7 @@ package io.apibuilder.api.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -2091,7 +2091,7 @@ package io.apibuilder.api.v0 {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/play-27-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-27-built-in-types.txt
@@ -80,7 +80,7 @@ package apibuilder.models {
     }
 
     private[apibuilder] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[apibuilder] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -361,7 +361,7 @@ package apibuilder {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/play-27-joda-date-time.txt
+++ b/lib/src/test/resources/generators/play-27-joda-date-time.txt
@@ -80,7 +80,7 @@ package io.gregor.time.types.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -197,7 +197,7 @@ package io.gregor.time.types.v0 {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/play-28-apidoc-api.txt
+++ b/lib/src/test/resources/generators/play-28-apidoc-api.txt
@@ -739,7 +739,7 @@ package io.apibuilder.api.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -2091,7 +2091,7 @@ package io.apibuilder.api.v0 {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/play-28-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-28-built-in-types.txt
@@ -80,7 +80,7 @@ package apibuilder.models {
     }
 
     private[apibuilder] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[apibuilder] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -361,7 +361,7 @@ package apibuilder {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/play-28-joda-date-time.txt
+++ b/lib/src/test/resources/generators/play-28-joda-date-time.txt
@@ -80,7 +80,7 @@ package io.gregor.time.types.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -197,7 +197,7 @@ package io.gregor.time.types.v0 {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -138,7 +138,7 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -138,7 +138,7 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -467,7 +467,7 @@ package io.apibuilder.reference.api.v0 {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -139,7 +139,7 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -139,7 +139,7 @@ package io.apibuilder.reference.api.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -468,7 +468,7 @@ package io.apibuilder.reference.api.v0 {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/http4s/date-time/020_joda/ApibuilderTimeTypesV0Client.scala.txt
+++ b/lib/src/test/resources/http4s/date-time/020_joda/ApibuilderTimeTypesV0Client.scala.txt
@@ -83,7 +83,7 @@ package io.gregor.time.types.v0.models {
       Encoder.encodeString.contramap[_root_.java.util.UUID](uuid => uuid.toString)
 
     private[v0] implicit val decodeDateTime: Decoder[_root_.org.joda.time.DateTime] =
-      Decoder.decodeString.emapTry(str => Try(_root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)))
+      Decoder.decodeString.emapTry(str => Try(_root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)))
 
     private[v0] implicit val encodeDateTime: Encoder[_root_.org.joda.time.DateTime] =
       Encoder.encodeString.contramap[_root_.org.joda.time.DateTime](_root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(_))

--- a/lib/src/test/resources/http4s/date-time/020_joda/ApibuilderTimeTypesV0Server.scala.txt
+++ b/lib/src/test/resources/http4s/date-time/020_joda/ApibuilderTimeTypesV0Server.scala.txt
@@ -18,7 +18,7 @@ private[server] trait Matchers[F[_]] extends Http4sDsl[F] {
     org.http4s.QueryParamDecoder.fromUnsafeCast[BigDecimal](p => BigDecimal(p.value))("BigDecimal")
 
   implicit lazy val queryParamDecodeDateTime: org.http4s.QueryParamDecoder[_root_.org.joda.time.DateTime] =
-    org.http4s.QueryParamDecoder.fromUnsafeCast[_root_.org.joda.time.DateTime](p => _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(p.value))("_root_.org.joda.time.DateTime")
+    org.http4s.QueryParamDecoder.fromUnsafeCast[_root_.org.joda.time.DateTime](p => _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(p.value))("_root_.org.joda.time.DateTime")
 
   implicit lazy val queryParamDecodeLocalDate: org.http4s.QueryParamDecoder[_root_.org.joda.time.LocalDate] =
     org.http4s.QueryParamDecoder.fromUnsafeCast[_root_.org.joda.time.LocalDate](p => _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseLocalDate(p.value))("_root_.org.joda.time.LocalDate")
@@ -39,7 +39,7 @@ private[server] trait Matchers[F[_]] extends Http4sDsl[F] {
   }
 
   object DateTimeVal {
-    def unapply(s: String): Option[_root_.org.joda.time.DateTime] = scala.util.Try(_root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(s)).toOption
+    def unapply(s: String): Option[_root_.org.joda.time.DateTime] = scala.util.Try(_root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(s)).toOption
   }
 
   object LocalDateVal {

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -116,7 +116,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -305,7 +305,7 @@ package io.apibuilder.example.union.types.discriminator.v0 {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/lib/src/test/resources/union-types-discriminator-service-play-27.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-27.txt
@@ -116,7 +116,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(str)
+      _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[_root_.org.joda.time.DateTime] {
@@ -305,7 +305,7 @@ package io.apibuilder.example.union.types.discriminator.v0 {
 
     object ApibuilderTypes {
       val dateTimeIso8601: ApibuilderTypeConverter[_root_.org.joda.time.DateTime] = new ApibuilderTypeConverter[_root_.org.joda.time.DateTime] {
-        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(value)
+        override def convert(value: String): _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(value)
         override def convert(value: _root_.org.joda.time.DateTime): String = _root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(value)
         override def example: _root_.org.joda.time.DateTime = _root_.org.joda.time.DateTime.now
       }

--- a/scala-generator/src/main/scala/models/generator/ScalaDatatype.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaDatatype.scala
@@ -141,7 +141,7 @@ object ScalaPrimitive {
     def apidocType = "date-time-iso8601"
     def shortName = "DateTime"
     override def asString(originalVarName: String): String = s"_root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(${ScalaUtil.quoteNameIfKeyword(originalVarName)})"
-    override def fromStringValue(value: String) = s"_root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(${ScalaUtil.quoteNameIfKeyword(value)})"
+    override def fromStringValue(value: String) = s"_root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(${ScalaUtil.quoteNameIfKeyword(value)})"
     override def default(value: String): String = fromStringValue(ScalaUtil.wrapInQuotes(value))
     override protected def default(json: JsValue): String = default(json.toString)
   }

--- a/scala-generator/src/test/scala/models/generator/ScalaDatatypeSpec.scala
+++ b/scala-generator/src/test/scala/models/generator/ScalaDatatypeSpec.scala
@@ -64,7 +64,7 @@ class ScalaDatatypeSpec extends AnyFunSpec with Matchers {
 
   it("DateTimeIso8601Joda sanity check") {
     DateTimeIso8601Joda.asString("myVar") shouldBe "_root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(myVar)"
-    DateTimeIso8601Joda.default("2020-12-31") shouldBe "_root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime(\"2020-12-31\")"
+    DateTimeIso8601Joda.default("2020-12-31") shouldBe "_root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime(\"2020-12-31\")"
     DateTimeIso8601Joda.name shouldBe "_root_.org.joda.time.DateTime"
   }
 

--- a/scala-generator/src/test/scala/models/generator/ScalaDefaultsSpec.scala
+++ b/scala-generator/src/test/scala/models/generator/ScalaDefaultsSpec.scala
@@ -27,7 +27,7 @@ class ScalaDefaultsSpec extends AnyFunSpec with Matchers {
                                |    isFlashy: Boolean = true,
                                |    markets: Seq[String] = scala.List("USA","CAN"),
                                |    launchedOn: _root_.org.joda.time.LocalDate = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseLocalDate("1986-02-01"),
-                               |    timestamp: _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime("2018-03-21T02:20:52Z")
+                               |    timestamp: _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime("2018-03-21T02:20:52Z")
                                |  )""".stripMargin) should be(true)
   }
 
@@ -51,7 +51,7 @@ class ScalaDefaultsSpec extends AnyFunSpec with Matchers {
                                |    isFlashy: Boolean = true,
                                |    markets: Seq[String] = scala.List("USA","CAN"),
                                |    launchedOn: _root_.org.joda.time.LocalDate = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseLocalDate("1986-02-01"),
-                               |    timestamp: _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime("2018-03-21T02:20:52Z")
+                               |    timestamp: _root_.org.joda.time.DateTime = _root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime("2018-03-21T02:20:52Z")
                                |  )""".stripMargin) should be(true)
   }
 
@@ -75,7 +75,7 @@ class ScalaDefaultsSpec extends AnyFunSpec with Matchers {
                                |    isFlashy: _root_.scala.Option[Boolean] = Some(true),
                                |    markets: _root_.scala.Option[Seq[String]] = Some(scala.List("USA","CAN")),
                                |    launchedOn: _root_.scala.Option[_root_.org.joda.time.LocalDate] = Some(_root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseLocalDate("1986-02-01")),
-                               |    timestamp: _root_.scala.Option[_root_.org.joda.time.DateTime] = Some(_root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime("2018-03-21T02:20:52Z"))
+                               |    timestamp: _root_.scala.Option[_root_.org.joda.time.DateTime] = Some(_root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime("2018-03-21T02:20:52Z"))
                                 |  )""".stripMargin) should be(true)
   }
 

--- a/scala-generator/src/test/scala/models/generator/ScalaUtilSpec.scala
+++ b/scala-generator/src/test/scala/models/generator/ScalaUtilSpec.scala
@@ -214,7 +214,7 @@ class ScalaUtilSpec extends AnyFunSpec with Matchers {
     describe ("default: 2014-03-14T12:13:15Z, datatype: date-time-iso8601") {
       it("behaves for Joda-Time") {
         ScalaUtil.scalaDefault("2014-03-14T12:13:15Z", ScalaPrimitive.DateTimeIso8601Joda) should be {
-          """_root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.parseDateTime("2014-03-14T12:13:15Z")"""
+          """_root_.org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed.parseDateTime("2014-03-14T12:13:15Z")"""
         }
       }
       it("behaves for java.time") {


### PR DESCRIPTION
See how adding `.withOffsetParsed` maintains the time zone information in the original timestamp, instead of converting to the local time zone.

```
scala> ISODateTimeFormat.dateTimeParser().parseDateTime("2019-01-01T00:00+08:00")
res22: org.joda.time.DateTime = 2018-12-31T11:00:00.000-05:00

scala> ISODateTimeFormat.dateTimeParser().withOffsetParsed().parseDateTime("2019-01-01T00:00+08:00")
res23: org.joda.time.DateTime = 2019-01-01T00:00:00.000+08:00
```

Would like to discuss the potential impact.