### PR TITLE
Fix ruby quoting issue in assertion

### DIFF
--- a/ruby-generator/src/main/scala/models/RubyClientGenerator.scala
+++ b/ruby-generator/src/main/scala/models/RubyClientGenerator.scala
@@ -834,7 +834,7 @@ ${headers.rubyModuleConstants.indentString(2)}
     model.fields.filter( f => f.required && f.default.isEmpty ) match {
       case Nil => {}
       case required => {
-        sb.append("    HttpClient::Preconditions.require_keys(opts, [" + required.map { f => s":${RubyUtil.quoteNameIfKeyword(f.name)}" }.mkString(", ") + s"], '$className')")
+        sb.append("    HttpClient::Preconditions.require_keys(opts, [" + required.map { f => s":${f.name}" }.mkString(", ") + s"], '$className')")
       }
     }
 


### PR DESCRIPTION
We are improperly generating ruby code:

```
          class SnoozeForm

            attr_reader :until_, :reason, :next_action_with, :source_type, :source_id

            def initialize(incoming={})
              opts = HttpClient::Helper.symbolize_keys(incoming)
              HttpClient::Preconditions.require_keys(opts, [:until_, :reason, :next_action_with, :source_type, :source_id], 'SnoozeForm')

```

the `until_` should not be quoted