### PR TITLE
Scala: generate mock envelope bodies for unit response types

### DIFF
--- a/lib/src/test/resources/http4s/server/status-codes-017.txt
+++ b/lib/src/test/resources/http4s/server/status-codes-017.txt
@@ -74,6 +74,17 @@ trait FooRoutes {
     _req: org.http4s.Request
   ): fs2.Task[Get300Response]
 
+  sealed trait Get303Response
+
+  object Get303Response {
+    case class HTTP303(location: org.http4s.Uri, headers: Seq[org.http4s.Header] = Nil) extends Get303Response
+    case class UndocumentedResponse(response: fs2.Task[org.http4s.Response]) extends Get303Response
+  }
+
+  def get303(
+    _req: org.http4s.Request
+  ): fs2.Task[Get303Response]
+
   sealed trait Get401Response
 
   object Get401Response {
@@ -111,6 +122,14 @@ trait FooRoutes {
         case Get300Response.UndocumentedResponse(response) => response
       }
     case _req @ GET -> Root / "foos" / "300" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
+
+    case _req @ GET -> Root / "foos" / "303" if apiVersionMatch(_req) =>
+      get303(_req).flatMap {
+        case Get303Response.HTTP303(location, headers) => SeeOther(location).putHeaders(headers: _*)
+        case Get303Response.UndocumentedResponse(response) => response
+      }
+    case _req @ GET -> Root / "foos" / "303" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "foos" / "401" if apiVersionMatch(_req) =>

--- a/lib/src/test/resources/http4s/server/status-codes-018.txt
+++ b/lib/src/test/resources/http4s/server/status-codes-018.txt
@@ -76,6 +76,17 @@ trait FooRoutes[F[_]] extends Matchers[F] {
     _req: org.http4s.Request[F]
   ): F[Get300Response]
 
+  sealed trait Get303Response
+
+  object Get303Response {
+    case class HTTP303(location: org.http4s.Uri, headers: Seq[org.http4s.Header] = Nil) extends Get303Response
+    case class UndocumentedResponse(response: F[org.http4s.Response[F]]) extends Get303Response
+  }
+
+  def get303(
+    _req: org.http4s.Request[F]
+  ): F[Get303Response]
+
   sealed trait Get401Response
 
   object Get401Response {
@@ -113,6 +124,14 @@ trait FooRoutes[F[_]] extends Matchers[F] {
         case Get300Response.UndocumentedResponse(response) => response
       }
     case _req @ GET -> Root / "foos" / "300" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
+
+    case _req @ GET -> Root / "foos" / "303" if apiVersionMatch(_req) =>
+      get303(_req).flatMap {
+        case Get303Response.HTTP303(location, headers) => SeeOther(location, headers: _*)
+        case Get303Response.UndocumentedResponse(response) => response
+      }
+    case _req @ GET -> Root / "foos" / "303" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "foos" / "401" if apiVersionMatch(_req) =>

--- a/lib/src/test/resources/http4s/server/status-codes-020.txt
+++ b/lib/src/test/resources/http4s/server/status-codes-020.txt
@@ -76,6 +76,17 @@ trait FooRoutes[F[_]] extends Matchers[F] {
     _req: org.http4s.Request[F]
   ): F[Get300Response]
 
+  sealed trait Get303Response
+
+  object Get303Response {
+    case class HTTP303(location: org.http4s.Uri, headers: Seq[org.http4s.Header] = Nil) extends Get303Response
+    case class UndocumentedResponse(response: F[org.http4s.Response[F]]) extends Get303Response
+  }
+
+  def get303(
+    _req: org.http4s.Request[F]
+  ): F[Get303Response]
+
   sealed trait Get401Response
 
   object Get401Response {
@@ -113,6 +124,14 @@ trait FooRoutes[F[_]] extends Matchers[F] {
         case Get300Response.UndocumentedResponse(response) => response
       }
     case _req @ GET -> Root / "foos" / "300" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
+      BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
+
+    case _req @ GET -> Root / "foos" / "303" if apiVersionMatch(_req) =>
+      get303(_req).flatMap {
+        case Get303Response.HTTP303(location, headers) => SeeOther(location, headers: _*)
+        case Get303Response.UndocumentedResponse(response) => response
+      }
+    case _req @ GET -> Root / "foos" / "303" if !_req.headers.get(ApiVersion.ApiVersionMajor).isDefined =>
       BadRequest(s"Missing required request header: ${ApiVersion.ApiVersionMajor}.")
 
     case _req @ GET -> Root / "foos" / "401" if apiVersionMatch(_req) =>

--- a/lib/src/test/resources/http4s/server/status-codes.json
+++ b/lib/src/test/resources/http4s/server/status-codes.json
@@ -98,6 +98,23 @@
         },
         {
           "method": "GET",
+          "path": "/foos/303",
+          "parameters": [],
+          "responses": [
+            {
+              "code": {
+                "integer": {
+                  "value": 303
+                }
+              },
+              "type": "unit",
+              "attributes": []
+            }
+          ],
+          "attributes": []
+        },
+        {
+          "method": "GET",
           "path": "/foos/401",
           "parameters": [],
           "responses": [

--- a/lib/src/test/resources/play2/mock-client/play28_empty_bodies.txt
+++ b/lib/src/test/resources/play2/mock-client/play28_empty_bodies.txt
@@ -1,0 +1,75 @@
+package me.gheine.status.codes.v0.mock {
+
+  trait Client extends me.gheine.status.codes.v0.interfaces.Client {
+
+    val baseUrl: String = "http://mock.localhost"
+
+    override def foos: me.gheine.status.codes.v0.Foos = MockFoosImpl
+
+  }
+
+  object MockFoosImpl extends MockFoos
+
+  trait MockFoos extends me.gheine.status.codes.v0.Foos {
+
+    def get200(
+      requestHeaders: Seq[(String, String)] = Nil
+    )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[me.gheine.status.codes.v0.Response[String]] = scala.concurrent.Future.successful {
+      me.gheine.status.codes.v0.ResponseImpl(
+        body = Factories.randomString(),
+        status = 200,
+        headers = me.gheine.status.codes.v0.ResponseHeaders(Map.empty)
+      )
+    }
+
+    def get205(
+      requestHeaders: Seq[(String, String)] = Nil
+    )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[me.gheine.status.codes.v0.Response[String]] = scala.concurrent.Future.successful {
+      me.gheine.status.codes.v0.ResponseImpl(
+        body = Factories.randomString(),
+        status = 205,
+        headers = me.gheine.status.codes.v0.ResponseHeaders(Map.empty)
+      )
+    }
+
+    def get300(
+      requestHeaders: Seq[(String, String)] = Nil
+    )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[me.gheine.status.codes.v0.Response[String]] = scala.concurrent.Future.successful {
+      me.gheine.status.codes.v0.ResponseImpl(
+        body = Factories.randomString(),
+        status = 300,
+        headers = me.gheine.status.codes.v0.ResponseHeaders(Map.empty)
+      )
+    }
+
+    def get303(
+      requestHeaders: Seq[(String, String)] = Nil
+    )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[me.gheine.status.codes.v0.Response[Unit]] = scala.concurrent.Future.successful {
+      me.gheine.status.codes.v0.ResponseImpl(
+        body = (),
+        status = 303,
+        headers = me.gheine.status.codes.v0.ResponseHeaders(Map.empty)
+      )
+    }
+
+    def get401(
+      requestHeaders: Seq[(String, String)] = Nil
+    )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[me.gheine.status.codes.v0.Response[Unit]] = scala.concurrent.Future.successful {
+      // No-op as there is no successful response defined
+    }
+
+  }
+
+  object Factories {
+
+    def randomString(length: Int = 24): String = {
+      _root_.scala.util.Random.alphanumeric.take(length).mkString
+    }
+
+    def makeFoo(): me.gheine.status.codes.v0.models.Foo = me.gheine.status.codes.v0.models.Foo(
+      id = Factories.randomString(24)
+    )
+
+  }
+
+}

--- a/lib/src/test/scala/TestHelper.scala
+++ b/lib/src/test/scala/TestHelper.scala
@@ -22,6 +22,7 @@ object TestHelper extends Matchers {
   lazy val dateTimeService: Service = parseFile(s"/examples/date-time-types.json")
   lazy val builtInTypesService: Service = parseFile(s"/examples/built-in-types.json")
   lazy val scalaKeywordsService: Service = parseFile(s"/examples/response-with-reserved-scala-keyword.json")
+  lazy val statusCodesService: Service = parseFile(s"/http4s/server/status-codes.json")
 
   lazy val generatorApiServiceWithUnionAndDescriminator: Service = parseFile(s"/examples/apidoc-example-union-types-discriminator.json")
   lazy val generatorApiServiceWithUnionWithoutDescriminator: Service = parseFile(s"/examples/apidoc-example-union-types.json")

--- a/scala-generator/src/main/scala/models/generator/ScalaService.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaService.scala
@@ -411,7 +411,7 @@ class ScalaResponse(ssd: ScalaService, method: Method, response: Response) {
   }
 
   val isSuccess: Boolean = response.code match {
-    case ResponseCodeInt(value) => value >= 200 && value < 300
+    case ResponseCodeInt(value) => value >= 200 && value < 400
     case ResponseCodeOption.Default | ResponseCodeOption.UNDEFINED(_) | ResponseCodeUndefinedType(_) => false
   }
 

--- a/scala-generator/src/main/scala/models/generator/mock/MockClientGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/mock/MockClientGenerator.scala
@@ -191,7 +191,7 @@ class MockClientGenerator(
     ).mkString("\n\n")
   }
 
-    def mockImplementation(cm: ScalaClientMethod): String = {
+  def mockImplementation(cm: ScalaClientMethod): String = {
     cm.operation.responses.find(_.isSuccess) match {
       case None => {
         "// No-op as there is no successful response defined"

--- a/scala-generator/src/test/scala/models/generator/mock/MockClientGeneratorSpec.scala
+++ b/scala-generator/src/test/scala/models/generator/mock/MockClientGeneratorSpec.scala
@@ -5,7 +5,7 @@ import models.TestHelper.assertValidScalaSourceCode
 import scala.generator.{ScalaClientMethodConfigs, ScalaService}
 import scala.generator.mock.MockClientGenerator._
 import scala.generator.ScalaField.Limitation
-import scala.models.{Attributes, DateTimeTypeConfig, DateTypeConfig}
+import scala.models.{Attributes, DateTimeTypeConfig, DateTypeConfig, ResponseConfig}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -110,6 +110,21 @@ class MockClientGeneratorSpec extends AnyFunSpec with Matchers {
 
       assertValidScalaSourceCode(sourceCode)
       models.TestHelper.assertEqualsFile(s"/play2/mock-client/play28_date-time-offsetdatetime.txt", sourceCode)
+    }
+  }
+
+  describe("play 2.8 - response envelope") {
+    it("generates mock clients with ResponseImpl for empty bodies") {
+      val service = models.TestHelper.statusCodesService
+      val conf = Attributes.PlayDefaultConfig.copy(response = ResponseConfig.Envelope)
+      val ssd = new ScalaService(service, conf)
+
+      val config = ScalaClientMethodConfigs.Play28(namespace = "whatever", attributes = conf, baseUrl = None)
+
+      val sourceCode = new MockClientGenerator(ssd, None, config).generateCode()
+
+      assertValidScalaSourceCode(sourceCode)
+      models.TestHelper.assertEqualsFile(s"/play2/mock-client/play28_empty_bodies.txt", sourceCode)
     }
   }
 


### PR DESCRIPTION
Before:
```scala
    def getDiscountCodesAndLookupJson(
      code: String,
      requestHeaders: Seq[(String, String)] = Nil
    )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.flow.shopify.external.v0.Response[Unit]] = scala.concurrent.Future.successful {
      // No-op as there is no successful response defined
    }
```

Notice that the response type is Future[Response[Unit]], but the body is just Future[Unit].

After:
```scala
    def getDiscountCodesAndLookupJson(
      code: String,
      requestHeaders: Seq[(String, String)] = Nil
    )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.flow.shopify.external.v0.Response[Unit]] = scala.concurrent.Future.successful {
      io.flow.shopify.external.v0.ResponseImpl(
        body = (),
        status = 303,
        headers = io.flow.shopify.external.v0.ResponseHeaders(Map.empty)
      )
    }
```