### PR TITLE
Extract mock factory generator from play mock client

### DIFF
--- a/generator/app/controllers/Generators.scala
+++ b/generator/app/controllers/Generators.scala
@@ -259,6 +259,17 @@ object Generators {
     ),
     CodeGenTarget(
       metaData = Generator(
+        key = "scala_mock_models",
+        name = "Scala mock models",
+        description = Some("Generate factory methods for mock models from the API description."),
+        language = Some("Scala"),
+        attributes = Seq("scala_generator")
+      ),
+      status = lib.generator.Status.Production,
+      codeGenerator = Some(scala.generator.mock.MockFactoriesGenerator)
+    ),
+    CodeGenTarget(
+      metaData = Generator(
         key = "scalacheck",
         name = "ScalaCheck",
         description = Some("Generate <a href='https://github.com/typelevel/scalacheck'>ScalaCheck</a> generators for models, enums, and unions."),

--- a/lib/src/test/resources/scala-mock-factories-reference-service.txt
+++ b/lib/src/test/resources/scala-mock-factories-reference-service.txt
@@ -1,0 +1,78 @@
+package io.apibuilder.reference.api.v0.mock {
+
+  object Factories {
+
+    def randomString(length: Int = 24): String = {
+      _root_.scala.util.Random.alphanumeric.take(length).mkString
+    }
+
+    def makeAgeGroup(): io.apibuilder.reference.api.v0.models.AgeGroup = io.apibuilder.reference.api.v0.models.AgeGroup.Youth
+
+    def makeBig(): io.apibuilder.reference.api.v0.models.Big = io.apibuilder.reference.api.v0.models.Big(
+      f1 = Factories.randomString(24),
+      f2 = Factories.randomString(24),
+      f3 = Factories.randomString(24),
+      f4 = Factories.randomString(24),
+      f5 = Factories.randomString(24),
+      f6 = Factories.randomString(24),
+      f7 = Factories.randomString(24),
+      f8 = Factories.randomString(24),
+      f9 = Factories.randomString(24),
+      f10 = Factories.randomString(24),
+      f11 = Factories.randomString(24),
+      f12 = Factories.randomString(24),
+      f13 = Factories.randomString(24),
+      f14 = Factories.randomString(24),
+      f15 = Factories.randomString(24),
+      f16 = Factories.randomString(24),
+      f17 = Factories.randomString(24),
+      f18 = Factories.randomString(24),
+      f19 = Factories.randomString(24),
+      f20 = Factories.randomString(24),
+      f21 = Factories.randomString(24),
+      f22 = Factories.randomString(24),
+      f23 = Factories.randomString(24),
+      f24 = Factories.randomString(24),
+      f25 = Factories.randomString(24)
+    )
+
+    def makeEcho(): io.apibuilder.reference.api.v0.models.Echo = io.apibuilder.reference.api.v0.models.Echo(
+      value = Factories.randomString(24)
+    )
+
+    def makeError(): io.apibuilder.reference.api.v0.models.Error = io.apibuilder.reference.api.v0.models.Error(
+      code = Factories.randomString(24),
+      message = Factories.randomString(24)
+    )
+
+    def makeGroup(): io.apibuilder.reference.api.v0.models.Group = io.apibuilder.reference.api.v0.models.Group(
+      members = Nil
+    )
+
+    def makeMember(): io.apibuilder.reference.api.v0.models.Member = io.apibuilder.reference.api.v0.models.Member(
+      guid = _root_.java.util.UUID.randomUUID,
+      organization = io.apibuilder.reference.api.v0.mock.Factories.makeOrganization(),
+      user = io.apibuilder.reference.api.v0.mock.Factories.makeUser(),
+      role = Factories.randomString(24)
+    )
+
+    def makeOrganization(): io.apibuilder.reference.api.v0.models.Organization = io.apibuilder.reference.api.v0.models.Organization(
+      guid = _root_.java.util.UUID.randomUUID,
+      name = Factories.randomString(24)
+    )
+
+    def makeUser(): io.apibuilder.reference.api.v0.models.User = io.apibuilder.reference.api.v0.models.User(
+      guid = _root_.java.util.UUID.randomUUID,
+      email = Factories.randomString(24),
+      active = true,
+      ageGroup = io.apibuilder.reference.api.v0.mock.Factories.makeAgeGroup(),
+      tags = None
+    )
+
+    def makeUserList(): io.apibuilder.reference.api.v0.models.UserList = io.apibuilder.reference.api.v0.models.UserList(
+      users = Nil
+    )
+
+  }
+
+}

--- a/scala-generator/src/main/scala/models/generator/mock/MockFactoriesGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/mock/MockFactoriesGenerator.scala
@@ -1,0 +1,152 @@
+package scala.generator.mock
+
+import generator.ServiceFileNames
+import io.apibuilder.generator.v0.models.{File, InvocationForm}
+import lib.Text._
+import lib.generator.CodeGenerator
+
+import scala.generator._
+import scala.models.{ApiBuilderComments, Attributes}
+
+object MockFactoriesGenerator extends CodeGenerator {
+
+  override def invoke(form: InvocationForm): Either[Seq[String], Seq[File]] = {
+    val ssd = new ScalaService(form.service, Attributes.PlayDefaultConfig.withAttributes(form.attributes))
+    new MockFactoriesGenerator(ssd, form.userAgent).invoke()
+  }
+
+  private[mock] def factoriesCode(ssd: ScalaService): String = Seq(
+    "object Factories {",
+    Seq(
+      """def randomString(length: Int = 24): String = {""",
+      """  _root_.scala.util.Random.alphanumeric.take(length).mkString""",
+      """}"""
+    ).mkString("\n").indentString(2),
+    Seq(
+      ssd.enums.map { makeEnum },
+      ssd.models.map { makeModel },
+      ssd.unions.map { makeUnion }
+    ).flatten.mkString("\n\n").indentString(2),
+    "}"
+  ).mkString("\n\n")
+
+  private[mock] def makeEnum(`enum`: ScalaEnum): String = {
+    val name = enum.values.headOption match {
+      case None => {
+        """UNDEFINED("other")"""
+      }
+      case Some(value) => {
+        value.name
+      }
+    }
+    s"def make${enum.name}(): ${enum.qualifiedName} = ${enum.qualifiedName}.$name"
+  }
+
+  private[mock] def makeModel(model: ScalaModel): String = {
+    Seq(
+      s"def make${model.name}(): ${model.qualifiedName} = ${model.qualifiedName}(",
+      model.fields.map { field =>
+        s"${field.name} = ${mockValue(field.datatype, Some(field.limitation))}"
+      }.mkString(",\n").indentString(2),
+      ")"
+    ).mkString("\n")
+  }
+
+  private[mock] def makeUnion(union: ScalaUnion): String = {
+    val typ = union.types.headOption.getOrElse {
+      sys.error(s"Union type[${union.qualifiedName}] does not have any times")
+    }
+    s"def make${union.name}(): ${union.qualifiedName} = ${mockValue(typ.datatype)}"
+  }
+
+  private[mock] def mockValue(
+    datatype: ScalaDatatype,
+    limitation: Option[ScalaField.Limitation] = None,
+    unitType: String = "// unit type",
+  ): String = {
+    datatype match {
+      case ScalaPrimitive.Boolean => "true"
+      case ScalaPrimitive.Double => "1.0"
+      case ScalaPrimitive.Integer => "1"
+      case ScalaPrimitive.Long => "1L"
+      case dt: ScalaPrimitive.DateIso8601 => s"${dt.fullName}.now"
+      case dt: ScalaPrimitive.DateTimeIso8601 => s"${dt.fullName}.now"
+      case ScalaPrimitive.Decimal => """BigDecimal("1")"""
+      case ScalaPrimitive.ObjectAsPlay => "_root_.play.api.libs.json.Json.obj()"
+      case ScalaPrimitive.ObjectAsCirce => "Map()"
+      case ScalaPrimitive.JsonValueAsPlay => "_root_.play.api.libs.json.Json.obj().asInstanceOf[_root_.play.api.libs.json.JsValue]"
+      case dt@ScalaPrimitive.JsonValueAsCirce => s"${dt.asInstanceOf[ScalaPrimitive].fullName}.obj()"
+      case ScalaPrimitive.String => {
+        limitation match {
+          case None => "Factories.randomString()"
+          case Some(limitationVal) => s"Factories.randomString(${calculateStringLength(limitationVal)})"
+        }
+      }
+      case ScalaPrimitive.Unit => unitType
+      case dt@ScalaPrimitive.Uuid => s"${dt.asInstanceOf[ScalaPrimitive].fullName}.randomUUID"
+      case ScalaDatatype.List(_) => "Nil"
+      case ScalaDatatype.Map(_) => "Map()"
+      case ScalaDatatype.Option(_) => "None"
+      case ScalaPrimitive.Enum(ns, name) => s"${ns.mock}.Factories.make$name()"
+      case ScalaPrimitive.Model(ns, name) => s"${ns.mock}.Factories.make$name()"
+      case ScalaPrimitive.Union(ns, name) => s"${ns.mock}.Factories.make$name()"
+      case ScalaPrimitive.GeneratedModel(_) => sys.error("Generated models should not be mocked")
+    }
+  }
+
+  private[mock] def calculateStringLength(limitation: ScalaField.Limitation): Int = {
+    val defaultCandidate = 24L
+
+    // TODO handle Int vs Long (really String of length Int.MaxValue + 1??!)
+    //   consider some artificial upper bound of e.g. 10,000; 100,000; 1,000,000 -- to be discussed
+
+    val withLimitationApplied = limitation match {
+      case ScalaField.Limitation(None, None) => defaultCandidate
+      case ScalaField.Limitation(Some(minimum), None) => Math.max(defaultCandidate, minimum)
+      case ScalaField.Limitation(None, Some(maximum)) => Math.min(defaultCandidate, maximum)
+      case ScalaField.Limitation(Some(minimum), Some(maximum)) =>
+        if (minimum < maximum) (minimum + maximum) / 2
+        else if (minimum == maximum) minimum
+        else 0
+    }
+
+    val withZeroAsLowerBound = Math.max(0L, withLimitationApplied)
+
+    if (!withZeroAsLowerBound.isValidInt) Int.MaxValue // TODO really?!
+    else withZeroAsLowerBound.toInt
+  }
+}
+
+private[mock] class MockFactoriesGenerator(
+  ssd: ScalaService,
+  userAgent: Option[String],
+) {
+  import MockFactoriesGenerator._
+
+  def invoke(): Either[Seq[String], Seq[File]] = {
+    val header = ApiBuilderComments(ssd.service.version, userAgent).toJavaString + "\n"
+    val code = generateCode()
+
+    Right(
+      Seq(
+        ServiceFileNames.toFile(
+          ssd.service.namespace,
+          ssd.service.organization.key,
+          ssd.service.application.key,
+          ssd.service.version,
+          "MockFactories",
+          header ++ code,
+          Some("Scala")
+        )
+      )
+    )
+  }
+
+  def generateCode(): String = {
+    Seq(
+      s"package ${ssd.namespaces.mock} {",
+      factoriesCode(ssd).indentString(2),
+      "}"
+    ).mkString("\n\n")
+  }
+}

--- a/scala-generator/src/test/scala/models/generator/mock/MockClientGeneratorSpec.scala
+++ b/scala-generator/src/test/scala/models/generator/mock/MockClientGeneratorSpec.scala
@@ -1,41 +1,13 @@
 package scala.generator.mock
 
 import models.TestHelper.assertValidScalaSourceCode
-
-import scala.generator.{ScalaClientMethodConfigs, ScalaService}
-import scala.generator.mock.MockClientGenerator._
-import scala.generator.ScalaField.Limitation
-import scala.models.{Attributes, DateTimeTypeConfig, DateTypeConfig, ResponseConfig}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.generator.{ScalaClientMethodConfigs, ScalaService}
+import scala.models.{Attributes, DateTimeTypeConfig, DateTypeConfig, ResponseConfig}
+
 class MockClientGeneratorSpec extends AnyFunSpec with Matchers {
-  it("should generate the right desired length for string given a field limitation") {
-    calculateStringLength(Limitation(None, None)) should be(24)
-    calculateStringLength(Limitation(Some(6), None)) should be(24) // TODO or [6, 24] ??? -> mostly for very small min vals e.g. min=3
-    calculateStringLength(Limitation(Some(25), None)) should be(25)
-    calculateStringLength(Limitation(None, Some(23))) should be(23)
-    // TODO or [24, 10000] ??? hmm, rather not ==> leave 24
-    //   this is not symmetric problem -- as min has a natural lower bound of 0, while max has a very high upper bound
-    calculateStringLength(Limitation(None, Some(10000))) should be(24)
-
-    val lenFrom22And25 = calculateStringLength(Limitation(Some(22), Some(25)))
-    lenFrom22And25 should be >= 22
-    lenFrom22And25 should be <= 25
-
-    val lenFrom6And8 = calculateStringLength(Limitation(Some(6), Some(8)))
-    lenFrom6And8 should be >= 6
-    lenFrom6And8 should be <= 8
-
-    calculateStringLength(Limitation(Some(3), Some(3))) should be(3)
-
-    calculateStringLength(Limitation(Some(25), Some(22))) should be(0)
-    calculateStringLength(Limitation(Some(22), Some(25))) should be(23)
-    calculateStringLength(Limitation(None, Some(-1))) should be(0)
-
-    calculateStringLength(Limitation(Some(Int.MaxValue), None)) should be(Int.MaxValue) // TODO: really?!
-    calculateStringLength(Limitation(Some(Long.MaxValue), None)) should be(Int.MaxValue) // TODO: really?!
-  }
 
   describe("Play 2.7 - date and date-time types") {
     it("uses joda time") {

--- a/scala-generator/src/test/scala/models/generator/mock/MockFactoriesGeneratorSpec.scala
+++ b/scala-generator/src/test/scala/models/generator/mock/MockFactoriesGeneratorSpec.scala
@@ -1,0 +1,50 @@
+package scala.generator.mock
+
+import models.TestHelper.assertValidScalaSourceCode
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.generator.{ScalaClientMethodConfigs, ScalaService}
+import scala.generator.ScalaField.Limitation
+import scala.models.{Attributes, DateTimeTypeConfig, DateTypeConfig}
+
+class MockFactoriesGeneratorSpec extends AnyFunSpec with Matchers {
+  import scala.generator.mock.MockFactoriesGenerator._
+
+  it("should generate the right desired length for string given a field limitation") {
+    calculateStringLength(Limitation(None, None)) should be(24)
+    calculateStringLength(Limitation(Some(6), None)) should be(24) // TODO or [6, 24] ??? -> mostly for very small min vals e.g. min=3
+    calculateStringLength(Limitation(Some(25), None)) should be(25)
+    calculateStringLength(Limitation(None, Some(23))) should be(23)
+    // TODO or [24, 10000] ??? hmm, rather not ==> leave 24
+    //   this is not symmetric problem -- as min has a natural lower bound of 0, while max has a very high upper bound
+    calculateStringLength(Limitation(None, Some(10000))) should be(24)
+
+    val lenFrom22And25 = calculateStringLength(Limitation(Some(22), Some(25)))
+    lenFrom22And25 should be >= 22
+    lenFrom22And25 should be <= 25
+
+    val lenFrom6And8 = calculateStringLength(Limitation(Some(6), Some(8)))
+    lenFrom6And8 should be >= 6
+    lenFrom6And8 should be <= 8
+
+    calculateStringLength(Limitation(Some(3), Some(3))) should be(3)
+
+    calculateStringLength(Limitation(Some(25), Some(22))) should be(0)
+    calculateStringLength(Limitation(Some(22), Some(25))) should be(23)
+    calculateStringLength(Limitation(None, Some(-1))) should be(0)
+
+    calculateStringLength(Limitation(Some(Int.MaxValue), None)) should be(Int.MaxValue) // TODO: really?!
+    calculateStringLength(Limitation(Some(Long.MaxValue), None)) should be(Int.MaxValue) // TODO: really?!
+  }
+
+  it("creates factory methods for the models ") {
+    val service = models.TestHelper.referenceApiService
+    val ssd = new ScalaService(service, Attributes.Http4sDefaultConfig)
+
+    val sourceCode = new MockFactoriesGenerator(ssd, None).generateCode()
+
+    assertValidScalaSourceCode(sourceCode)
+    models.TestHelper.assertEqualsFile(s"/scala-mock-factories-reference-service.txt", sourceCode)
+  }
+}


### PR DESCRIPTION
Goal is to allow a consumer to build for example a database module that may return/persist model instances. When testing it is useful to be able to use mock model instances but not want a dependency on play because of the client interface included in mock client. 