### PR TITLE
Go: fix deserialization of `[string]`

### DIFF
--- a/go-generator/src/main/scala/models/ResponseBuilder.scala
+++ b/go-generator/src/main/scala/models/ResponseBuilder.scala
@@ -6,8 +6,8 @@ import lib.{Datatype, DatatypeResolver}
 object ResponseBuilder {
 
   sealed trait DataSource
-  object FromJson extends DataSource
-  object FromMap extends DataSource
+  case object FromJson extends DataSource
+  case object FromMap extends DataSource
 
 }
 


### PR DESCRIPTION
We can't call `ioutil.ReadAll()` on an `interface{}`. The code was only
previously used at the top level, when the provided reader is the entire
json body and we could just `ReadAll()` into a string.

Now this supports reading strings inside maps and lists, because we can
just convert the `interface{}` into a `string`.