### PR TITLE
bump lombok to avoid java16+ compile error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '13' ]
+        java: [ '13', '18' ]
         scala: [ '2.13.8' ]
     steps:
     - uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val javaAwsLambdaPojos = project
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.461",
       "me.geso" % "tinyvalidator" % "0.9.1",
-      "org.projectlombok" % "lombok" % "1.18.4"
+      "org.projectlombok" % "lombok" % "1.18.24"
     )
   )
 


### PR DESCRIPTION
On Java 16+, compilation fails with:

```
[error] Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private com.sun.tools.javac.processing.JavacProcessingEnvironment$DiscoveredProcessors com.sun.tools.javac.processing.JavacProcessingEnvironment.discoveredProcs accessible: module jdk.compiler does not "opens com.sun.tools.javac.processing" to unnamed module @7316cb78
[error] 	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
[error] 	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
[error] 	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:180)
[error] 	at java.base/java.lang.reflect.Field.setAccessible(Field.java:174)
[error] 	at lombok.permit.Permit.setAccessible(Permit.java:50)
[error] 	at lombok.permit.Permit.getField(Permit.java:84)
[error] 	at lombok.javac.apt.LombokProcessor.getFieldAccessor(LombokProcessor.java:116)
[error] 	at lombok.javac.apt.LombokProcessor.<clinit>(LombokProcessor.java:110)
```

caused by https://github.com/projectlombok/lombok/issues/2681

This PR upgrades lombok to a version containing the fix, and adds Java 18 to the build matrix.

