### PR TITLE
Scala `json` anorm fix

### DIFF
--- a/lib/src/test/resources/generator/anorm/cap-name-conversions-26.txt
+++ b/lib/src/test/resources/generator/anorm/cap-name-conversions-26.txt
@@ -58,6 +58,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/cap-name-conversions-28.txt
+++ b/lib/src/test/resources/generator/anorm/cap-name-conversions-28.txt
@@ -58,6 +58,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/datetime-conversions-java.txt
+++ b/lib/src/test/resources/generator/anorm/datetime-conversions-java.txt
@@ -57,6 +57,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/datetime-conversions-joda.txt
+++ b/lib/src/test/resources/generator/anorm/datetime-conversions-joda.txt
@@ -58,6 +58,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/enum-conversions-24.txt
+++ b/lib/src/test/resources/generator/anorm/enum-conversions-24.txt
@@ -59,6 +59,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/enum-conversions-26.txt
+++ b/lib/src/test/resources/generator/anorm/enum-conversions-26.txt
@@ -60,6 +60,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/enum-conversions-28.txt
+++ b/lib/src/test/resources/generator/anorm/enum-conversions-28.txt
@@ -60,6 +60,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/list-conversions-24.txt
+++ b/lib/src/test/resources/generator/anorm/list-conversions-24.txt
@@ -57,6 +57,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/list-conversions-26.txt
+++ b/lib/src/test/resources/generator/anorm/list-conversions-26.txt
@@ -58,6 +58,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/list-conversions-28.txt
+++ b/lib/src/test/resources/generator/anorm/list-conversions-28.txt
@@ -58,6 +58,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/location-conversions-24.txt
+++ b/lib/src/test/resources/generator/anorm/location-conversions-24.txt
@@ -57,6 +57,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/location-conversions-26.txt
+++ b/lib/src/test/resources/generator/anorm/location-conversions-26.txt
@@ -58,6 +58,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/location-conversions-28.txt
+++ b/lib/src/test/resources/generator/anorm/location-conversions-28.txt
@@ -58,6 +58,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/name-conversions-24.txt
+++ b/lib/src/test/resources/generator/anorm/name-conversions-24.txt
@@ -57,6 +57,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/name-conversions-26.txt
+++ b/lib/src/test/resources/generator/anorm/name-conversions-26.txt
@@ -58,6 +58,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/name-conversions-28.txt
+++ b/lib/src/test/resources/generator/anorm/name-conversions-28.txt
@@ -58,6 +58,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/reference-conversions-24.txt
+++ b/lib/src/test/resources/generator/anorm/reference-conversions-24.txt
@@ -57,6 +57,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/reference-conversions-26.txt
+++ b/lib/src/test/resources/generator/anorm/reference-conversions-26.txt
@@ -58,6 +58,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/reference-conversions-28.txt
+++ b/lib/src/test/resources/generator/anorm/reference-conversions-28.txt
@@ -58,6 +58,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/union-conversions-24.txt
+++ b/lib/src/test/resources/generator/anorm/union-conversions-24.txt
@@ -61,6 +61,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/union-conversions-26.txt
+++ b/lib/src/test/resources/generator/anorm/union-conversions-26.txt
@@ -62,6 +62,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/union-conversions-28.txt
+++ b/lib/src/test/resources/generator/anorm/union-conversions-28.txt
@@ -62,6 +62,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/user-conversions-24.txt
+++ b/lib/src/test/resources/generator/anorm/user-conversions-24.txt
@@ -59,6 +59,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/user-conversions-26.txt
+++ b/lib/src/test/resources/generator/anorm/user-conversions-26.txt
@@ -60,6 +60,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/user-conversions-28.txt
+++ b/lib/src/test/resources/generator/anorm/user-conversions-28.txt
@@ -60,6 +60,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
   object Standard {
     implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }
+    implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }
     implicit val columnToSeqBoolean: Column[Seq[Boolean]] = Util.parser { _.as[Seq[Boolean]] }
     implicit val columnToMapBoolean: Column[Map[String, Boolean]] = Util.parser { _.as[Map[String, Boolean]] }
     implicit val columnToSeqDouble: Column[Seq[Double]] = Util.parser { _.as[Seq[Double]] }

--- a/lib/src/test/resources/generator/anorm/user.txt
+++ b/lib/src/test/resources/generator/anorm/user.txt
@@ -40,16 +40,22 @@ package test.apidoc.apidoctest.v0.anorm.parsers {
       guid: String = "guid",
       email: String = "email",
       namePrefix: String = "name",
+      obj: String = "obj",
+      blob: String = "blob",
       prefixOpt: Option[String] = None
     ): RowParser[test.apidoc.apidoctest.v0.models.User] = {
       SqlParser.get[_root_.java.util.UUID](prefixOpt.getOrElse("") + guid) ~
       SqlParser.str(prefixOpt.getOrElse("") + email) ~
-      test.apidoc.apidoctest.v0.anorm.parsers.Name.parserWithPrefix(prefixOpt.getOrElse("") + namePrefix).? map {
-        case guid ~ email ~ name => {
+      test.apidoc.apidoctest.v0.anorm.parsers.Name.parserWithPrefix(prefixOpt.getOrElse("") + namePrefix).? ~
+      SqlParser.get[_root_.play.api.libs.json.JsObject](prefixOpt.getOrElse("") + obj).? ~
+      SqlParser.get[_root_.play.api.libs.json.JsValue](prefixOpt.getOrElse("") + blob).? map {
+        case guid ~ email ~ name ~ obj ~ blob => {
           test.apidoc.apidoctest.v0.models.User(
             guid = guid,
             email = email,
-            name = name
+            name = name,
+            obj = obj,
+            blob = blob
           )
         }
       }

--- a/scala-generator/src/main/scala/models/generator/anorm/Conversions.scala
+++ b/scala-generator/src/main/scala/models/generator/anorm/Conversions.scala
@@ -89,7 +89,8 @@ package %s {
     (
       Seq(
         Seq(
-          s"implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }"
+          s"implicit val columnToJsObject: Column[play.api.libs.json.JsObject] = Util.parser { _.as[play.api.libs.json.JsObject] }",
+          s"implicit val columnToJsValue: Column[play.api.libs.json.JsValue] = Util.parser { _.as[play.api.libs.json.JsValue] }"
         )
       ) ++ types.map { t =>
         Seq(

--- a/scala-generator/src/test/scala/models/generator/anorm/ParserGenerator24Spec.scala
+++ b/scala-generator/src/test/scala/models/generator/anorm/ParserGenerator24Spec.scala
@@ -128,7 +128,9 @@ class ParserGenerator24Spec extends AnyFunSpec with Matchers {
         "fields": [
           { "name": "guid", "type": "uuid", "required": true, "attributes": [] },
           { "name": "email", "type": "string", "required": true, "attributes": [] },
-          { "name": "name", "type": "name", "required": false, "attributes": [] }
+          { "name": "name", "type": "name", "required": false, "attributes": [] },
+          { "name": "obj", "type": "object", "required": false, "attributes": [] },
+          { "name": "blob", "type": "json", "required": false, "attributes": [] }
         ]
       }
     """).form

--- a/scala-generator/src/test/scala/models/generator/anorm/ParserGenerator26Spec.scala
+++ b/scala-generator/src/test/scala/models/generator/anorm/ParserGenerator26Spec.scala
@@ -168,7 +168,9 @@ class ParserGenerator26Spec extends AnyFunSpec with Matchers {
         "fields": [
           { "name": "guid", "type": "uuid", "required": true, "attributes": [] },
           { "name": "email", "type": "string", "required": true, "attributes": [] },
-          { "name": "name", "type": "name", "required": false, "attributes": [] }
+          { "name": "name", "type": "name", "required": false, "attributes": [] },
+          { "name": "obj", "type": "object", "required": false, "attributes": [] },
+          { "name": "blob", "type": "json", "required": false, "attributes": [] }
         ]
       }
     """).form

--- a/scala-generator/src/test/scala/models/generator/anorm/ParserGenerator28Spec.scala
+++ b/scala-generator/src/test/scala/models/generator/anorm/ParserGenerator28Spec.scala
@@ -168,7 +168,9 @@ class ParserGenerator28Spec extends AnyFunSpec with Matchers {
         "fields": [
           { "name": "guid", "type": "uuid", "required": true, "attributes": [] },
           { "name": "email", "type": "string", "required": true, "attributes": [] },
-          { "name": "name", "type": "name", "required": false, "attributes": [] }
+          { "name": "name", "type": "name", "required": false, "attributes": [] },
+          { "name": "obj", "type": "object", "required": false, "attributes": [] },
+          { "name": "blob", "type": "json", "required": false, "attributes": [] }
         ]
       }
     """).form


### PR DESCRIPTION
Using `json` in a model breaks the scala generator for anorm parsers because there isn't proper handling for `JsValue` implicit conversion. This change would handle that conversion so that this value could be freely used in models.