### PR TITLE
Play: Fully qualify js readers/writers

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -223,7 +223,7 @@ package io.apibuilder.example.union.types.v0.models {
 
     implicit def jsonWritesApidocExampleUnionTypesBar: play.api.libs.json.Writes[Bar] = {
       (obj: io.apibuilder.example.union.types.v0.models.Bar) => {
-        jsonWritesApidocExampleUnionTypesBar(obj)
+        io.apibuilder.example.union.types.v0.models.json.jsonWritesApidocExampleUnionTypesBar(obj)
       }
     }
 
@@ -255,7 +255,7 @@ package io.apibuilder.example.union.types.v0.models {
 
     implicit def jsonWritesApidocExampleUnionTypesFoo: play.api.libs.json.Writes[Foo] = {
       (obj: io.apibuilder.example.union.types.v0.models.Foo) => {
-        jsonWritesApidocExampleUnionTypesFoo(obj)
+        io.apibuilder.example.union.types.v0.models.json.jsonWritesApidocExampleUnionTypesFoo(obj)
       }
     }
 
@@ -275,7 +275,7 @@ package io.apibuilder.example.union.types.v0.models {
 
     implicit def jsonWritesApidocExampleUnionTypesGuestUser: play.api.libs.json.Writes[GuestUser] = {
       (obj: io.apibuilder.example.union.types.v0.models.GuestUser) => {
-        jsObjectGuestUser(obj)
+        io.apibuilder.example.union.types.v0.models.json.jsObjectGuestUser(obj)
       }
     }
 
@@ -291,13 +291,13 @@ package io.apibuilder.example.union.types.v0.models {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
         "email" -> play.api.libs.json.JsString(obj.email),
-        "preference" -> jsObjectFoobar(obj.preference)
+        "preference" -> io.apibuilder.example.union.types.v0.models.json.jsObjectFoobar(obj.preference)
       ) ++ play.api.libs.json.Json.obj("discriminator" -> "registered_user")
     }
 
     implicit def jsonWritesApidocExampleUnionTypesRegisteredUser: play.api.libs.json.Writes[RegisteredUser] = {
       (obj: io.apibuilder.example.union.types.v0.models.RegisteredUser) => {
-        jsObjectRegisteredUser(obj)
+        io.apibuilder.example.union.types.v0.models.json.jsObjectRegisteredUser(obj)
       }
     }
 
@@ -324,16 +324,16 @@ package io.apibuilder.example.union.types.v0.models {
     }
     implicit def jsonWritesApidocExampleUnionTypesFoobar: play.api.libs.json.Writes[Foobar] = {
       (obj: io.apibuilder.example.union.types.v0.models.Foobar) => {
-        jsObjectFoobar(obj)
+        io.apibuilder.example.union.types.v0.models.json.jsObjectFoobar(obj)
       }
     }
 
     implicit def jsonReadsApidocExampleUnionTypesUser: play.api.libs.json.Reads[io.apibuilder.example.union.types.v0.models.User] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "registered_user" => jsonReadsApidocExampleUnionTypesRegisteredUser.reads(js)
-          case "guest_user" => jsonReadsApidocExampleUnionTypesGuestUser.reads(js)
-          case "uuid" => jsonReadsApidocExampleUnionTypesUuid.reads(js)
+          case "registered_user" => io.apibuilder.example.union.types.v0.models.json.jsonReadsApidocExampleUnionTypesRegisteredUser.reads(js)
+          case "guest_user" => io.apibuilder.example.union.types.v0.models.json.jsonReadsApidocExampleUnionTypesGuestUser.reads(js)
+          case "uuid" => io.apibuilder.example.union.types.v0.models.json.jsonReadsApidocExampleUnionTypesUuid.reads(js)
           case other => play.api.libs.json.JsSuccess(io.apibuilder.example.union.types.v0.models.UserUndefinedType(other))
         }
       }
@@ -345,8 +345,8 @@ package io.apibuilder.example.union.types.v0.models {
 
     def jsObjectUser(obj: io.apibuilder.example.union.types.v0.models.User): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.example.union.types.v0.models.RegisteredUser => jsObjectRegisteredUser(x)
-        case x: io.apibuilder.example.union.types.v0.models.GuestUser => jsObjectGuestUser(x)
+        case x: io.apibuilder.example.union.types.v0.models.RegisteredUser => io.apibuilder.example.union.types.v0.models.json.jsObjectRegisteredUser(x)
+        case x: io.apibuilder.example.union.types.v0.models.GuestUser => io.apibuilder.example.union.types.v0.models.json.jsObjectGuestUser(x)
         case x: io.apibuilder.example.union.types.v0.models.UserUuid => play.api.libs.json.Json.obj("discriminator" -> "uuid", "value" -> play.api.libs.json.JsString(x.value.toString))
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
@@ -355,7 +355,7 @@ package io.apibuilder.example.union.types.v0.models {
     }
     implicit def jsonWritesApidocExampleUnionTypesUser: play.api.libs.json.Writes[User] = {
       (obj: io.apibuilder.example.union.types.v0.models.User) => {
-        jsObjectUser(obj)
+        io.apibuilder.example.union.types.v0.models.json.jsObjectUser(obj)
       }
     }
   }

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -223,7 +223,7 @@ package io.apibuilder.example.union.types.v0.models {
 
     implicit def jsonWritesApidocExampleUnionTypesBar: play.api.libs.json.Writes[Bar] = {
       (obj: io.apibuilder.example.union.types.v0.models.Bar) => {
-        jsonWritesApidocExampleUnionTypesBar(obj)
+        io.apibuilder.example.union.types.v0.models.json.jsonWritesApidocExampleUnionTypesBar(obj)
       }
     }
 
@@ -255,7 +255,7 @@ package io.apibuilder.example.union.types.v0.models {
 
     implicit def jsonWritesApidocExampleUnionTypesFoo: play.api.libs.json.Writes[Foo] = {
       (obj: io.apibuilder.example.union.types.v0.models.Foo) => {
-        jsonWritesApidocExampleUnionTypesFoo(obj)
+        io.apibuilder.example.union.types.v0.models.json.jsonWritesApidocExampleUnionTypesFoo(obj)
       }
     }
 
@@ -275,7 +275,7 @@ package io.apibuilder.example.union.types.v0.models {
 
     implicit def jsonWritesApidocExampleUnionTypesGuestUser: play.api.libs.json.Writes[GuestUser] = {
       (obj: io.apibuilder.example.union.types.v0.models.GuestUser) => {
-        jsObjectGuestUser(obj)
+        io.apibuilder.example.union.types.v0.models.json.jsObjectGuestUser(obj)
       }
     }
 
@@ -291,13 +291,13 @@ package io.apibuilder.example.union.types.v0.models {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
         "email" -> play.api.libs.json.JsString(obj.email),
-        "preference" -> jsObjectFoobar(obj.preference)
+        "preference" -> io.apibuilder.example.union.types.v0.models.json.jsObjectFoobar(obj.preference)
       ) ++ play.api.libs.json.Json.obj("discriminator" -> "registered_user")
     }
 
     implicit def jsonWritesApidocExampleUnionTypesRegisteredUser: play.api.libs.json.Writes[RegisteredUser] = {
       (obj: io.apibuilder.example.union.types.v0.models.RegisteredUser) => {
-        jsObjectRegisteredUser(obj)
+        io.apibuilder.example.union.types.v0.models.json.jsObjectRegisteredUser(obj)
       }
     }
 
@@ -324,16 +324,16 @@ package io.apibuilder.example.union.types.v0.models {
     }
     implicit def jsonWritesApidocExampleUnionTypesFoobar: play.api.libs.json.Writes[Foobar] = {
       (obj: io.apibuilder.example.union.types.v0.models.Foobar) => {
-        jsObjectFoobar(obj)
+        io.apibuilder.example.union.types.v0.models.json.jsObjectFoobar(obj)
       }
     }
 
     implicit def jsonReadsApidocExampleUnionTypesUser: play.api.libs.json.Reads[io.apibuilder.example.union.types.v0.models.User] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "registered_user" => jsonReadsApidocExampleUnionTypesRegisteredUser.reads(js)
-          case "guest_user" => jsonReadsApidocExampleUnionTypesGuestUser.reads(js)
-          case "uuid" => jsonReadsApidocExampleUnionTypesUuid.reads(js)
+          case "registered_user" => io.apibuilder.example.union.types.v0.models.json.jsonReadsApidocExampleUnionTypesRegisteredUser.reads(js)
+          case "guest_user" => io.apibuilder.example.union.types.v0.models.json.jsonReadsApidocExampleUnionTypesGuestUser.reads(js)
+          case "uuid" => io.apibuilder.example.union.types.v0.models.json.jsonReadsApidocExampleUnionTypesUuid.reads(js)
           case other => play.api.libs.json.JsSuccess(io.apibuilder.example.union.types.v0.models.UserUndefinedType(other))
         }
       }
@@ -345,8 +345,8 @@ package io.apibuilder.example.union.types.v0.models {
 
     def jsObjectUser(obj: io.apibuilder.example.union.types.v0.models.User): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.example.union.types.v0.models.RegisteredUser => jsObjectRegisteredUser(x)
-        case x: io.apibuilder.example.union.types.v0.models.GuestUser => jsObjectGuestUser(x)
+        case x: io.apibuilder.example.union.types.v0.models.RegisteredUser => io.apibuilder.example.union.types.v0.models.json.jsObjectRegisteredUser(x)
+        case x: io.apibuilder.example.union.types.v0.models.GuestUser => io.apibuilder.example.union.types.v0.models.json.jsObjectGuestUser(x)
         case x: io.apibuilder.example.union.types.v0.models.UserUuid => play.api.libs.json.Json.obj("discriminator" -> "uuid", "value" -> play.api.libs.json.JsString(x.value.toString))
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
@@ -355,7 +355,7 @@ package io.apibuilder.example.union.types.v0.models {
     }
     implicit def jsonWritesApidocExampleUnionTypesUser: play.api.libs.json.Writes[User] = {
       (obj: io.apibuilder.example.union.types.v0.models.User) => {
-        jsObjectUser(obj)
+        io.apibuilder.example.union.types.v0.models.json.jsObjectUser(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/collection-json-defaults-ahc-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ahc-client.txt
@@ -71,7 +71,7 @@ package com.gilt.test.v0.models {
 
     implicit def jsonWritesTestUser: play.api.libs.json.Writes[User] = {
       (obj: com.gilt.test.v0.models.User) => {
-        jsObjectUser(obj)
+        com.gilt.test.v0.models.json.jsObjectUser(obj)
       }
     }
 
@@ -95,7 +95,7 @@ package com.gilt.test.v0.models {
 
     implicit def jsonWritesTestUserPatch: play.api.libs.json.Writes[UserPatch] = {
       (obj: com.gilt.test.v0.models.UserPatch) => {
-        jsObjectUserPatch(obj)
+        com.gilt.test.v0.models.json.jsObjectUserPatch(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
@@ -71,7 +71,7 @@ package com.gilt.test.v0.models {
 
     implicit def jsonWritesTestUser: play.api.libs.json.Writes[User] = {
       (obj: com.gilt.test.v0.models.User) => {
-        jsObjectUser(obj)
+        com.gilt.test.v0.models.json.jsObjectUser(obj)
       }
     }
 
@@ -95,7 +95,7 @@ package com.gilt.test.v0.models {
 
     implicit def jsonWritesTestUserPatch: play.api.libs.json.Writes[UserPatch] = {
       (obj: com.gilt.test.v0.models.UserPatch) => {
-        jsObjectUserPatch(obj)
+        com.gilt.test.v0.models.json.jsObjectUserPatch(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
@@ -71,7 +71,7 @@ package com.gilt.test.v0.models {
 
     implicit def jsonWritesTestUser: play.api.libs.json.Writes[User] = {
       (obj: com.gilt.test.v0.models.User) => {
-        jsObjectUser(obj)
+        com.gilt.test.v0.models.json.jsObjectUser(obj)
       }
     }
 
@@ -95,7 +95,7 @@ package com.gilt.test.v0.models {
 
     implicit def jsonWritesTestUserPatch: play.api.libs.json.Writes[UserPatch] = {
       (obj: com.gilt.test.v0.models.UserPatch) => {
-        jsObjectUserPatch(obj)
+        com.gilt.test.v0.models.json.jsObjectUserPatch(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-2-json-spec-quality-healthcheck-writers.txt
+++ b/lib/src/test/resources/generators/play-2-json-spec-quality-healthcheck-writers.txt
@@ -6,6 +6,6 @@ def jsObjectHealthcheck(obj: com.gilt.quality.v0.models.Healthcheck): play.api.l
 
 implicit def jsonWritesQualityHealthcheck: play.api.libs.json.Writes[Healthcheck] = {
   (obj: com.gilt.quality.v0.models.Healthcheck) => {
-    jsObjectHealthcheck(obj)
+    com.gilt.quality.v0.models.json.jsObjectHealthcheck(obj)
   }
 }

--- a/lib/src/test/resources/generators/play-2-json-spec-quality-plan-writers.txt
+++ b/lib/src/test/resources/generators/play-2-json-spec-quality-plan-writers.txt
@@ -12,6 +12,6 @@ def jsObjectPlan(obj: com.gilt.quality.v0.models.Plan): play.api.libs.json.JsObj
 
 implicit def jsonWritesQualityPlan: play.api.libs.json.Writes[Plan] = {
   (obj: com.gilt.quality.v0.models.Plan) => {
-    jsObjectPlan(obj)
+    com.gilt.quality.v0.models.json.jsObjectPlan(obj)
   }
 }

--- a/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
+++ b/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
@@ -643,7 +643,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityExternalServiceName: play.api.libs.json.Writes[ExternalServiceName] = {
       (obj: com.gilt.quality.v0.models.ExternalServiceName) => {
-        jsonWritesQualityExternalServiceName(obj)
+        com.gilt.quality.v0.models.json.jsonWritesQualityExternalServiceName(obj)
       }
     }
 
@@ -675,7 +675,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityPublication: play.api.libs.json.Writes[Publication] = {
       (obj: com.gilt.quality.v0.models.Publication) => {
-        jsonWritesQualityPublication(obj)
+        com.gilt.quality.v0.models.json.jsonWritesQualityPublication(obj)
       }
     }
 
@@ -707,7 +707,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityResponse: play.api.libs.json.Writes[Response] = {
       (obj: com.gilt.quality.v0.models.Response) => {
-        jsonWritesQualityResponse(obj)
+        com.gilt.quality.v0.models.json.jsonWritesQualityResponse(obj)
       }
     }
 
@@ -739,7 +739,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualitySeverity: play.api.libs.json.Writes[Severity] = {
       (obj: com.gilt.quality.v0.models.Severity) => {
-        jsonWritesQualitySeverity(obj)
+        com.gilt.quality.v0.models.json.jsonWritesQualitySeverity(obj)
       }
     }
 
@@ -771,7 +771,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityTask: play.api.libs.json.Writes[Task] = {
       (obj: com.gilt.quality.v0.models.Task) => {
-        jsonWritesQualityTask(obj)
+        com.gilt.quality.v0.models.json.jsonWritesQualityTask(obj)
       }
     }
 
@@ -788,7 +788,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityAdjournForm: play.api.libs.json.Writes[AdjournForm] = {
       (obj: com.gilt.quality.v0.models.AdjournForm) => {
-        jsObjectAdjournForm(obj)
+        com.gilt.quality.v0.models.json.jsObjectAdjournForm(obj)
       }
     }
 
@@ -804,15 +804,15 @@ package com.gilt.quality.v0.models {
     def jsObjectAgendaItem(obj: com.gilt.quality.v0.models.AgendaItem): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "id" -> play.api.libs.json.JsNumber(obj.id),
-        "meeting" -> jsObjectMeeting(obj.meeting),
-        "incident" -> jsObjectIncident(obj.incident),
+        "meeting" -> com.gilt.quality.v0.models.json.jsObjectMeeting(obj.meeting),
+        "incident" -> com.gilt.quality.v0.models.json.jsObjectIncident(obj.incident),
         "task" -> play.api.libs.json.JsString(obj.task.toString)
       )
     }
 
     implicit def jsonWritesQualityAgendaItem: play.api.libs.json.Writes[AgendaItem] = {
       (obj: com.gilt.quality.v0.models.AgendaItem) => {
-        jsObjectAgendaItem(obj)
+        com.gilt.quality.v0.models.json.jsObjectAgendaItem(obj)
       }
     }
 
@@ -834,7 +834,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityAgendaItemForm: play.api.libs.json.Writes[AgendaItemForm] = {
       (obj: com.gilt.quality.v0.models.AgendaItemForm) => {
-        jsObjectAgendaItemForm(obj)
+        com.gilt.quality.v0.models.json.jsObjectAgendaItemForm(obj)
       }
     }
 
@@ -850,7 +850,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityAuthenticationForm: play.api.libs.json.Writes[AuthenticationForm] = {
       (obj: com.gilt.quality.v0.models.AuthenticationForm) => {
-        jsObjectAuthenticationForm(obj)
+        com.gilt.quality.v0.models.json.jsObjectAuthenticationForm(obj)
       }
     }
 
@@ -870,7 +870,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityEmailMessage: play.api.libs.json.Writes[EmailMessage] = {
       (obj: com.gilt.quality.v0.models.EmailMessage) => {
-        jsObjectEmailMessage(obj)
+        com.gilt.quality.v0.models.json.jsObjectEmailMessage(obj)
       }
     }
 
@@ -890,7 +890,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityError: play.api.libs.json.Writes[Error] = {
       (obj: com.gilt.quality.v0.models.Error) => {
-        jsObjectError(obj)
+        com.gilt.quality.v0.models.json.jsObjectError(obj)
       }
     }
 
@@ -907,7 +907,7 @@ package com.gilt.quality.v0.models {
     def jsObjectExternalService(obj: com.gilt.quality.v0.models.ExternalService): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "id" -> play.api.libs.json.JsNumber(obj.id),
-        "organization" -> jsObjectOrganization(obj.organization),
+        "organization" -> com.gilt.quality.v0.models.json.jsObjectOrganization(obj.organization),
         "name" -> play.api.libs.json.JsString(obj.name.toString),
         "url" -> play.api.libs.json.JsString(obj.url),
         "username" -> play.api.libs.json.JsString(obj.username)
@@ -916,7 +916,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityExternalService: play.api.libs.json.Writes[ExternalService] = {
       (obj: com.gilt.quality.v0.models.ExternalService) => {
-        jsObjectExternalService(obj)
+        com.gilt.quality.v0.models.json.jsObjectExternalService(obj)
       }
     }
 
@@ -940,7 +940,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityExternalServiceForm: play.api.libs.json.Writes[ExternalServiceForm] = {
       (obj: com.gilt.quality.v0.models.ExternalServiceForm) => {
-        jsObjectExternalServiceForm(obj)
+        com.gilt.quality.v0.models.json.jsObjectExternalServiceForm(obj)
       }
     }
 
@@ -955,14 +955,14 @@ package com.gilt.quality.v0.models {
     def jsObjectFollowup(obj: com.gilt.quality.v0.models.Followup): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "key" -> play.api.libs.json.JsString(obj.key),
-        "plan" -> jsObjectPlan(obj.plan),
+        "plan" -> com.gilt.quality.v0.models.json.jsObjectPlan(obj.plan),
         "sent_at" -> play.api.libs.json.JsString(_root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(obj.sentAt))
       )
     }
 
     implicit def jsonWritesQualityFollowup: play.api.libs.json.Writes[Followup] = {
       (obj: com.gilt.quality.v0.models.Followup) => {
-        jsObjectFollowup(obj)
+        com.gilt.quality.v0.models.json.jsObjectFollowup(obj)
       }
     }
 
@@ -977,16 +977,16 @@ package com.gilt.quality.v0.models {
 
     def jsObjectFollowupResponse(obj: com.gilt.quality.v0.models.FollowupResponse): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "followup" -> jsObjectFollowup(obj.followup),
+        "followup" -> com.gilt.quality.v0.models.json.jsObjectFollowup(obj.followup),
         "response" -> play.api.libs.json.JsString(obj.response.toString),
         "created_at" -> play.api.libs.json.JsString(_root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(obj.createdAt)),
-        "created_by" -> jsObjectUser(obj.createdBy)
+        "created_by" -> com.gilt.quality.v0.models.json.jsObjectUser(obj.createdBy)
       )
     }
 
     implicit def jsonWritesQualityFollowupResponse: play.api.libs.json.Writes[FollowupResponse] = {
       (obj: com.gilt.quality.v0.models.FollowupResponse) => {
-        jsObjectFollowupResponse(obj)
+        com.gilt.quality.v0.models.json.jsObjectFollowupResponse(obj)
       }
     }
 
@@ -1002,7 +1002,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityHealthcheck: play.api.libs.json.Writes[Healthcheck] = {
       (obj: com.gilt.quality.v0.models.Healthcheck) => {
-        jsObjectHealthcheck(obj)
+        com.gilt.quality.v0.models.json.jsObjectHealthcheck(obj)
       }
     }
 
@@ -1022,7 +1022,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityIcons: play.api.libs.json.Writes[Icons] = {
       (obj: com.gilt.quality.v0.models.Icons) => {
-        jsObjectIcons(obj)
+        com.gilt.quality.v0.models.json.jsObjectIcons(obj)
       }
     }
 
@@ -1043,7 +1043,7 @@ package com.gilt.quality.v0.models {
     def jsObjectIncident(obj: com.gilt.quality.v0.models.Incident): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "id" -> play.api.libs.json.JsNumber(obj.id),
-        "organization" -> jsObjectOrganization(obj.organization),
+        "organization" -> com.gilt.quality.v0.models.json.jsObjectOrganization(obj.organization),
         "summary" -> play.api.libs.json.JsString(obj.summary),
         "severity" -> play.api.libs.json.JsString(obj.severity.toString),
         "created_at" -> play.api.libs.json.JsString(_root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(obj.createdAt))
@@ -1053,7 +1053,7 @@ package com.gilt.quality.v0.models {
       }) ++
       (obj.team match {
         case None => play.api.libs.json.Json.obj()
-        case Some(x) => play.api.libs.json.Json.obj("team" -> jsObjectTeam(x))
+        case Some(x) => play.api.libs.json.Json.obj("team" -> com.gilt.quality.v0.models.json.jsObjectTeam(x))
       }) ++
       (obj.tags match {
         case None => play.api.libs.json.Json.obj()
@@ -1061,13 +1061,13 @@ package com.gilt.quality.v0.models {
       }) ++
       (obj.plan match {
         case None => play.api.libs.json.Json.obj()
-        case Some(x) => play.api.libs.json.Json.obj("plan" -> jsObjectPlan(x))
+        case Some(x) => play.api.libs.json.Json.obj("plan" -> com.gilt.quality.v0.models.json.jsObjectPlan(x))
       })
     }
 
     implicit def jsonWritesQualityIncident: play.api.libs.json.Writes[Incident] = {
       (obj: com.gilt.quality.v0.models.Incident) => {
-        jsObjectIncident(obj)
+        com.gilt.quality.v0.models.json.jsObjectIncident(obj)
       }
     }
 
@@ -1101,7 +1101,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityIncidentForm: play.api.libs.json.Writes[IncidentForm] = {
       (obj: com.gilt.quality.v0.models.IncidentForm) => {
-        jsObjectIncidentForm(obj)
+        com.gilt.quality.v0.models.json.jsObjectIncidentForm(obj)
       }
     }
 
@@ -1121,7 +1121,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityIncidentOrganizationChange: play.api.libs.json.Writes[IncidentOrganizationChange] = {
       (obj: com.gilt.quality.v0.models.IncidentOrganizationChange) => {
-        jsObjectIncidentOrganizationChange(obj)
+        com.gilt.quality.v0.models.json.jsObjectIncidentOrganizationChange(obj)
       }
     }
 
@@ -1143,7 +1143,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityIncidentSummary: play.api.libs.json.Writes[IncidentSummary] = {
       (obj: com.gilt.quality.v0.models.IncidentSummary) => {
-        jsObjectIncidentSummary(obj)
+        com.gilt.quality.v0.models.json.jsObjectIncidentSummary(obj)
       }
     }
 
@@ -1159,7 +1159,7 @@ package com.gilt.quality.v0.models {
     def jsObjectMeeting(obj: com.gilt.quality.v0.models.Meeting): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "id" -> play.api.libs.json.JsNumber(obj.id),
-        "organization" -> jsObjectOrganization(obj.organization),
+        "organization" -> com.gilt.quality.v0.models.json.jsObjectOrganization(obj.organization),
         "scheduled_at" -> play.api.libs.json.JsString(_root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(obj.scheduledAt))
       ) ++ (obj.adjournedAt match {
         case None => play.api.libs.json.Json.obj()
@@ -1169,7 +1169,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityMeeting: play.api.libs.json.Writes[Meeting] = {
       (obj: com.gilt.quality.v0.models.Meeting) => {
-        jsObjectMeeting(obj)
+        com.gilt.quality.v0.models.json.jsObjectMeeting(obj)
       }
     }
 
@@ -1185,7 +1185,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityMeetingForm: play.api.libs.json.Writes[MeetingForm] = {
       (obj: com.gilt.quality.v0.models.MeetingForm) => {
-        jsObjectMeetingForm(obj)
+        com.gilt.quality.v0.models.json.jsObjectMeetingForm(obj)
       }
     }
 
@@ -1199,20 +1199,20 @@ package com.gilt.quality.v0.models {
 
     def jsObjectMeetingPager(obj: com.gilt.quality.v0.models.MeetingPager): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "meeting" -> jsObjectMeeting(obj.meeting)
+        "meeting" -> com.gilt.quality.v0.models.json.jsObjectMeeting(obj.meeting)
       ) ++ (obj.priorIncident match {
         case None => play.api.libs.json.Json.obj()
-        case Some(x) => play.api.libs.json.Json.obj("prior_incident" -> jsObjectIncident(x))
+        case Some(x) => play.api.libs.json.Json.obj("prior_incident" -> com.gilt.quality.v0.models.json.jsObjectIncident(x))
       }) ++
       (obj.nextIncident match {
         case None => play.api.libs.json.Json.obj()
-        case Some(x) => play.api.libs.json.Json.obj("next_incident" -> jsObjectIncident(x))
+        case Some(x) => play.api.libs.json.Json.obj("next_incident" -> com.gilt.quality.v0.models.json.jsObjectIncident(x))
       })
     }
 
     implicit def jsonWritesQualityMeetingPager: play.api.libs.json.Writes[MeetingPager] = {
       (obj: com.gilt.quality.v0.models.MeetingPager) => {
-        jsObjectMeetingPager(obj)
+        com.gilt.quality.v0.models.json.jsObjectMeetingPager(obj)
       }
     }
 
@@ -1232,7 +1232,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityOrganization: play.api.libs.json.Writes[Organization] = {
       (obj: com.gilt.quality.v0.models.Organization) => {
-        jsObjectOrganization(obj)
+        com.gilt.quality.v0.models.json.jsObjectOrganization(obj)
       }
     }
 
@@ -1254,7 +1254,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityOrganizationForm: play.api.libs.json.Writes[OrganizationForm] = {
       (obj: com.gilt.quality.v0.models.OrganizationForm) => {
-        jsObjectOrganizationForm(obj)
+        com.gilt.quality.v0.models.json.jsObjectOrganizationForm(obj)
       }
     }
 
@@ -1282,7 +1282,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityPlan: play.api.libs.json.Writes[Plan] = {
       (obj: com.gilt.quality.v0.models.Plan) => {
-        jsObjectPlan(obj)
+        com.gilt.quality.v0.models.json.jsObjectPlan(obj)
       }
     }
 
@@ -1302,7 +1302,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityPlanForm: play.api.libs.json.Writes[PlanForm] = {
       (obj: com.gilt.quality.v0.models.PlanForm) => {
-        jsObjectPlanForm(obj)
+        com.gilt.quality.v0.models.json.jsObjectPlanForm(obj)
       }
     }
 
@@ -1320,7 +1320,7 @@ package com.gilt.quality.v0.models {
 
     def jsObjectStatistic(obj: com.gilt.quality.v0.models.Statistic): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "team" -> jsObjectTeam(obj.team),
+        "team" -> com.gilt.quality.v0.models.json.jsObjectTeam(obj.team),
         "total_grades" -> play.api.libs.json.JsNumber(obj.totalGrades),
         "total_open_incidents" -> play.api.libs.json.JsNumber(obj.totalOpenIncidents),
         "total_incidents" -> play.api.libs.json.JsNumber(obj.totalIncidents),
@@ -1337,7 +1337,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityStatistic: play.api.libs.json.Writes[Statistic] = {
       (obj: com.gilt.quality.v0.models.Statistic) => {
-        jsObjectStatistic(obj)
+        com.gilt.quality.v0.models.json.jsObjectStatistic(obj)
       }
     }
 
@@ -1353,15 +1353,15 @@ package com.gilt.quality.v0.models {
     def jsObjectSubscription(obj: com.gilt.quality.v0.models.Subscription): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "id" -> play.api.libs.json.JsNumber(obj.id),
-        "organization" -> jsObjectOrganization(obj.organization),
-        "user" -> jsObjectUser(obj.user),
+        "organization" -> com.gilt.quality.v0.models.json.jsObjectOrganization(obj.organization),
+        "user" -> com.gilt.quality.v0.models.json.jsObjectUser(obj.user),
         "publication" -> play.api.libs.json.JsString(obj.publication.toString)
       )
     }
 
     implicit def jsonWritesQualitySubscription: play.api.libs.json.Writes[Subscription] = {
       (obj: com.gilt.quality.v0.models.Subscription) => {
-        jsObjectSubscription(obj)
+        com.gilt.quality.v0.models.json.jsObjectSubscription(obj)
       }
     }
 
@@ -1383,7 +1383,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualitySubscriptionForm: play.api.libs.json.Writes[SubscriptionForm] = {
       (obj: com.gilt.quality.v0.models.SubscriptionForm) => {
-        jsObjectSubscriptionForm(obj)
+        com.gilt.quality.v0.models.json.jsObjectSubscriptionForm(obj)
       }
     }
 
@@ -1398,9 +1398,9 @@ package com.gilt.quality.v0.models {
 
     def jsObjectTeam(obj: com.gilt.quality.v0.models.Team): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "organization" -> jsObjectOrganization(obj.organization),
+        "organization" -> com.gilt.quality.v0.models.json.jsObjectOrganization(obj.organization),
         "key" -> play.api.libs.json.JsString(obj.key),
-        "icons" -> jsObjectIcons(obj.icons)
+        "icons" -> com.gilt.quality.v0.models.json.jsObjectIcons(obj.icons)
       ) ++ (obj.email match {
         case None => play.api.libs.json.Json.obj()
         case Some(x) => play.api.libs.json.Json.obj("email" -> play.api.libs.json.JsString(x))
@@ -1409,7 +1409,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityTeam: play.api.libs.json.Writes[Team] = {
       (obj: com.gilt.quality.v0.models.Team) => {
-        jsObjectTeam(obj)
+        com.gilt.quality.v0.models.json.jsObjectTeam(obj)
       }
     }
 
@@ -1441,7 +1441,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityTeamForm: play.api.libs.json.Writes[TeamForm] = {
       (obj: com.gilt.quality.v0.models.TeamForm) => {
-        jsObjectTeamForm(obj)
+        com.gilt.quality.v0.models.json.jsObjectTeamForm(obj)
       }
     }
 
@@ -1454,14 +1454,14 @@ package com.gilt.quality.v0.models {
 
     def jsObjectTeamMember(obj: com.gilt.quality.v0.models.TeamMember): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "team" -> jsObjectTeam(obj.team),
-        "user" -> jsObjectUser(obj.user)
+        "team" -> com.gilt.quality.v0.models.json.jsObjectTeam(obj.team),
+        "user" -> com.gilt.quality.v0.models.json.jsObjectUser(obj.user)
       )
     }
 
     implicit def jsonWritesQualityTeamMember: play.api.libs.json.Writes[TeamMember] = {
       (obj: com.gilt.quality.v0.models.TeamMember) => {
-        jsObjectTeamMember(obj)
+        com.gilt.quality.v0.models.json.jsObjectTeamMember(obj)
       }
     }
 
@@ -1474,14 +1474,14 @@ package com.gilt.quality.v0.models {
 
     def jsObjectTeamMemberSummary(obj: com.gilt.quality.v0.models.TeamMemberSummary): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "team" -> jsObjectTeam(obj.team),
+        "team" -> com.gilt.quality.v0.models.json.jsObjectTeam(obj.team),
         "number_members" -> play.api.libs.json.JsNumber(obj.numberMembers)
       )
     }
 
     implicit def jsonWritesQualityTeamMemberSummary: play.api.libs.json.Writes[TeamMemberSummary] = {
       (obj: com.gilt.quality.v0.models.TeamMemberSummary) => {
-        jsObjectTeamMemberSummary(obj)
+        com.gilt.quality.v0.models.json.jsObjectTeamMemberSummary(obj)
       }
     }
 
@@ -1510,7 +1510,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityUpdateTeamForm: play.api.libs.json.Writes[UpdateTeamForm] = {
       (obj: com.gilt.quality.v0.models.UpdateTeamForm) => {
-        jsObjectUpdateTeamForm(obj)
+        com.gilt.quality.v0.models.json.jsObjectUpdateTeamForm(obj)
       }
     }
 
@@ -1530,7 +1530,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityUser: play.api.libs.json.Writes[User] = {
       (obj: com.gilt.quality.v0.models.User) => {
-        jsObjectUser(obj)
+        com.gilt.quality.v0.models.json.jsObjectUser(obj)
       }
     }
 
@@ -1546,7 +1546,7 @@ package com.gilt.quality.v0.models {
 
     implicit def jsonWritesQualityUserForm: play.api.libs.json.Writes[UserForm] = {
       (obj: com.gilt.quality.v0.models.UserForm) => {
-        jsObjectUserForm(obj)
+        com.gilt.quality.v0.models.json.jsObjectUserForm(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-22-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-22-built-in-types.txt
@@ -127,7 +127,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesArray: play.api.libs.json.Writes[Array] = {
       (obj: apibuilder.models.Array) => {
-        jsObjectArray(obj)
+        apibuilder.models.json.jsObjectArray(obj)
       }
     }
 
@@ -196,7 +196,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptarray: play.api.libs.json.Writes[Optarray] = {
       (obj: apibuilder.models.Optarray) => {
-        jsObjectOptarray(obj)
+        apibuilder.models.json.jsObjectOptarray(obj)
       }
     }
 
@@ -265,7 +265,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptional: play.api.libs.json.Writes[Optional] = {
       (obj: apibuilder.models.Optional) => {
-        jsObjectOptional(obj)
+        apibuilder.models.json.jsObjectOptional(obj)
       }
     }
 
@@ -303,7 +303,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesRequired: play.api.libs.json.Writes[Required] = {
       (obj: apibuilder.models.Required) => {
-        jsObjectRequired(obj)
+        apibuilder.models.json.jsObjectRequired(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-23-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-23-built-in-types.txt
@@ -127,7 +127,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesArray: play.api.libs.json.Writes[Array] = {
       (obj: apibuilder.models.Array) => {
-        jsObjectArray(obj)
+        apibuilder.models.json.jsObjectArray(obj)
       }
     }
 
@@ -196,7 +196,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptarray: play.api.libs.json.Writes[Optarray] = {
       (obj: apibuilder.models.Optarray) => {
-        jsObjectOptarray(obj)
+        apibuilder.models.json.jsObjectOptarray(obj)
       }
     }
 
@@ -265,7 +265,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptional: play.api.libs.json.Writes[Optional] = {
       (obj: apibuilder.models.Optional) => {
-        jsObjectOptional(obj)
+        apibuilder.models.json.jsObjectOptional(obj)
       }
     }
 
@@ -303,7 +303,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesRequired: play.api.libs.json.Writes[Required] = {
       (obj: apibuilder.models.Required) => {
-        jsObjectRequired(obj)
+        apibuilder.models.json.jsObjectRequired(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-24-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-24-built-in-types.txt
@@ -127,7 +127,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesArray: play.api.libs.json.Writes[Array] = {
       (obj: apibuilder.models.Array) => {
-        jsObjectArray(obj)
+        apibuilder.models.json.jsObjectArray(obj)
       }
     }
 
@@ -196,7 +196,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptarray: play.api.libs.json.Writes[Optarray] = {
       (obj: apibuilder.models.Optarray) => {
-        jsObjectOptarray(obj)
+        apibuilder.models.json.jsObjectOptarray(obj)
       }
     }
 
@@ -265,7 +265,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptional: play.api.libs.json.Writes[Optional] = {
       (obj: apibuilder.models.Optional) => {
-        jsObjectOptional(obj)
+        apibuilder.models.json.jsObjectOptional(obj)
       }
     }
 
@@ -303,7 +303,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesRequired: play.api.libs.json.Writes[Required] = {
       (obj: apibuilder.models.Required) => {
-        jsObjectRequired(obj)
+        apibuilder.models.json.jsObjectRequired(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-25-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-25-built-in-types.txt
@@ -127,7 +127,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesArray: play.api.libs.json.Writes[Array] = {
       (obj: apibuilder.models.Array) => {
-        jsObjectArray(obj)
+        apibuilder.models.json.jsObjectArray(obj)
       }
     }
 
@@ -196,7 +196,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptarray: play.api.libs.json.Writes[Optarray] = {
       (obj: apibuilder.models.Optarray) => {
-        jsObjectOptarray(obj)
+        apibuilder.models.json.jsObjectOptarray(obj)
       }
     }
 
@@ -265,7 +265,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptional: play.api.libs.json.Writes[Optional] = {
       (obj: apibuilder.models.Optional) => {
-        jsObjectOptional(obj)
+        apibuilder.models.json.jsObjectOptional(obj)
       }
     }
 
@@ -303,7 +303,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesRequired: play.api.libs.json.Writes[Required] = {
       (obj: apibuilder.models.Required) => {
-        jsObjectRequired(obj)
+        apibuilder.models.json.jsObjectRequired(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-26-apidoc-api.txt
+++ b/lib/src/test/resources/generators/play-26-apidoc-api.txt
@@ -852,7 +852,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOriginalType: play.api.libs.json.Writes[OriginalType] = {
       (obj: io.apibuilder.api.v0.models.OriginalType) => {
-        jsonWritesApidocApiOriginalType(obj)
+        io.apibuilder.api.v0.models.json.jsonWritesApidocApiOriginalType(obj)
       }
     }
 
@@ -884,7 +884,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiPublication: play.api.libs.json.Writes[Publication] = {
       (obj: io.apibuilder.api.v0.models.Publication) => {
-        jsonWritesApidocApiPublication(obj)
+        io.apibuilder.api.v0.models.json.jsonWritesApidocApiPublication(obj)
       }
     }
 
@@ -916,7 +916,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiVisibility: play.api.libs.json.Writes[Visibility] = {
       (obj: io.apibuilder.api.v0.models.Visibility) => {
-        jsonWritesApidocApiVisibility(obj)
+        io.apibuilder.api.v0.models.json.jsonWritesApidocApiVisibility(obj)
       }
     }
 
@@ -948,7 +948,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiApplication: play.api.libs.json.Writes[Application] = {
       (obj: io.apibuilder.api.v0.models.Application) => {
-        jsObjectApplication(obj)
+        io.apibuilder.api.v0.models.json.jsObjectApplication(obj)
       }
     }
 
@@ -977,7 +977,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiApplicationForm: play.api.libs.json.Writes[ApplicationForm] = {
       (obj: io.apibuilder.api.v0.models.ApplicationForm) => {
-        jsObjectApplicationForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectApplicationForm(obj)
       }
     }
 
@@ -999,7 +999,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiApplicationSummary: play.api.libs.json.Writes[ApplicationSummary] = {
       (obj: io.apibuilder.api.v0.models.ApplicationSummary) => {
-        jsObjectApplicationSummary(obj)
+        io.apibuilder.api.v0.models.json.jsObjectApplicationSummary(obj)
       }
     }
 
@@ -1025,7 +1025,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttribute: play.api.libs.json.Writes[Attribute] = {
       (obj: io.apibuilder.api.v0.models.Attribute) => {
-        jsObjectAttribute(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttribute(obj)
       }
     }
 
@@ -1047,7 +1047,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttributeForm: play.api.libs.json.Writes[AttributeForm] = {
       (obj: io.apibuilder.api.v0.models.AttributeForm) => {
-        jsObjectAttributeForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttributeForm(obj)
       }
     }
 
@@ -1067,7 +1067,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttributeSummary: play.api.libs.json.Writes[AttributeSummary] = {
       (obj: io.apibuilder.api.v0.models.AttributeSummary) => {
-        jsObjectAttributeSummary(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttributeSummary(obj)
       }
     }
 
@@ -1083,7 +1083,7 @@ package io.apibuilder.api.v0.models {
     def jsObjectAttributeValue(obj: io.apibuilder.api.v0.models.AttributeValue): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "attribute" -> jsObjectAttributeSummary(obj.attribute),
+        "attribute" -> io.apibuilder.api.v0.models.json.jsObjectAttributeSummary(obj.attribute),
         "value" -> play.api.libs.json.JsString(obj.value),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
@@ -1091,7 +1091,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttributeValue: play.api.libs.json.Writes[AttributeValue] = {
       (obj: io.apibuilder.api.v0.models.AttributeValue) => {
-        jsObjectAttributeValue(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttributeValue(obj)
       }
     }
 
@@ -1107,7 +1107,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttributeValueForm: play.api.libs.json.Writes[AttributeValueForm] = {
       (obj: io.apibuilder.api.v0.models.AttributeValueForm) => {
-        jsObjectAttributeValueForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttributeValueForm(obj)
       }
     }
 
@@ -1130,18 +1130,18 @@ package io.apibuilder.api.v0.models {
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
         "organization" -> io.apibuilder.common.v0.models.json.jsObjectReference(obj.organization),
         "application" -> io.apibuilder.common.v0.models.json.jsObjectReference(obj.application),
-        "from_version" -> jsObjectChangeVersion(obj.fromVersion),
-        "to_version" -> jsObjectChangeVersion(obj.toVersion),
-        "diff" -> jsObjectDiff(obj.diff),
+        "from_version" -> io.apibuilder.api.v0.models.json.jsObjectChangeVersion(obj.fromVersion),
+        "to_version" -> io.apibuilder.api.v0.models.json.jsObjectChangeVersion(obj.toVersion),
+        "diff" -> io.apibuilder.api.v0.models.json.jsObjectDiff(obj.diff),
         "changed_at" -> play.api.libs.json.JsString(_root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(obj.changedAt)),
-        "changed_by" -> jsObjectUserSummary(obj.changedBy),
+        "changed_by" -> io.apibuilder.api.v0.models.json.jsObjectUserSummary(obj.changedBy),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
     }
 
     implicit def jsonWritesApidocApiChange: play.api.libs.json.Writes[Change] = {
       (obj: io.apibuilder.api.v0.models.Change) => {
-        jsObjectChange(obj)
+        io.apibuilder.api.v0.models.json.jsObjectChange(obj)
       }
     }
 
@@ -1161,7 +1161,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiChangeVersion: play.api.libs.json.Writes[ChangeVersion] = {
       (obj: io.apibuilder.api.v0.models.ChangeVersion) => {
-        jsObjectChangeVersion(obj)
+        io.apibuilder.api.v0.models.json.jsObjectChangeVersion(obj)
       }
     }
 
@@ -1177,7 +1177,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiCleartextToken: play.api.libs.json.Writes[CleartextToken] = {
       (obj: io.apibuilder.api.v0.models.CleartextToken) => {
-        jsObjectCleartextToken(obj)
+        io.apibuilder.api.v0.models.json.jsObjectCleartextToken(obj)
       }
     }
 
@@ -1191,7 +1191,7 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectCode(obj: io.apibuilder.api.v0.models.Code): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "generator" -> jsObjectGeneratorWithService(obj.generator),
+        "generator" -> io.apibuilder.api.v0.models.json.jsObjectGeneratorWithService(obj.generator),
         "source" -> play.api.libs.json.JsString(obj.source),
         "files" -> play.api.libs.json.Json.toJson(obj.files)
       )
@@ -1199,7 +1199,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiCode: play.api.libs.json.Writes[Code] = {
       (obj: io.apibuilder.api.v0.models.Code) => {
-        jsObjectCode(obj)
+        io.apibuilder.api.v0.models.json.jsObjectCode(obj)
       }
     }
 
@@ -1215,7 +1215,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiDiffBreaking: play.api.libs.json.Writes[DiffBreaking] = {
       (obj: io.apibuilder.api.v0.models.DiffBreaking) => {
-        jsObjectDiffBreaking(obj)
+        io.apibuilder.api.v0.models.json.jsObjectDiffBreaking(obj)
       }
     }
 
@@ -1231,7 +1231,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiDiffNonBreaking: play.api.libs.json.Writes[DiffNonBreaking] = {
       (obj: io.apibuilder.api.v0.models.DiffNonBreaking) => {
-        jsObjectDiffNonBreaking(obj)
+        io.apibuilder.api.v0.models.json.jsObjectDiffNonBreaking(obj)
       }
     }
 
@@ -1247,7 +1247,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiDomain: play.api.libs.json.Writes[Domain] = {
       (obj: io.apibuilder.api.v0.models.Domain) => {
-        jsObjectDomain(obj)
+        io.apibuilder.api.v0.models.json.jsObjectDomain(obj)
       }
     }
 
@@ -1263,7 +1263,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiEmailVerificationConfirmationForm: play.api.libs.json.Writes[EmailVerificationConfirmationForm] = {
       (obj: io.apibuilder.api.v0.models.EmailVerificationConfirmationForm) => {
-        jsObjectEmailVerificationConfirmationForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectEmailVerificationConfirmationForm(obj)
       }
     }
 
@@ -1283,7 +1283,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiError: play.api.libs.json.Writes[Error] = {
       (obj: io.apibuilder.api.v0.models.Error) => {
-        jsObjectError(obj)
+        io.apibuilder.api.v0.models.json.jsObjectError(obj)
       }
     }
 
@@ -1303,7 +1303,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiGeneratorForm: play.api.libs.json.Writes[GeneratorForm] = {
       (obj: io.apibuilder.api.v0.models.GeneratorForm) => {
-        jsObjectGeneratorForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectGeneratorForm(obj)
       }
     }
 
@@ -1325,7 +1325,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiGeneratorService: play.api.libs.json.Writes[GeneratorService] = {
       (obj: io.apibuilder.api.v0.models.GeneratorService) => {
-        jsObjectGeneratorService(obj)
+        io.apibuilder.api.v0.models.json.jsObjectGeneratorService(obj)
       }
     }
 
@@ -1341,7 +1341,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiGeneratorServiceForm: play.api.libs.json.Writes[GeneratorServiceForm] = {
       (obj: io.apibuilder.api.v0.models.GeneratorServiceForm) => {
-        jsObjectGeneratorServiceForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectGeneratorServiceForm(obj)
       }
     }
 
@@ -1354,14 +1354,14 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectGeneratorWithService(obj: io.apibuilder.api.v0.models.GeneratorWithService): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "service" -> jsObjectGeneratorService(obj.service),
+        "service" -> io.apibuilder.api.v0.models.json.jsObjectGeneratorService(obj.service),
         "generator" -> io.apibuilder.generator.v0.models.json.jsObjectGenerator(obj.generator)
       )
     }
 
     implicit def jsonWritesApidocApiGeneratorWithService: play.api.libs.json.Writes[GeneratorWithService] = {
       (obj: io.apibuilder.api.v0.models.GeneratorWithService) => {
-        jsObjectGeneratorWithService(obj)
+        io.apibuilder.api.v0.models.json.jsObjectGeneratorWithService(obj)
       }
     }
 
@@ -1377,7 +1377,7 @@ package io.apibuilder.api.v0.models {
     def jsObjectItem(obj: io.apibuilder.api.v0.models.Item): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "detail" -> jsObjectItemDetail(obj.detail),
+        "detail" -> io.apibuilder.api.v0.models.json.jsObjectItemDetail(obj.detail),
         "label" -> play.api.libs.json.JsString(obj.label)
       ) ++ (obj.description match {
         case None => play.api.libs.json.Json.obj()
@@ -1387,7 +1387,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiItem: play.api.libs.json.Writes[Item] = {
       (obj: io.apibuilder.api.v0.models.Item) => {
-        jsObjectItem(obj)
+        io.apibuilder.api.v0.models.json.jsObjectItem(obj)
       }
     }
 
@@ -1404,8 +1404,8 @@ package io.apibuilder.api.v0.models {
     def jsObjectMembership(obj: io.apibuilder.api.v0.models.Membership): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "user" -> jsObjectUser(obj.user),
-        "organization" -> jsObjectOrganization(obj.organization),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.api.v0.models.json.jsObjectOrganization(obj.organization),
         "role" -> play.api.libs.json.JsString(obj.role),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
@@ -1413,7 +1413,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiMembership: play.api.libs.json.Writes[Membership] = {
       (obj: io.apibuilder.api.v0.models.Membership) => {
-        jsObjectMembership(obj)
+        io.apibuilder.api.v0.models.json.jsObjectMembership(obj)
       }
     }
 
@@ -1430,8 +1430,8 @@ package io.apibuilder.api.v0.models {
     def jsObjectMembershipRequest(obj: io.apibuilder.api.v0.models.MembershipRequest): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "user" -> jsObjectUser(obj.user),
-        "organization" -> jsObjectOrganization(obj.organization),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.api.v0.models.json.jsObjectOrganization(obj.organization),
         "role" -> play.api.libs.json.JsString(obj.role),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
@@ -1439,7 +1439,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiMembershipRequest: play.api.libs.json.Writes[MembershipRequest] = {
       (obj: io.apibuilder.api.v0.models.MembershipRequest) => {
-        jsObjectMembershipRequest(obj)
+        io.apibuilder.api.v0.models.json.jsObjectMembershipRequest(obj)
       }
     }
 
@@ -1455,7 +1455,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiMoveForm: play.api.libs.json.Writes[MoveForm] = {
       (obj: io.apibuilder.api.v0.models.MoveForm) => {
-        jsObjectMoveForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectMoveForm(obj)
       }
     }
 
@@ -1485,7 +1485,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOrganization: play.api.libs.json.Writes[Organization] = {
       (obj: io.apibuilder.api.v0.models.Organization) => {
-        jsObjectOrganization(obj)
+        io.apibuilder.api.v0.models.json.jsObjectOrganization(obj)
       }
     }
 
@@ -1516,7 +1516,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOrganizationForm: play.api.libs.json.Writes[OrganizationForm] = {
       (obj: io.apibuilder.api.v0.models.OrganizationForm) => {
-        jsObjectOrganizationForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectOrganizationForm(obj)
       }
     }
 
@@ -1536,7 +1536,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOriginal: play.api.libs.json.Writes[Original] = {
       (obj: io.apibuilder.api.v0.models.Original) => {
-        jsObjectOriginal(obj)
+        io.apibuilder.api.v0.models.json.jsObjectOriginal(obj)
       }
     }
 
@@ -1558,7 +1558,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOriginalForm: play.api.libs.json.Writes[OriginalForm] = {
       (obj: io.apibuilder.api.v0.models.OriginalForm) => {
-        jsObjectOriginalForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectOriginalForm(obj)
       }
     }
 
@@ -1578,7 +1578,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiPasswordReset: play.api.libs.json.Writes[PasswordReset] = {
       (obj: io.apibuilder.api.v0.models.PasswordReset) => {
-        jsObjectPasswordReset(obj)
+        io.apibuilder.api.v0.models.json.jsObjectPasswordReset(obj)
       }
     }
 
@@ -1594,7 +1594,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiPasswordResetRequest: play.api.libs.json.Writes[PasswordResetRequest] = {
       (obj: io.apibuilder.api.v0.models.PasswordResetRequest) => {
-        jsObjectPasswordResetRequest(obj)
+        io.apibuilder.api.v0.models.json.jsObjectPasswordResetRequest(obj)
       }
     }
 
@@ -1610,7 +1610,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiPasswordResetSuccess: play.api.libs.json.Writes[PasswordResetSuccess] = {
       (obj: io.apibuilder.api.v0.models.PasswordResetSuccess) => {
-        jsObjectPasswordResetSuccess(obj)
+        io.apibuilder.api.v0.models.json.jsObjectPasswordResetSuccess(obj)
       }
     }
 
@@ -1627,8 +1627,8 @@ package io.apibuilder.api.v0.models {
     def jsObjectSubscription(obj: io.apibuilder.api.v0.models.Subscription): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "organization" -> jsObjectOrganization(obj.organization),
-        "user" -> jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.api.v0.models.json.jsObjectOrganization(obj.organization),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
         "publication" -> play.api.libs.json.JsString(obj.publication.toString),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
@@ -1636,7 +1636,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiSubscription: play.api.libs.json.Writes[Subscription] = {
       (obj: io.apibuilder.api.v0.models.Subscription) => {
-        jsObjectSubscription(obj)
+        io.apibuilder.api.v0.models.json.jsObjectSubscription(obj)
       }
     }
 
@@ -1658,7 +1658,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiSubscriptionForm: play.api.libs.json.Writes[SubscriptionForm] = {
       (obj: io.apibuilder.api.v0.models.SubscriptionForm) => {
-        jsObjectSubscriptionForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectSubscriptionForm(obj)
       }
     }
 
@@ -1675,7 +1675,7 @@ package io.apibuilder.api.v0.models {
     def jsObjectToken(obj: io.apibuilder.api.v0.models.Token): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "user" -> jsObjectUser(obj.user),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
         "masked_token" -> play.api.libs.json.JsString(obj.maskedToken),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       ) ++ (obj.description match {
@@ -1686,7 +1686,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiToken: play.api.libs.json.Writes[Token] = {
       (obj: io.apibuilder.api.v0.models.Token) => {
-        jsObjectToken(obj)
+        io.apibuilder.api.v0.models.json.jsObjectToken(obj)
       }
     }
 
@@ -1708,7 +1708,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiTokenForm: play.api.libs.json.Writes[TokenForm] = {
       (obj: io.apibuilder.api.v0.models.TokenForm) => {
-        jsObjectTokenForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectTokenForm(obj)
       }
     }
 
@@ -1736,7 +1736,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiUser: play.api.libs.json.Writes[User] = {
       (obj: io.apibuilder.api.v0.models.User) => {
-        jsObjectUser(obj)
+        io.apibuilder.api.v0.models.json.jsObjectUser(obj)
       }
     }
 
@@ -1765,7 +1765,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiUserForm: play.api.libs.json.Writes[UserForm] = {
       (obj: io.apibuilder.api.v0.models.UserForm) => {
-        jsObjectUserForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectUserForm(obj)
       }
     }
 
@@ -1785,7 +1785,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiUserSummary: play.api.libs.json.Writes[UserSummary] = {
       (obj: io.apibuilder.api.v0.models.UserSummary) => {
-        jsObjectUserSummary(obj)
+        io.apibuilder.api.v0.models.json.jsObjectUserSummary(obj)
       }
     }
 
@@ -1809,7 +1809,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiUserUpdateForm: play.api.libs.json.Writes[UserUpdateForm] = {
       (obj: io.apibuilder.api.v0.models.UserUpdateForm) => {
-        jsObjectUserUpdateForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectUserUpdateForm(obj)
       }
     }
 
@@ -1829,7 +1829,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiValidation: play.api.libs.json.Writes[Validation] = {
       (obj: io.apibuilder.api.v0.models.Validation) => {
-        jsObjectValidation(obj)
+        io.apibuilder.api.v0.models.json.jsObjectValidation(obj)
       }
     }
 
@@ -1855,13 +1855,13 @@ package io.apibuilder.api.v0.models {
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       ) ++ (obj.original match {
         case None => play.api.libs.json.Json.obj()
-        case Some(x) => play.api.libs.json.Json.obj("original" -> jsObjectOriginal(x))
+        case Some(x) => play.api.libs.json.Json.obj("original" -> io.apibuilder.api.v0.models.json.jsObjectOriginal(x))
       })
     }
 
     implicit def jsonWritesApidocApiVersion: play.api.libs.json.Writes[Version] = {
       (obj: io.apibuilder.api.v0.models.Version) => {
-        jsObjectVersion(obj)
+        io.apibuilder.api.v0.models.json.jsObjectVersion(obj)
       }
     }
 
@@ -1874,7 +1874,7 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectVersionForm(obj: io.apibuilder.api.v0.models.VersionForm): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "original_form" -> jsObjectOriginalForm(obj.originalForm)
+        "original_form" -> io.apibuilder.api.v0.models.json.jsObjectOriginalForm(obj.originalForm)
       ) ++ (obj.visibility match {
         case None => play.api.libs.json.Json.obj()
         case Some(x) => play.api.libs.json.Json.obj("visibility" -> play.api.libs.json.JsString(x.toString))
@@ -1883,7 +1883,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiVersionForm: play.api.libs.json.Writes[VersionForm] = {
       (obj: io.apibuilder.api.v0.models.VersionForm) => {
-        jsObjectVersionForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectVersionForm(obj)
       }
     }
 
@@ -1900,16 +1900,16 @@ package io.apibuilder.api.v0.models {
     def jsObjectWatch(obj: io.apibuilder.api.v0.models.Watch): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "user" -> jsObjectUser(obj.user),
-        "organization" -> jsObjectOrganization(obj.organization),
-        "application" -> jsObjectApplication(obj.application),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.api.v0.models.json.jsObjectOrganization(obj.organization),
+        "application" -> io.apibuilder.api.v0.models.json.jsObjectApplication(obj.application),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
     }
 
     implicit def jsonWritesApidocApiWatch: play.api.libs.json.Writes[Watch] = {
       (obj: io.apibuilder.api.v0.models.Watch) => {
-        jsObjectWatch(obj)
+        io.apibuilder.api.v0.models.json.jsObjectWatch(obj)
       }
     }
 
@@ -1931,15 +1931,15 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiWatchForm: play.api.libs.json.Writes[WatchForm] = {
       (obj: io.apibuilder.api.v0.models.WatchForm) => {
-        jsObjectWatchForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectWatchForm(obj)
       }
     }
 
     implicit def jsonReadsApidocApiDiff: play.api.libs.json.Reads[io.apibuilder.api.v0.models.Diff] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "diff_breaking" => jsonReadsApidocApiDiffBreaking.reads(js)
-          case "diff_non_breaking" => jsonReadsApidocApiDiffNonBreaking.reads(js)
+          case "diff_breaking" => io.apibuilder.api.v0.models.json.jsonReadsApidocApiDiffBreaking.reads(js)
+          case "diff_non_breaking" => io.apibuilder.api.v0.models.json.jsonReadsApidocApiDiffNonBreaking.reads(js)
           case other => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.DiffUndefinedType(other))
         }
       }
@@ -1951,8 +1951,8 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectDiff(obj: io.apibuilder.api.v0.models.Diff): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.api.v0.models.DiffBreaking => jsObjectDiffBreaking(x)
-        case x: io.apibuilder.api.v0.models.DiffNonBreaking => jsObjectDiffNonBreaking(x)
+        case x: io.apibuilder.api.v0.models.DiffBreaking => io.apibuilder.api.v0.models.json.jsObjectDiffBreaking(x)
+        case x: io.apibuilder.api.v0.models.DiffNonBreaking => io.apibuilder.api.v0.models.json.jsObjectDiffNonBreaking(x)
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
         }
@@ -1960,14 +1960,14 @@ package io.apibuilder.api.v0.models {
     }
     implicit def jsonWritesApidocApiDiff: play.api.libs.json.Writes[Diff] = {
       (obj: io.apibuilder.api.v0.models.Diff) => {
-        jsObjectDiff(obj)
+        io.apibuilder.api.v0.models.json.jsObjectDiff(obj)
       }
     }
 
     implicit def jsonReadsApidocApiItemDetail: play.api.libs.json.Reads[io.apibuilder.api.v0.models.ItemDetail] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "application_summary" => jsonReadsApidocApiApplicationSummary.reads(js)
+          case "application_summary" => io.apibuilder.api.v0.models.json.jsonReadsApidocApiApplicationSummary.reads(js)
           case other => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.ItemDetailUndefinedType(other))
         }
       }
@@ -1979,7 +1979,7 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectItemDetail(obj: io.apibuilder.api.v0.models.ItemDetail): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.api.v0.models.ApplicationSummary => jsObjectApplicationSummary(x)
+        case x: io.apibuilder.api.v0.models.ApplicationSummary => io.apibuilder.api.v0.models.json.jsObjectApplicationSummary(x)
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
         }
@@ -1987,7 +1987,7 @@ package io.apibuilder.api.v0.models {
     }
     implicit def jsonWritesApidocApiItemDetail: play.api.libs.json.Writes[ItemDetail] = {
       (obj: io.apibuilder.api.v0.models.ItemDetail) => {
-        jsObjectItemDetail(obj)
+        io.apibuilder.api.v0.models.json.jsObjectItemDetail(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-26-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-26-built-in-types.txt
@@ -127,7 +127,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesArray: play.api.libs.json.Writes[Array] = {
       (obj: apibuilder.models.Array) => {
-        jsObjectArray(obj)
+        apibuilder.models.json.jsObjectArray(obj)
       }
     }
 
@@ -196,7 +196,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptarray: play.api.libs.json.Writes[Optarray] = {
       (obj: apibuilder.models.Optarray) => {
-        jsObjectOptarray(obj)
+        apibuilder.models.json.jsObjectOptarray(obj)
       }
     }
 
@@ -265,7 +265,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptional: play.api.libs.json.Writes[Optional] = {
       (obj: apibuilder.models.Optional) => {
-        jsObjectOptional(obj)
+        apibuilder.models.json.jsObjectOptional(obj)
       }
     }
 
@@ -303,7 +303,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesRequired: play.api.libs.json.Writes[Required] = {
       (obj: apibuilder.models.Required) => {
-        jsObjectRequired(obj)
+        apibuilder.models.json.jsObjectRequired(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-26-envelope.txt
+++ b/lib/src/test/resources/generators/play-26-envelope.txt
@@ -116,7 +116,7 @@ package io.gregor.time.types.v0.models {
 
     implicit def jsonWritesTimeTypesDateTimeModel: play.api.libs.json.Writes[DateTimeModel] = {
       (obj: io.gregor.time.types.v0.models.DateTimeModel) => {
-        jsObjectDateTimeModel(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeModel(obj)
       }
     }
 
@@ -131,8 +131,8 @@ package io.gregor.time.types.v0.models {
     implicit def jsonReadsTimeTypesDateTimeUnion: play.api.libs.json.Reads[io.gregor.time.types.v0.models.DateTimeUnion] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "date-time-iso8601" => jsonReadsTimeTypesDateTimeIso8601.reads(js)
-          case "date-iso8601" => jsonReadsTimeTypesDateIso8601.reads(js)
+          case "date-time-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateTimeIso8601.reads(js)
+          case "date-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateIso8601.reads(js)
           case other => play.api.libs.json.JsSuccess(io.gregor.time.types.v0.models.DateTimeUnionUndefinedType(other))
         }
       }
@@ -153,7 +153,7 @@ package io.gregor.time.types.v0.models {
     }
     implicit def jsonWritesTimeTypesDateTimeUnion: play.api.libs.json.Writes[DateTimeUnion] = {
       (obj: io.gregor.time.types.v0.models.DateTimeUnion) => {
-        jsObjectDateTimeUnion(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeUnion(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-27-apidoc-api.txt
+++ b/lib/src/test/resources/generators/play-27-apidoc-api.txt
@@ -852,7 +852,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOriginalType: play.api.libs.json.Writes[OriginalType] = {
       (obj: io.apibuilder.api.v0.models.OriginalType) => {
-        jsonWritesApidocApiOriginalType(obj)
+        io.apibuilder.api.v0.models.json.jsonWritesApidocApiOriginalType(obj)
       }
     }
 
@@ -884,7 +884,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiPublication: play.api.libs.json.Writes[Publication] = {
       (obj: io.apibuilder.api.v0.models.Publication) => {
-        jsonWritesApidocApiPublication(obj)
+        io.apibuilder.api.v0.models.json.jsonWritesApidocApiPublication(obj)
       }
     }
 
@@ -916,7 +916,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiVisibility: play.api.libs.json.Writes[Visibility] = {
       (obj: io.apibuilder.api.v0.models.Visibility) => {
-        jsonWritesApidocApiVisibility(obj)
+        io.apibuilder.api.v0.models.json.jsonWritesApidocApiVisibility(obj)
       }
     }
 
@@ -948,7 +948,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiApplication: play.api.libs.json.Writes[Application] = {
       (obj: io.apibuilder.api.v0.models.Application) => {
-        jsObjectApplication(obj)
+        io.apibuilder.api.v0.models.json.jsObjectApplication(obj)
       }
     }
 
@@ -977,7 +977,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiApplicationForm: play.api.libs.json.Writes[ApplicationForm] = {
       (obj: io.apibuilder.api.v0.models.ApplicationForm) => {
-        jsObjectApplicationForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectApplicationForm(obj)
       }
     }
 
@@ -999,7 +999,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiApplicationSummary: play.api.libs.json.Writes[ApplicationSummary] = {
       (obj: io.apibuilder.api.v0.models.ApplicationSummary) => {
-        jsObjectApplicationSummary(obj)
+        io.apibuilder.api.v0.models.json.jsObjectApplicationSummary(obj)
       }
     }
 
@@ -1025,7 +1025,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttribute: play.api.libs.json.Writes[Attribute] = {
       (obj: io.apibuilder.api.v0.models.Attribute) => {
-        jsObjectAttribute(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttribute(obj)
       }
     }
 
@@ -1047,7 +1047,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttributeForm: play.api.libs.json.Writes[AttributeForm] = {
       (obj: io.apibuilder.api.v0.models.AttributeForm) => {
-        jsObjectAttributeForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttributeForm(obj)
       }
     }
 
@@ -1067,7 +1067,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttributeSummary: play.api.libs.json.Writes[AttributeSummary] = {
       (obj: io.apibuilder.api.v0.models.AttributeSummary) => {
-        jsObjectAttributeSummary(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttributeSummary(obj)
       }
     }
 
@@ -1083,7 +1083,7 @@ package io.apibuilder.api.v0.models {
     def jsObjectAttributeValue(obj: io.apibuilder.api.v0.models.AttributeValue): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "attribute" -> jsObjectAttributeSummary(obj.attribute),
+        "attribute" -> io.apibuilder.api.v0.models.json.jsObjectAttributeSummary(obj.attribute),
         "value" -> play.api.libs.json.JsString(obj.value),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
@@ -1091,7 +1091,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttributeValue: play.api.libs.json.Writes[AttributeValue] = {
       (obj: io.apibuilder.api.v0.models.AttributeValue) => {
-        jsObjectAttributeValue(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttributeValue(obj)
       }
     }
 
@@ -1107,7 +1107,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttributeValueForm: play.api.libs.json.Writes[AttributeValueForm] = {
       (obj: io.apibuilder.api.v0.models.AttributeValueForm) => {
-        jsObjectAttributeValueForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttributeValueForm(obj)
       }
     }
 
@@ -1130,18 +1130,18 @@ package io.apibuilder.api.v0.models {
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
         "organization" -> io.apibuilder.common.v0.models.json.jsObjectReference(obj.organization),
         "application" -> io.apibuilder.common.v0.models.json.jsObjectReference(obj.application),
-        "from_version" -> jsObjectChangeVersion(obj.fromVersion),
-        "to_version" -> jsObjectChangeVersion(obj.toVersion),
-        "diff" -> jsObjectDiff(obj.diff),
+        "from_version" -> io.apibuilder.api.v0.models.json.jsObjectChangeVersion(obj.fromVersion),
+        "to_version" -> io.apibuilder.api.v0.models.json.jsObjectChangeVersion(obj.toVersion),
+        "diff" -> io.apibuilder.api.v0.models.json.jsObjectDiff(obj.diff),
         "changed_at" -> play.api.libs.json.JsString(_root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(obj.changedAt)),
-        "changed_by" -> jsObjectUserSummary(obj.changedBy),
+        "changed_by" -> io.apibuilder.api.v0.models.json.jsObjectUserSummary(obj.changedBy),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
     }
 
     implicit def jsonWritesApidocApiChange: play.api.libs.json.Writes[Change] = {
       (obj: io.apibuilder.api.v0.models.Change) => {
-        jsObjectChange(obj)
+        io.apibuilder.api.v0.models.json.jsObjectChange(obj)
       }
     }
 
@@ -1161,7 +1161,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiChangeVersion: play.api.libs.json.Writes[ChangeVersion] = {
       (obj: io.apibuilder.api.v0.models.ChangeVersion) => {
-        jsObjectChangeVersion(obj)
+        io.apibuilder.api.v0.models.json.jsObjectChangeVersion(obj)
       }
     }
 
@@ -1177,7 +1177,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiCleartextToken: play.api.libs.json.Writes[CleartextToken] = {
       (obj: io.apibuilder.api.v0.models.CleartextToken) => {
-        jsObjectCleartextToken(obj)
+        io.apibuilder.api.v0.models.json.jsObjectCleartextToken(obj)
       }
     }
 
@@ -1191,7 +1191,7 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectCode(obj: io.apibuilder.api.v0.models.Code): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "generator" -> jsObjectGeneratorWithService(obj.generator),
+        "generator" -> io.apibuilder.api.v0.models.json.jsObjectGeneratorWithService(obj.generator),
         "source" -> play.api.libs.json.JsString(obj.source),
         "files" -> play.api.libs.json.Json.toJson(obj.files)
       )
@@ -1199,7 +1199,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiCode: play.api.libs.json.Writes[Code] = {
       (obj: io.apibuilder.api.v0.models.Code) => {
-        jsObjectCode(obj)
+        io.apibuilder.api.v0.models.json.jsObjectCode(obj)
       }
     }
 
@@ -1215,7 +1215,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiDiffBreaking: play.api.libs.json.Writes[DiffBreaking] = {
       (obj: io.apibuilder.api.v0.models.DiffBreaking) => {
-        jsObjectDiffBreaking(obj)
+        io.apibuilder.api.v0.models.json.jsObjectDiffBreaking(obj)
       }
     }
 
@@ -1231,7 +1231,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiDiffNonBreaking: play.api.libs.json.Writes[DiffNonBreaking] = {
       (obj: io.apibuilder.api.v0.models.DiffNonBreaking) => {
-        jsObjectDiffNonBreaking(obj)
+        io.apibuilder.api.v0.models.json.jsObjectDiffNonBreaking(obj)
       }
     }
 
@@ -1247,7 +1247,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiDomain: play.api.libs.json.Writes[Domain] = {
       (obj: io.apibuilder.api.v0.models.Domain) => {
-        jsObjectDomain(obj)
+        io.apibuilder.api.v0.models.json.jsObjectDomain(obj)
       }
     }
 
@@ -1263,7 +1263,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiEmailVerificationConfirmationForm: play.api.libs.json.Writes[EmailVerificationConfirmationForm] = {
       (obj: io.apibuilder.api.v0.models.EmailVerificationConfirmationForm) => {
-        jsObjectEmailVerificationConfirmationForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectEmailVerificationConfirmationForm(obj)
       }
     }
 
@@ -1283,7 +1283,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiError: play.api.libs.json.Writes[Error] = {
       (obj: io.apibuilder.api.v0.models.Error) => {
-        jsObjectError(obj)
+        io.apibuilder.api.v0.models.json.jsObjectError(obj)
       }
     }
 
@@ -1303,7 +1303,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiGeneratorForm: play.api.libs.json.Writes[GeneratorForm] = {
       (obj: io.apibuilder.api.v0.models.GeneratorForm) => {
-        jsObjectGeneratorForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectGeneratorForm(obj)
       }
     }
 
@@ -1325,7 +1325,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiGeneratorService: play.api.libs.json.Writes[GeneratorService] = {
       (obj: io.apibuilder.api.v0.models.GeneratorService) => {
-        jsObjectGeneratorService(obj)
+        io.apibuilder.api.v0.models.json.jsObjectGeneratorService(obj)
       }
     }
 
@@ -1341,7 +1341,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiGeneratorServiceForm: play.api.libs.json.Writes[GeneratorServiceForm] = {
       (obj: io.apibuilder.api.v0.models.GeneratorServiceForm) => {
-        jsObjectGeneratorServiceForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectGeneratorServiceForm(obj)
       }
     }
 
@@ -1354,14 +1354,14 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectGeneratorWithService(obj: io.apibuilder.api.v0.models.GeneratorWithService): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "service" -> jsObjectGeneratorService(obj.service),
+        "service" -> io.apibuilder.api.v0.models.json.jsObjectGeneratorService(obj.service),
         "generator" -> io.apibuilder.generator.v0.models.json.jsObjectGenerator(obj.generator)
       )
     }
 
     implicit def jsonWritesApidocApiGeneratorWithService: play.api.libs.json.Writes[GeneratorWithService] = {
       (obj: io.apibuilder.api.v0.models.GeneratorWithService) => {
-        jsObjectGeneratorWithService(obj)
+        io.apibuilder.api.v0.models.json.jsObjectGeneratorWithService(obj)
       }
     }
 
@@ -1377,7 +1377,7 @@ package io.apibuilder.api.v0.models {
     def jsObjectItem(obj: io.apibuilder.api.v0.models.Item): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "detail" -> jsObjectItemDetail(obj.detail),
+        "detail" -> io.apibuilder.api.v0.models.json.jsObjectItemDetail(obj.detail),
         "label" -> play.api.libs.json.JsString(obj.label)
       ) ++ (obj.description match {
         case None => play.api.libs.json.Json.obj()
@@ -1387,7 +1387,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiItem: play.api.libs.json.Writes[Item] = {
       (obj: io.apibuilder.api.v0.models.Item) => {
-        jsObjectItem(obj)
+        io.apibuilder.api.v0.models.json.jsObjectItem(obj)
       }
     }
 
@@ -1404,8 +1404,8 @@ package io.apibuilder.api.v0.models {
     def jsObjectMembership(obj: io.apibuilder.api.v0.models.Membership): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "user" -> jsObjectUser(obj.user),
-        "organization" -> jsObjectOrganization(obj.organization),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.api.v0.models.json.jsObjectOrganization(obj.organization),
         "role" -> play.api.libs.json.JsString(obj.role),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
@@ -1413,7 +1413,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiMembership: play.api.libs.json.Writes[Membership] = {
       (obj: io.apibuilder.api.v0.models.Membership) => {
-        jsObjectMembership(obj)
+        io.apibuilder.api.v0.models.json.jsObjectMembership(obj)
       }
     }
 
@@ -1430,8 +1430,8 @@ package io.apibuilder.api.v0.models {
     def jsObjectMembershipRequest(obj: io.apibuilder.api.v0.models.MembershipRequest): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "user" -> jsObjectUser(obj.user),
-        "organization" -> jsObjectOrganization(obj.organization),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.api.v0.models.json.jsObjectOrganization(obj.organization),
         "role" -> play.api.libs.json.JsString(obj.role),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
@@ -1439,7 +1439,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiMembershipRequest: play.api.libs.json.Writes[MembershipRequest] = {
       (obj: io.apibuilder.api.v0.models.MembershipRequest) => {
-        jsObjectMembershipRequest(obj)
+        io.apibuilder.api.v0.models.json.jsObjectMembershipRequest(obj)
       }
     }
 
@@ -1455,7 +1455,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiMoveForm: play.api.libs.json.Writes[MoveForm] = {
       (obj: io.apibuilder.api.v0.models.MoveForm) => {
-        jsObjectMoveForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectMoveForm(obj)
       }
     }
 
@@ -1485,7 +1485,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOrganization: play.api.libs.json.Writes[Organization] = {
       (obj: io.apibuilder.api.v0.models.Organization) => {
-        jsObjectOrganization(obj)
+        io.apibuilder.api.v0.models.json.jsObjectOrganization(obj)
       }
     }
 
@@ -1516,7 +1516,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOrganizationForm: play.api.libs.json.Writes[OrganizationForm] = {
       (obj: io.apibuilder.api.v0.models.OrganizationForm) => {
-        jsObjectOrganizationForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectOrganizationForm(obj)
       }
     }
 
@@ -1536,7 +1536,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOriginal: play.api.libs.json.Writes[Original] = {
       (obj: io.apibuilder.api.v0.models.Original) => {
-        jsObjectOriginal(obj)
+        io.apibuilder.api.v0.models.json.jsObjectOriginal(obj)
       }
     }
 
@@ -1558,7 +1558,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOriginalForm: play.api.libs.json.Writes[OriginalForm] = {
       (obj: io.apibuilder.api.v0.models.OriginalForm) => {
-        jsObjectOriginalForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectOriginalForm(obj)
       }
     }
 
@@ -1578,7 +1578,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiPasswordReset: play.api.libs.json.Writes[PasswordReset] = {
       (obj: io.apibuilder.api.v0.models.PasswordReset) => {
-        jsObjectPasswordReset(obj)
+        io.apibuilder.api.v0.models.json.jsObjectPasswordReset(obj)
       }
     }
 
@@ -1594,7 +1594,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiPasswordResetRequest: play.api.libs.json.Writes[PasswordResetRequest] = {
       (obj: io.apibuilder.api.v0.models.PasswordResetRequest) => {
-        jsObjectPasswordResetRequest(obj)
+        io.apibuilder.api.v0.models.json.jsObjectPasswordResetRequest(obj)
       }
     }
 
@@ -1610,7 +1610,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiPasswordResetSuccess: play.api.libs.json.Writes[PasswordResetSuccess] = {
       (obj: io.apibuilder.api.v0.models.PasswordResetSuccess) => {
-        jsObjectPasswordResetSuccess(obj)
+        io.apibuilder.api.v0.models.json.jsObjectPasswordResetSuccess(obj)
       }
     }
 
@@ -1627,8 +1627,8 @@ package io.apibuilder.api.v0.models {
     def jsObjectSubscription(obj: io.apibuilder.api.v0.models.Subscription): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "organization" -> jsObjectOrganization(obj.organization),
-        "user" -> jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.api.v0.models.json.jsObjectOrganization(obj.organization),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
         "publication" -> play.api.libs.json.JsString(obj.publication.toString),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
@@ -1636,7 +1636,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiSubscription: play.api.libs.json.Writes[Subscription] = {
       (obj: io.apibuilder.api.v0.models.Subscription) => {
-        jsObjectSubscription(obj)
+        io.apibuilder.api.v0.models.json.jsObjectSubscription(obj)
       }
     }
 
@@ -1658,7 +1658,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiSubscriptionForm: play.api.libs.json.Writes[SubscriptionForm] = {
       (obj: io.apibuilder.api.v0.models.SubscriptionForm) => {
-        jsObjectSubscriptionForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectSubscriptionForm(obj)
       }
     }
 
@@ -1675,7 +1675,7 @@ package io.apibuilder.api.v0.models {
     def jsObjectToken(obj: io.apibuilder.api.v0.models.Token): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "user" -> jsObjectUser(obj.user),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
         "masked_token" -> play.api.libs.json.JsString(obj.maskedToken),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       ) ++ (obj.description match {
@@ -1686,7 +1686,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiToken: play.api.libs.json.Writes[Token] = {
       (obj: io.apibuilder.api.v0.models.Token) => {
-        jsObjectToken(obj)
+        io.apibuilder.api.v0.models.json.jsObjectToken(obj)
       }
     }
 
@@ -1708,7 +1708,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiTokenForm: play.api.libs.json.Writes[TokenForm] = {
       (obj: io.apibuilder.api.v0.models.TokenForm) => {
-        jsObjectTokenForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectTokenForm(obj)
       }
     }
 
@@ -1736,7 +1736,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiUser: play.api.libs.json.Writes[User] = {
       (obj: io.apibuilder.api.v0.models.User) => {
-        jsObjectUser(obj)
+        io.apibuilder.api.v0.models.json.jsObjectUser(obj)
       }
     }
 
@@ -1765,7 +1765,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiUserForm: play.api.libs.json.Writes[UserForm] = {
       (obj: io.apibuilder.api.v0.models.UserForm) => {
-        jsObjectUserForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectUserForm(obj)
       }
     }
 
@@ -1785,7 +1785,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiUserSummary: play.api.libs.json.Writes[UserSummary] = {
       (obj: io.apibuilder.api.v0.models.UserSummary) => {
-        jsObjectUserSummary(obj)
+        io.apibuilder.api.v0.models.json.jsObjectUserSummary(obj)
       }
     }
 
@@ -1809,7 +1809,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiUserUpdateForm: play.api.libs.json.Writes[UserUpdateForm] = {
       (obj: io.apibuilder.api.v0.models.UserUpdateForm) => {
-        jsObjectUserUpdateForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectUserUpdateForm(obj)
       }
     }
 
@@ -1829,7 +1829,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiValidation: play.api.libs.json.Writes[Validation] = {
       (obj: io.apibuilder.api.v0.models.Validation) => {
-        jsObjectValidation(obj)
+        io.apibuilder.api.v0.models.json.jsObjectValidation(obj)
       }
     }
 
@@ -1855,13 +1855,13 @@ package io.apibuilder.api.v0.models {
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       ) ++ (obj.original match {
         case None => play.api.libs.json.Json.obj()
-        case Some(x) => play.api.libs.json.Json.obj("original" -> jsObjectOriginal(x))
+        case Some(x) => play.api.libs.json.Json.obj("original" -> io.apibuilder.api.v0.models.json.jsObjectOriginal(x))
       })
     }
 
     implicit def jsonWritesApidocApiVersion: play.api.libs.json.Writes[Version] = {
       (obj: io.apibuilder.api.v0.models.Version) => {
-        jsObjectVersion(obj)
+        io.apibuilder.api.v0.models.json.jsObjectVersion(obj)
       }
     }
 
@@ -1874,7 +1874,7 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectVersionForm(obj: io.apibuilder.api.v0.models.VersionForm): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "original_form" -> jsObjectOriginalForm(obj.originalForm)
+        "original_form" -> io.apibuilder.api.v0.models.json.jsObjectOriginalForm(obj.originalForm)
       ) ++ (obj.visibility match {
         case None => play.api.libs.json.Json.obj()
         case Some(x) => play.api.libs.json.Json.obj("visibility" -> play.api.libs.json.JsString(x.toString))
@@ -1883,7 +1883,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiVersionForm: play.api.libs.json.Writes[VersionForm] = {
       (obj: io.apibuilder.api.v0.models.VersionForm) => {
-        jsObjectVersionForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectVersionForm(obj)
       }
     }
 
@@ -1900,16 +1900,16 @@ package io.apibuilder.api.v0.models {
     def jsObjectWatch(obj: io.apibuilder.api.v0.models.Watch): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "user" -> jsObjectUser(obj.user),
-        "organization" -> jsObjectOrganization(obj.organization),
-        "application" -> jsObjectApplication(obj.application),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.api.v0.models.json.jsObjectOrganization(obj.organization),
+        "application" -> io.apibuilder.api.v0.models.json.jsObjectApplication(obj.application),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
     }
 
     implicit def jsonWritesApidocApiWatch: play.api.libs.json.Writes[Watch] = {
       (obj: io.apibuilder.api.v0.models.Watch) => {
-        jsObjectWatch(obj)
+        io.apibuilder.api.v0.models.json.jsObjectWatch(obj)
       }
     }
 
@@ -1931,15 +1931,15 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiWatchForm: play.api.libs.json.Writes[WatchForm] = {
       (obj: io.apibuilder.api.v0.models.WatchForm) => {
-        jsObjectWatchForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectWatchForm(obj)
       }
     }
 
     implicit def jsonReadsApidocApiDiff: play.api.libs.json.Reads[io.apibuilder.api.v0.models.Diff] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "diff_breaking" => jsonReadsApidocApiDiffBreaking.reads(js)
-          case "diff_non_breaking" => jsonReadsApidocApiDiffNonBreaking.reads(js)
+          case "diff_breaking" => io.apibuilder.api.v0.models.json.jsonReadsApidocApiDiffBreaking.reads(js)
+          case "diff_non_breaking" => io.apibuilder.api.v0.models.json.jsonReadsApidocApiDiffNonBreaking.reads(js)
           case other => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.DiffUndefinedType(other))
         }
       }
@@ -1951,8 +1951,8 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectDiff(obj: io.apibuilder.api.v0.models.Diff): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.api.v0.models.DiffBreaking => jsObjectDiffBreaking(x)
-        case x: io.apibuilder.api.v0.models.DiffNonBreaking => jsObjectDiffNonBreaking(x)
+        case x: io.apibuilder.api.v0.models.DiffBreaking => io.apibuilder.api.v0.models.json.jsObjectDiffBreaking(x)
+        case x: io.apibuilder.api.v0.models.DiffNonBreaking => io.apibuilder.api.v0.models.json.jsObjectDiffNonBreaking(x)
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
         }
@@ -1960,14 +1960,14 @@ package io.apibuilder.api.v0.models {
     }
     implicit def jsonWritesApidocApiDiff: play.api.libs.json.Writes[Diff] = {
       (obj: io.apibuilder.api.v0.models.Diff) => {
-        jsObjectDiff(obj)
+        io.apibuilder.api.v0.models.json.jsObjectDiff(obj)
       }
     }
 
     implicit def jsonReadsApidocApiItemDetail: play.api.libs.json.Reads[io.apibuilder.api.v0.models.ItemDetail] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "application_summary" => jsonReadsApidocApiApplicationSummary.reads(js)
+          case "application_summary" => io.apibuilder.api.v0.models.json.jsonReadsApidocApiApplicationSummary.reads(js)
           case other => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.ItemDetailUndefinedType(other))
         }
       }
@@ -1979,7 +1979,7 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectItemDetail(obj: io.apibuilder.api.v0.models.ItemDetail): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.api.v0.models.ApplicationSummary => jsObjectApplicationSummary(x)
+        case x: io.apibuilder.api.v0.models.ApplicationSummary => io.apibuilder.api.v0.models.json.jsObjectApplicationSummary(x)
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
         }
@@ -1987,7 +1987,7 @@ package io.apibuilder.api.v0.models {
     }
     implicit def jsonWritesApidocApiItemDetail: play.api.libs.json.Writes[ItemDetail] = {
       (obj: io.apibuilder.api.v0.models.ItemDetail) => {
-        jsObjectItemDetail(obj)
+        io.apibuilder.api.v0.models.json.jsObjectItemDetail(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-27-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-27-built-in-types.txt
@@ -127,7 +127,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesArray: play.api.libs.json.Writes[Array] = {
       (obj: apibuilder.models.Array) => {
-        jsObjectArray(obj)
+        apibuilder.models.json.jsObjectArray(obj)
       }
     }
 
@@ -196,7 +196,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptarray: play.api.libs.json.Writes[Optarray] = {
       (obj: apibuilder.models.Optarray) => {
-        jsObjectOptarray(obj)
+        apibuilder.models.json.jsObjectOptarray(obj)
       }
     }
 
@@ -265,7 +265,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptional: play.api.libs.json.Writes[Optional] = {
       (obj: apibuilder.models.Optional) => {
-        jsObjectOptional(obj)
+        apibuilder.models.json.jsObjectOptional(obj)
       }
     }
 
@@ -303,7 +303,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesRequired: play.api.libs.json.Writes[Required] = {
       (obj: apibuilder.models.Required) => {
-        jsObjectRequired(obj)
+        apibuilder.models.json.jsObjectRequired(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-27-java-instant.txt
+++ b/lib/src/test/resources/generators/play-27-java-instant.txt
@@ -96,7 +96,7 @@ package io.gregor.time.types.v0.models {
 
     implicit def jsonWritesTimeTypesDateTimeModel: play.api.libs.json.Writes[DateTimeModel] = {
       (obj: io.gregor.time.types.v0.models.DateTimeModel) => {
-        jsObjectDateTimeModel(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeModel(obj)
       }
     }
 
@@ -111,8 +111,8 @@ package io.gregor.time.types.v0.models {
     implicit def jsonReadsTimeTypesDateTimeUnion: play.api.libs.json.Reads[io.gregor.time.types.v0.models.DateTimeUnion] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "date-time-iso8601" => jsonReadsTimeTypesDateTimeIso8601.reads(js)
-          case "date-iso8601" => jsonReadsTimeTypesDateIso8601.reads(js)
+          case "date-time-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateTimeIso8601.reads(js)
+          case "date-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateIso8601.reads(js)
           case other => play.api.libs.json.JsSuccess(io.gregor.time.types.v0.models.DateTimeUnionUndefinedType(other))
         }
       }
@@ -133,7 +133,7 @@ package io.gregor.time.types.v0.models {
     }
     implicit def jsonWritesTimeTypesDateTimeUnion: play.api.libs.json.Writes[DateTimeUnion] = {
       (obj: io.gregor.time.types.v0.models.DateTimeUnion) => {
-        jsObjectDateTimeUnion(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeUnion(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-27-java-offsetdatetime.txt
+++ b/lib/src/test/resources/generators/play-27-java-offsetdatetime.txt
@@ -96,7 +96,7 @@ package io.gregor.time.types.v0.models {
 
     implicit def jsonWritesTimeTypesDateTimeModel: play.api.libs.json.Writes[DateTimeModel] = {
       (obj: io.gregor.time.types.v0.models.DateTimeModel) => {
-        jsObjectDateTimeModel(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeModel(obj)
       }
     }
 
@@ -111,8 +111,8 @@ package io.gregor.time.types.v0.models {
     implicit def jsonReadsTimeTypesDateTimeUnion: play.api.libs.json.Reads[io.gregor.time.types.v0.models.DateTimeUnion] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "date-time-iso8601" => jsonReadsTimeTypesDateTimeIso8601.reads(js)
-          case "date-iso8601" => jsonReadsTimeTypesDateIso8601.reads(js)
+          case "date-time-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateTimeIso8601.reads(js)
+          case "date-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateIso8601.reads(js)
           case other => play.api.libs.json.JsSuccess(io.gregor.time.types.v0.models.DateTimeUnionUndefinedType(other))
         }
       }
@@ -133,7 +133,7 @@ package io.gregor.time.types.v0.models {
     }
     implicit def jsonWritesTimeTypesDateTimeUnion: play.api.libs.json.Writes[DateTimeUnion] = {
       (obj: io.gregor.time.types.v0.models.DateTimeUnion) => {
-        jsObjectDateTimeUnion(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeUnion(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-27-joda-date-time.txt
+++ b/lib/src/test/resources/generators/play-27-joda-date-time.txt
@@ -116,7 +116,7 @@ package io.gregor.time.types.v0.models {
 
     implicit def jsonWritesTimeTypesDateTimeModel: play.api.libs.json.Writes[DateTimeModel] = {
       (obj: io.gregor.time.types.v0.models.DateTimeModel) => {
-        jsObjectDateTimeModel(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeModel(obj)
       }
     }
 
@@ -131,8 +131,8 @@ package io.gregor.time.types.v0.models {
     implicit def jsonReadsTimeTypesDateTimeUnion: play.api.libs.json.Reads[io.gregor.time.types.v0.models.DateTimeUnion] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "date-time-iso8601" => jsonReadsTimeTypesDateTimeIso8601.reads(js)
-          case "date-iso8601" => jsonReadsTimeTypesDateIso8601.reads(js)
+          case "date-time-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateTimeIso8601.reads(js)
+          case "date-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateIso8601.reads(js)
           case other => play.api.libs.json.JsSuccess(io.gregor.time.types.v0.models.DateTimeUnionUndefinedType(other))
         }
       }
@@ -153,7 +153,7 @@ package io.gregor.time.types.v0.models {
     }
     implicit def jsonWritesTimeTypesDateTimeUnion: play.api.libs.json.Writes[DateTimeUnion] = {
       (obj: io.gregor.time.types.v0.models.DateTimeUnion) => {
-        jsObjectDateTimeUnion(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeUnion(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-28-apidoc-api.txt
+++ b/lib/src/test/resources/generators/play-28-apidoc-api.txt
@@ -852,7 +852,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOriginalType: play.api.libs.json.Writes[OriginalType] = {
       (obj: io.apibuilder.api.v0.models.OriginalType) => {
-        jsonWritesApidocApiOriginalType(obj)
+        io.apibuilder.api.v0.models.json.jsonWritesApidocApiOriginalType(obj)
       }
     }
 
@@ -884,7 +884,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiPublication: play.api.libs.json.Writes[Publication] = {
       (obj: io.apibuilder.api.v0.models.Publication) => {
-        jsonWritesApidocApiPublication(obj)
+        io.apibuilder.api.v0.models.json.jsonWritesApidocApiPublication(obj)
       }
     }
 
@@ -916,7 +916,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiVisibility: play.api.libs.json.Writes[Visibility] = {
       (obj: io.apibuilder.api.v0.models.Visibility) => {
-        jsonWritesApidocApiVisibility(obj)
+        io.apibuilder.api.v0.models.json.jsonWritesApidocApiVisibility(obj)
       }
     }
 
@@ -948,7 +948,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiApplication: play.api.libs.json.Writes[Application] = {
       (obj: io.apibuilder.api.v0.models.Application) => {
-        jsObjectApplication(obj)
+        io.apibuilder.api.v0.models.json.jsObjectApplication(obj)
       }
     }
 
@@ -977,7 +977,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiApplicationForm: play.api.libs.json.Writes[ApplicationForm] = {
       (obj: io.apibuilder.api.v0.models.ApplicationForm) => {
-        jsObjectApplicationForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectApplicationForm(obj)
       }
     }
 
@@ -999,7 +999,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiApplicationSummary: play.api.libs.json.Writes[ApplicationSummary] = {
       (obj: io.apibuilder.api.v0.models.ApplicationSummary) => {
-        jsObjectApplicationSummary(obj)
+        io.apibuilder.api.v0.models.json.jsObjectApplicationSummary(obj)
       }
     }
 
@@ -1025,7 +1025,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttribute: play.api.libs.json.Writes[Attribute] = {
       (obj: io.apibuilder.api.v0.models.Attribute) => {
-        jsObjectAttribute(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttribute(obj)
       }
     }
 
@@ -1047,7 +1047,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttributeForm: play.api.libs.json.Writes[AttributeForm] = {
       (obj: io.apibuilder.api.v0.models.AttributeForm) => {
-        jsObjectAttributeForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttributeForm(obj)
       }
     }
 
@@ -1067,7 +1067,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttributeSummary: play.api.libs.json.Writes[AttributeSummary] = {
       (obj: io.apibuilder.api.v0.models.AttributeSummary) => {
-        jsObjectAttributeSummary(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttributeSummary(obj)
       }
     }
 
@@ -1083,7 +1083,7 @@ package io.apibuilder.api.v0.models {
     def jsObjectAttributeValue(obj: io.apibuilder.api.v0.models.AttributeValue): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "attribute" -> jsObjectAttributeSummary(obj.attribute),
+        "attribute" -> io.apibuilder.api.v0.models.json.jsObjectAttributeSummary(obj.attribute),
         "value" -> play.api.libs.json.JsString(obj.value),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
@@ -1091,7 +1091,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttributeValue: play.api.libs.json.Writes[AttributeValue] = {
       (obj: io.apibuilder.api.v0.models.AttributeValue) => {
-        jsObjectAttributeValue(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttributeValue(obj)
       }
     }
 
@@ -1107,7 +1107,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiAttributeValueForm: play.api.libs.json.Writes[AttributeValueForm] = {
       (obj: io.apibuilder.api.v0.models.AttributeValueForm) => {
-        jsObjectAttributeValueForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectAttributeValueForm(obj)
       }
     }
 
@@ -1130,18 +1130,18 @@ package io.apibuilder.api.v0.models {
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
         "organization" -> io.apibuilder.common.v0.models.json.jsObjectReference(obj.organization),
         "application" -> io.apibuilder.common.v0.models.json.jsObjectReference(obj.application),
-        "from_version" -> jsObjectChangeVersion(obj.fromVersion),
-        "to_version" -> jsObjectChangeVersion(obj.toVersion),
-        "diff" -> jsObjectDiff(obj.diff),
+        "from_version" -> io.apibuilder.api.v0.models.json.jsObjectChangeVersion(obj.fromVersion),
+        "to_version" -> io.apibuilder.api.v0.models.json.jsObjectChangeVersion(obj.toVersion),
+        "diff" -> io.apibuilder.api.v0.models.json.jsObjectDiff(obj.diff),
         "changed_at" -> play.api.libs.json.JsString(_root_.org.joda.time.format.ISODateTimeFormat.dateTime.print(obj.changedAt)),
-        "changed_by" -> jsObjectUserSummary(obj.changedBy),
+        "changed_by" -> io.apibuilder.api.v0.models.json.jsObjectUserSummary(obj.changedBy),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
     }
 
     implicit def jsonWritesApidocApiChange: play.api.libs.json.Writes[Change] = {
       (obj: io.apibuilder.api.v0.models.Change) => {
-        jsObjectChange(obj)
+        io.apibuilder.api.v0.models.json.jsObjectChange(obj)
       }
     }
 
@@ -1161,7 +1161,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiChangeVersion: play.api.libs.json.Writes[ChangeVersion] = {
       (obj: io.apibuilder.api.v0.models.ChangeVersion) => {
-        jsObjectChangeVersion(obj)
+        io.apibuilder.api.v0.models.json.jsObjectChangeVersion(obj)
       }
     }
 
@@ -1177,7 +1177,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiCleartextToken: play.api.libs.json.Writes[CleartextToken] = {
       (obj: io.apibuilder.api.v0.models.CleartextToken) => {
-        jsObjectCleartextToken(obj)
+        io.apibuilder.api.v0.models.json.jsObjectCleartextToken(obj)
       }
     }
 
@@ -1191,7 +1191,7 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectCode(obj: io.apibuilder.api.v0.models.Code): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "generator" -> jsObjectGeneratorWithService(obj.generator),
+        "generator" -> io.apibuilder.api.v0.models.json.jsObjectGeneratorWithService(obj.generator),
         "source" -> play.api.libs.json.JsString(obj.source),
         "files" -> play.api.libs.json.Json.toJson(obj.files)
       )
@@ -1199,7 +1199,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiCode: play.api.libs.json.Writes[Code] = {
       (obj: io.apibuilder.api.v0.models.Code) => {
-        jsObjectCode(obj)
+        io.apibuilder.api.v0.models.json.jsObjectCode(obj)
       }
     }
 
@@ -1215,7 +1215,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiDiffBreaking: play.api.libs.json.Writes[DiffBreaking] = {
       (obj: io.apibuilder.api.v0.models.DiffBreaking) => {
-        jsObjectDiffBreaking(obj)
+        io.apibuilder.api.v0.models.json.jsObjectDiffBreaking(obj)
       }
     }
 
@@ -1231,7 +1231,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiDiffNonBreaking: play.api.libs.json.Writes[DiffNonBreaking] = {
       (obj: io.apibuilder.api.v0.models.DiffNonBreaking) => {
-        jsObjectDiffNonBreaking(obj)
+        io.apibuilder.api.v0.models.json.jsObjectDiffNonBreaking(obj)
       }
     }
 
@@ -1247,7 +1247,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiDomain: play.api.libs.json.Writes[Domain] = {
       (obj: io.apibuilder.api.v0.models.Domain) => {
-        jsObjectDomain(obj)
+        io.apibuilder.api.v0.models.json.jsObjectDomain(obj)
       }
     }
 
@@ -1263,7 +1263,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiEmailVerificationConfirmationForm: play.api.libs.json.Writes[EmailVerificationConfirmationForm] = {
       (obj: io.apibuilder.api.v0.models.EmailVerificationConfirmationForm) => {
-        jsObjectEmailVerificationConfirmationForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectEmailVerificationConfirmationForm(obj)
       }
     }
 
@@ -1283,7 +1283,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiError: play.api.libs.json.Writes[Error] = {
       (obj: io.apibuilder.api.v0.models.Error) => {
-        jsObjectError(obj)
+        io.apibuilder.api.v0.models.json.jsObjectError(obj)
       }
     }
 
@@ -1303,7 +1303,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiGeneratorForm: play.api.libs.json.Writes[GeneratorForm] = {
       (obj: io.apibuilder.api.v0.models.GeneratorForm) => {
-        jsObjectGeneratorForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectGeneratorForm(obj)
       }
     }
 
@@ -1325,7 +1325,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiGeneratorService: play.api.libs.json.Writes[GeneratorService] = {
       (obj: io.apibuilder.api.v0.models.GeneratorService) => {
-        jsObjectGeneratorService(obj)
+        io.apibuilder.api.v0.models.json.jsObjectGeneratorService(obj)
       }
     }
 
@@ -1341,7 +1341,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiGeneratorServiceForm: play.api.libs.json.Writes[GeneratorServiceForm] = {
       (obj: io.apibuilder.api.v0.models.GeneratorServiceForm) => {
-        jsObjectGeneratorServiceForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectGeneratorServiceForm(obj)
       }
     }
 
@@ -1354,14 +1354,14 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectGeneratorWithService(obj: io.apibuilder.api.v0.models.GeneratorWithService): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "service" -> jsObjectGeneratorService(obj.service),
+        "service" -> io.apibuilder.api.v0.models.json.jsObjectGeneratorService(obj.service),
         "generator" -> io.apibuilder.generator.v0.models.json.jsObjectGenerator(obj.generator)
       )
     }
 
     implicit def jsonWritesApidocApiGeneratorWithService: play.api.libs.json.Writes[GeneratorWithService] = {
       (obj: io.apibuilder.api.v0.models.GeneratorWithService) => {
-        jsObjectGeneratorWithService(obj)
+        io.apibuilder.api.v0.models.json.jsObjectGeneratorWithService(obj)
       }
     }
 
@@ -1377,7 +1377,7 @@ package io.apibuilder.api.v0.models {
     def jsObjectItem(obj: io.apibuilder.api.v0.models.Item): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "detail" -> jsObjectItemDetail(obj.detail),
+        "detail" -> io.apibuilder.api.v0.models.json.jsObjectItemDetail(obj.detail),
         "label" -> play.api.libs.json.JsString(obj.label)
       ) ++ (obj.description match {
         case None => play.api.libs.json.Json.obj()
@@ -1387,7 +1387,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiItem: play.api.libs.json.Writes[Item] = {
       (obj: io.apibuilder.api.v0.models.Item) => {
-        jsObjectItem(obj)
+        io.apibuilder.api.v0.models.json.jsObjectItem(obj)
       }
     }
 
@@ -1404,8 +1404,8 @@ package io.apibuilder.api.v0.models {
     def jsObjectMembership(obj: io.apibuilder.api.v0.models.Membership): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "user" -> jsObjectUser(obj.user),
-        "organization" -> jsObjectOrganization(obj.organization),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.api.v0.models.json.jsObjectOrganization(obj.organization),
         "role" -> play.api.libs.json.JsString(obj.role),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
@@ -1413,7 +1413,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiMembership: play.api.libs.json.Writes[Membership] = {
       (obj: io.apibuilder.api.v0.models.Membership) => {
-        jsObjectMembership(obj)
+        io.apibuilder.api.v0.models.json.jsObjectMembership(obj)
       }
     }
 
@@ -1430,8 +1430,8 @@ package io.apibuilder.api.v0.models {
     def jsObjectMembershipRequest(obj: io.apibuilder.api.v0.models.MembershipRequest): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "user" -> jsObjectUser(obj.user),
-        "organization" -> jsObjectOrganization(obj.organization),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.api.v0.models.json.jsObjectOrganization(obj.organization),
         "role" -> play.api.libs.json.JsString(obj.role),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
@@ -1439,7 +1439,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiMembershipRequest: play.api.libs.json.Writes[MembershipRequest] = {
       (obj: io.apibuilder.api.v0.models.MembershipRequest) => {
-        jsObjectMembershipRequest(obj)
+        io.apibuilder.api.v0.models.json.jsObjectMembershipRequest(obj)
       }
     }
 
@@ -1455,7 +1455,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiMoveForm: play.api.libs.json.Writes[MoveForm] = {
       (obj: io.apibuilder.api.v0.models.MoveForm) => {
-        jsObjectMoveForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectMoveForm(obj)
       }
     }
 
@@ -1485,7 +1485,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOrganization: play.api.libs.json.Writes[Organization] = {
       (obj: io.apibuilder.api.v0.models.Organization) => {
-        jsObjectOrganization(obj)
+        io.apibuilder.api.v0.models.json.jsObjectOrganization(obj)
       }
     }
 
@@ -1516,7 +1516,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOrganizationForm: play.api.libs.json.Writes[OrganizationForm] = {
       (obj: io.apibuilder.api.v0.models.OrganizationForm) => {
-        jsObjectOrganizationForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectOrganizationForm(obj)
       }
     }
 
@@ -1536,7 +1536,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOriginal: play.api.libs.json.Writes[Original] = {
       (obj: io.apibuilder.api.v0.models.Original) => {
-        jsObjectOriginal(obj)
+        io.apibuilder.api.v0.models.json.jsObjectOriginal(obj)
       }
     }
 
@@ -1558,7 +1558,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiOriginalForm: play.api.libs.json.Writes[OriginalForm] = {
       (obj: io.apibuilder.api.v0.models.OriginalForm) => {
-        jsObjectOriginalForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectOriginalForm(obj)
       }
     }
 
@@ -1578,7 +1578,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiPasswordReset: play.api.libs.json.Writes[PasswordReset] = {
       (obj: io.apibuilder.api.v0.models.PasswordReset) => {
-        jsObjectPasswordReset(obj)
+        io.apibuilder.api.v0.models.json.jsObjectPasswordReset(obj)
       }
     }
 
@@ -1594,7 +1594,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiPasswordResetRequest: play.api.libs.json.Writes[PasswordResetRequest] = {
       (obj: io.apibuilder.api.v0.models.PasswordResetRequest) => {
-        jsObjectPasswordResetRequest(obj)
+        io.apibuilder.api.v0.models.json.jsObjectPasswordResetRequest(obj)
       }
     }
 
@@ -1610,7 +1610,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiPasswordResetSuccess: play.api.libs.json.Writes[PasswordResetSuccess] = {
       (obj: io.apibuilder.api.v0.models.PasswordResetSuccess) => {
-        jsObjectPasswordResetSuccess(obj)
+        io.apibuilder.api.v0.models.json.jsObjectPasswordResetSuccess(obj)
       }
     }
 
@@ -1627,8 +1627,8 @@ package io.apibuilder.api.v0.models {
     def jsObjectSubscription(obj: io.apibuilder.api.v0.models.Subscription): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "organization" -> jsObjectOrganization(obj.organization),
-        "user" -> jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.api.v0.models.json.jsObjectOrganization(obj.organization),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
         "publication" -> play.api.libs.json.JsString(obj.publication.toString),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
@@ -1636,7 +1636,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiSubscription: play.api.libs.json.Writes[Subscription] = {
       (obj: io.apibuilder.api.v0.models.Subscription) => {
-        jsObjectSubscription(obj)
+        io.apibuilder.api.v0.models.json.jsObjectSubscription(obj)
       }
     }
 
@@ -1658,7 +1658,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiSubscriptionForm: play.api.libs.json.Writes[SubscriptionForm] = {
       (obj: io.apibuilder.api.v0.models.SubscriptionForm) => {
-        jsObjectSubscriptionForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectSubscriptionForm(obj)
       }
     }
 
@@ -1675,7 +1675,7 @@ package io.apibuilder.api.v0.models {
     def jsObjectToken(obj: io.apibuilder.api.v0.models.Token): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "user" -> jsObjectUser(obj.user),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
         "masked_token" -> play.api.libs.json.JsString(obj.maskedToken),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       ) ++ (obj.description match {
@@ -1686,7 +1686,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiToken: play.api.libs.json.Writes[Token] = {
       (obj: io.apibuilder.api.v0.models.Token) => {
-        jsObjectToken(obj)
+        io.apibuilder.api.v0.models.json.jsObjectToken(obj)
       }
     }
 
@@ -1708,7 +1708,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiTokenForm: play.api.libs.json.Writes[TokenForm] = {
       (obj: io.apibuilder.api.v0.models.TokenForm) => {
-        jsObjectTokenForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectTokenForm(obj)
       }
     }
 
@@ -1736,7 +1736,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiUser: play.api.libs.json.Writes[User] = {
       (obj: io.apibuilder.api.v0.models.User) => {
-        jsObjectUser(obj)
+        io.apibuilder.api.v0.models.json.jsObjectUser(obj)
       }
     }
 
@@ -1765,7 +1765,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiUserForm: play.api.libs.json.Writes[UserForm] = {
       (obj: io.apibuilder.api.v0.models.UserForm) => {
-        jsObjectUserForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectUserForm(obj)
       }
     }
 
@@ -1785,7 +1785,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiUserSummary: play.api.libs.json.Writes[UserSummary] = {
       (obj: io.apibuilder.api.v0.models.UserSummary) => {
-        jsObjectUserSummary(obj)
+        io.apibuilder.api.v0.models.json.jsObjectUserSummary(obj)
       }
     }
 
@@ -1809,7 +1809,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiUserUpdateForm: play.api.libs.json.Writes[UserUpdateForm] = {
       (obj: io.apibuilder.api.v0.models.UserUpdateForm) => {
-        jsObjectUserUpdateForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectUserUpdateForm(obj)
       }
     }
 
@@ -1829,7 +1829,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiValidation: play.api.libs.json.Writes[Validation] = {
       (obj: io.apibuilder.api.v0.models.Validation) => {
-        jsObjectValidation(obj)
+        io.apibuilder.api.v0.models.json.jsObjectValidation(obj)
       }
     }
 
@@ -1855,13 +1855,13 @@ package io.apibuilder.api.v0.models {
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       ) ++ (obj.original match {
         case None => play.api.libs.json.Json.obj()
-        case Some(x) => play.api.libs.json.Json.obj("original" -> jsObjectOriginal(x))
+        case Some(x) => play.api.libs.json.Json.obj("original" -> io.apibuilder.api.v0.models.json.jsObjectOriginal(x))
       })
     }
 
     implicit def jsonWritesApidocApiVersion: play.api.libs.json.Writes[Version] = {
       (obj: io.apibuilder.api.v0.models.Version) => {
-        jsObjectVersion(obj)
+        io.apibuilder.api.v0.models.json.jsObjectVersion(obj)
       }
     }
 
@@ -1874,7 +1874,7 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectVersionForm(obj: io.apibuilder.api.v0.models.VersionForm): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
-        "original_form" -> jsObjectOriginalForm(obj.originalForm)
+        "original_form" -> io.apibuilder.api.v0.models.json.jsObjectOriginalForm(obj.originalForm)
       ) ++ (obj.visibility match {
         case None => play.api.libs.json.Json.obj()
         case Some(x) => play.api.libs.json.Json.obj("visibility" -> play.api.libs.json.JsString(x.toString))
@@ -1883,7 +1883,7 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiVersionForm: play.api.libs.json.Writes[VersionForm] = {
       (obj: io.apibuilder.api.v0.models.VersionForm) => {
-        jsObjectVersionForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectVersionForm(obj)
       }
     }
 
@@ -1900,16 +1900,16 @@ package io.apibuilder.api.v0.models {
     def jsObjectWatch(obj: io.apibuilder.api.v0.models.Watch): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "user" -> jsObjectUser(obj.user),
-        "organization" -> jsObjectOrganization(obj.organization),
-        "application" -> jsObjectApplication(obj.application),
+        "user" -> io.apibuilder.api.v0.models.json.jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.api.v0.models.json.jsObjectOrganization(obj.organization),
+        "application" -> io.apibuilder.api.v0.models.json.jsObjectApplication(obj.application),
         "audit" -> io.apibuilder.common.v0.models.json.jsObjectAudit(obj.audit)
       )
     }
 
     implicit def jsonWritesApidocApiWatch: play.api.libs.json.Writes[Watch] = {
       (obj: io.apibuilder.api.v0.models.Watch) => {
-        jsObjectWatch(obj)
+        io.apibuilder.api.v0.models.json.jsObjectWatch(obj)
       }
     }
 
@@ -1931,15 +1931,15 @@ package io.apibuilder.api.v0.models {
 
     implicit def jsonWritesApidocApiWatchForm: play.api.libs.json.Writes[WatchForm] = {
       (obj: io.apibuilder.api.v0.models.WatchForm) => {
-        jsObjectWatchForm(obj)
+        io.apibuilder.api.v0.models.json.jsObjectWatchForm(obj)
       }
     }
 
     implicit def jsonReadsApidocApiDiff: play.api.libs.json.Reads[io.apibuilder.api.v0.models.Diff] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "diff_breaking" => jsonReadsApidocApiDiffBreaking.reads(js)
-          case "diff_non_breaking" => jsonReadsApidocApiDiffNonBreaking.reads(js)
+          case "diff_breaking" => io.apibuilder.api.v0.models.json.jsonReadsApidocApiDiffBreaking.reads(js)
+          case "diff_non_breaking" => io.apibuilder.api.v0.models.json.jsonReadsApidocApiDiffNonBreaking.reads(js)
           case other => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.DiffUndefinedType(other))
         }
       }
@@ -1951,8 +1951,8 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectDiff(obj: io.apibuilder.api.v0.models.Diff): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.api.v0.models.DiffBreaking => jsObjectDiffBreaking(x)
-        case x: io.apibuilder.api.v0.models.DiffNonBreaking => jsObjectDiffNonBreaking(x)
+        case x: io.apibuilder.api.v0.models.DiffBreaking => io.apibuilder.api.v0.models.json.jsObjectDiffBreaking(x)
+        case x: io.apibuilder.api.v0.models.DiffNonBreaking => io.apibuilder.api.v0.models.json.jsObjectDiffNonBreaking(x)
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
         }
@@ -1960,14 +1960,14 @@ package io.apibuilder.api.v0.models {
     }
     implicit def jsonWritesApidocApiDiff: play.api.libs.json.Writes[Diff] = {
       (obj: io.apibuilder.api.v0.models.Diff) => {
-        jsObjectDiff(obj)
+        io.apibuilder.api.v0.models.json.jsObjectDiff(obj)
       }
     }
 
     implicit def jsonReadsApidocApiItemDetail: play.api.libs.json.Reads[io.apibuilder.api.v0.models.ItemDetail] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "application_summary" => jsonReadsApidocApiApplicationSummary.reads(js)
+          case "application_summary" => io.apibuilder.api.v0.models.json.jsonReadsApidocApiApplicationSummary.reads(js)
           case other => play.api.libs.json.JsSuccess(io.apibuilder.api.v0.models.ItemDetailUndefinedType(other))
         }
       }
@@ -1979,7 +1979,7 @@ package io.apibuilder.api.v0.models {
 
     def jsObjectItemDetail(obj: io.apibuilder.api.v0.models.ItemDetail): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.api.v0.models.ApplicationSummary => jsObjectApplicationSummary(x)
+        case x: io.apibuilder.api.v0.models.ApplicationSummary => io.apibuilder.api.v0.models.json.jsObjectApplicationSummary(x)
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
         }
@@ -1987,7 +1987,7 @@ package io.apibuilder.api.v0.models {
     }
     implicit def jsonWritesApidocApiItemDetail: play.api.libs.json.Writes[ItemDetail] = {
       (obj: io.apibuilder.api.v0.models.ItemDetail) => {
-        jsObjectItemDetail(obj)
+        io.apibuilder.api.v0.models.json.jsObjectItemDetail(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-28-built-in-types.txt
+++ b/lib/src/test/resources/generators/play-28-built-in-types.txt
@@ -127,7 +127,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesArray: play.api.libs.json.Writes[Array] = {
       (obj: apibuilder.models.Array) => {
-        jsObjectArray(obj)
+        apibuilder.models.json.jsObjectArray(obj)
       }
     }
 
@@ -196,7 +196,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptarray: play.api.libs.json.Writes[Optarray] = {
       (obj: apibuilder.models.Optarray) => {
-        jsObjectOptarray(obj)
+        apibuilder.models.json.jsObjectOptarray(obj)
       }
     }
 
@@ -265,7 +265,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesOptional: play.api.libs.json.Writes[Optional] = {
       (obj: apibuilder.models.Optional) => {
-        jsObjectOptional(obj)
+        apibuilder.models.json.jsObjectOptional(obj)
       }
     }
 
@@ -303,7 +303,7 @@ package apibuilder.models {
 
     implicit def jsonWritesBuiltInTypesRequired: play.api.libs.json.Writes[Required] = {
       (obj: apibuilder.models.Required) => {
-        jsObjectRequired(obj)
+        apibuilder.models.json.jsObjectRequired(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-28-java-instant.txt
+++ b/lib/src/test/resources/generators/play-28-java-instant.txt
@@ -96,7 +96,7 @@ package io.gregor.time.types.v0.models {
 
     implicit def jsonWritesTimeTypesDateTimeModel: play.api.libs.json.Writes[DateTimeModel] = {
       (obj: io.gregor.time.types.v0.models.DateTimeModel) => {
-        jsObjectDateTimeModel(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeModel(obj)
       }
     }
 
@@ -111,8 +111,8 @@ package io.gregor.time.types.v0.models {
     implicit def jsonReadsTimeTypesDateTimeUnion: play.api.libs.json.Reads[io.gregor.time.types.v0.models.DateTimeUnion] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "date-time-iso8601" => jsonReadsTimeTypesDateTimeIso8601.reads(js)
-          case "date-iso8601" => jsonReadsTimeTypesDateIso8601.reads(js)
+          case "date-time-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateTimeIso8601.reads(js)
+          case "date-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateIso8601.reads(js)
           case other => play.api.libs.json.JsSuccess(io.gregor.time.types.v0.models.DateTimeUnionUndefinedType(other))
         }
       }
@@ -133,7 +133,7 @@ package io.gregor.time.types.v0.models {
     }
     implicit def jsonWritesTimeTypesDateTimeUnion: play.api.libs.json.Writes[DateTimeUnion] = {
       (obj: io.gregor.time.types.v0.models.DateTimeUnion) => {
-        jsObjectDateTimeUnion(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeUnion(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-28-java-offsetdatetime.txt
+++ b/lib/src/test/resources/generators/play-28-java-offsetdatetime.txt
@@ -96,7 +96,7 @@ package io.gregor.time.types.v0.models {
 
     implicit def jsonWritesTimeTypesDateTimeModel: play.api.libs.json.Writes[DateTimeModel] = {
       (obj: io.gregor.time.types.v0.models.DateTimeModel) => {
-        jsObjectDateTimeModel(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeModel(obj)
       }
     }
 
@@ -111,8 +111,8 @@ package io.gregor.time.types.v0.models {
     implicit def jsonReadsTimeTypesDateTimeUnion: play.api.libs.json.Reads[io.gregor.time.types.v0.models.DateTimeUnion] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "date-time-iso8601" => jsonReadsTimeTypesDateTimeIso8601.reads(js)
-          case "date-iso8601" => jsonReadsTimeTypesDateIso8601.reads(js)
+          case "date-time-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateTimeIso8601.reads(js)
+          case "date-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateIso8601.reads(js)
           case other => play.api.libs.json.JsSuccess(io.gregor.time.types.v0.models.DateTimeUnionUndefinedType(other))
         }
       }
@@ -133,7 +133,7 @@ package io.gregor.time.types.v0.models {
     }
     implicit def jsonWritesTimeTypesDateTimeUnion: play.api.libs.json.Writes[DateTimeUnion] = {
       (obj: io.gregor.time.types.v0.models.DateTimeUnion) => {
-        jsObjectDateTimeUnion(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeUnion(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/play-28-joda-date-time.txt
+++ b/lib/src/test/resources/generators/play-28-joda-date-time.txt
@@ -116,7 +116,7 @@ package io.gregor.time.types.v0.models {
 
     implicit def jsonWritesTimeTypesDateTimeModel: play.api.libs.json.Writes[DateTimeModel] = {
       (obj: io.gregor.time.types.v0.models.DateTimeModel) => {
-        jsObjectDateTimeModel(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeModel(obj)
       }
     }
 
@@ -131,8 +131,8 @@ package io.gregor.time.types.v0.models {
     implicit def jsonReadsTimeTypesDateTimeUnion: play.api.libs.json.Reads[io.gregor.time.types.v0.models.DateTimeUnion] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "date-time-iso8601" => jsonReadsTimeTypesDateTimeIso8601.reads(js)
-          case "date-iso8601" => jsonReadsTimeTypesDateIso8601.reads(js)
+          case "date-time-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateTimeIso8601.reads(js)
+          case "date-iso8601" => io.gregor.time.types.v0.models.json.jsonReadsTimeTypesDateIso8601.reads(js)
           case other => play.api.libs.json.JsSuccess(io.gregor.time.types.v0.models.DateTimeUnionUndefinedType(other))
         }
       }
@@ -153,7 +153,7 @@ package io.gregor.time.types.v0.models {
     }
     implicit def jsonWritesTimeTypesDateTimeUnion: play.api.libs.json.Writes[DateTimeUnion] = {
       (obj: io.gregor.time.types.v0.models.DateTimeUnion) => {
-        jsObjectDateTimeUnion(obj)
+        io.gregor.time.types.v0.models.json.jsObjectDateTimeUnion(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -180,7 +180,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiAgeGroup: play.api.libs.json.Writes[AgeGroup] = {
       (obj: io.apibuilder.reference.api.v0.models.AgeGroup) => {
-        jsonWritesApidocReferenceApiAgeGroup(obj)
+        io.apibuilder.reference.api.v0.models.json.jsonWritesApidocReferenceApiAgeGroup(obj)
       }
     }
 
@@ -246,7 +246,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiBig: play.api.libs.json.Writes[Big] = {
       (obj: io.apibuilder.reference.api.v0.models.Big) => {
-        jsObjectBig(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectBig(obj)
       }
     }
 
@@ -262,7 +262,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiEcho: play.api.libs.json.Writes[Echo] = {
       (obj: io.apibuilder.reference.api.v0.models.Echo) => {
-        jsObjectEcho(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectEcho(obj)
       }
     }
 
@@ -282,7 +282,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiError: play.api.libs.json.Writes[Error] = {
       (obj: io.apibuilder.reference.api.v0.models.Error) => {
-        jsObjectError(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectError(obj)
       }
     }
 
@@ -298,7 +298,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiGroup: play.api.libs.json.Writes[Group] = {
       (obj: io.apibuilder.reference.api.v0.models.Group) => {
-        jsObjectGroup(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectGroup(obj)
       }
     }
 
@@ -314,15 +314,15 @@ package io.apibuilder.reference.api.v0.models {
     def jsObjectMember(obj: io.apibuilder.reference.api.v0.models.Member): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "organization" -> jsObjectOrganization(obj.organization),
-        "user" -> jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.reference.api.v0.models.json.jsObjectOrganization(obj.organization),
+        "user" -> io.apibuilder.reference.api.v0.models.json.jsObjectUser(obj.user),
         "role" -> play.api.libs.json.JsString(obj.role)
       )
     }
 
     implicit def jsonWritesApidocReferenceApiMember: play.api.libs.json.Writes[Member] = {
       (obj: io.apibuilder.reference.api.v0.models.Member) => {
-        jsObjectMember(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectMember(obj)
       }
     }
 
@@ -342,7 +342,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiOrganization: play.api.libs.json.Writes[Organization] = {
       (obj: io.apibuilder.reference.api.v0.models.Organization) => {
-        jsObjectOrganization(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectOrganization(obj)
       }
     }
 
@@ -370,7 +370,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiUser: play.api.libs.json.Writes[User] = {
       (obj: io.apibuilder.reference.api.v0.models.User) => {
-        jsObjectUser(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectUser(obj)
       }
     }
 
@@ -386,7 +386,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiUserList: play.api.libs.json.Writes[UserList] = {
       (obj: io.apibuilder.reference.api.v0.models.UserList) => {
-        jsObjectUserList(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectUserList(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -180,7 +180,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiAgeGroup: play.api.libs.json.Writes[AgeGroup] = {
       (obj: io.apibuilder.reference.api.v0.models.AgeGroup) => {
-        jsonWritesApidocReferenceApiAgeGroup(obj)
+        io.apibuilder.reference.api.v0.models.json.jsonWritesApidocReferenceApiAgeGroup(obj)
       }
     }
 
@@ -246,7 +246,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiBig: play.api.libs.json.Writes[Big] = {
       (obj: io.apibuilder.reference.api.v0.models.Big) => {
-        jsObjectBig(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectBig(obj)
       }
     }
 
@@ -262,7 +262,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiEcho: play.api.libs.json.Writes[Echo] = {
       (obj: io.apibuilder.reference.api.v0.models.Echo) => {
-        jsObjectEcho(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectEcho(obj)
       }
     }
 
@@ -282,7 +282,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiError: play.api.libs.json.Writes[Error] = {
       (obj: io.apibuilder.reference.api.v0.models.Error) => {
-        jsObjectError(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectError(obj)
       }
     }
 
@@ -298,7 +298,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiGroup: play.api.libs.json.Writes[Group] = {
       (obj: io.apibuilder.reference.api.v0.models.Group) => {
-        jsObjectGroup(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectGroup(obj)
       }
     }
 
@@ -314,15 +314,15 @@ package io.apibuilder.reference.api.v0.models {
     def jsObjectMember(obj: io.apibuilder.reference.api.v0.models.Member): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "organization" -> jsObjectOrganization(obj.organization),
-        "user" -> jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.reference.api.v0.models.json.jsObjectOrganization(obj.organization),
+        "user" -> io.apibuilder.reference.api.v0.models.json.jsObjectUser(obj.user),
         "role" -> play.api.libs.json.JsString(obj.role)
       )
     }
 
     implicit def jsonWritesApidocReferenceApiMember: play.api.libs.json.Writes[Member] = {
       (obj: io.apibuilder.reference.api.v0.models.Member) => {
-        jsObjectMember(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectMember(obj)
       }
     }
 
@@ -342,7 +342,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiOrganization: play.api.libs.json.Writes[Organization] = {
       (obj: io.apibuilder.reference.api.v0.models.Organization) => {
-        jsObjectOrganization(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectOrganization(obj)
       }
     }
 
@@ -370,7 +370,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiUser: play.api.libs.json.Writes[User] = {
       (obj: io.apibuilder.reference.api.v0.models.User) => {
-        jsObjectUser(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectUser(obj)
       }
     }
 
@@ -386,7 +386,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiUserList: play.api.libs.json.Writes[UserList] = {
       (obj: io.apibuilder.reference.api.v0.models.UserList) => {
-        jsObjectUserList(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectUserList(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -181,7 +181,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiAgeGroup: play.api.libs.json.Writes[AgeGroup] = {
       (obj: io.apibuilder.reference.api.v0.models.AgeGroup) => {
-        jsonWritesApidocReferenceApiAgeGroup(obj)
+        io.apibuilder.reference.api.v0.models.json.jsonWritesApidocReferenceApiAgeGroup(obj)
       }
     }
 
@@ -247,7 +247,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiBig: play.api.libs.json.Writes[Big] = {
       (obj: io.apibuilder.reference.api.v0.models.Big) => {
-        jsObjectBig(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectBig(obj)
       }
     }
 
@@ -263,7 +263,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiEcho: play.api.libs.json.Writes[Echo] = {
       (obj: io.apibuilder.reference.api.v0.models.Echo) => {
-        jsObjectEcho(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectEcho(obj)
       }
     }
 
@@ -283,7 +283,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiError: play.api.libs.json.Writes[Error] = {
       (obj: io.apibuilder.reference.api.v0.models.Error) => {
-        jsObjectError(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectError(obj)
       }
     }
 
@@ -299,7 +299,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiGroup: play.api.libs.json.Writes[Group] = {
       (obj: io.apibuilder.reference.api.v0.models.Group) => {
-        jsObjectGroup(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectGroup(obj)
       }
     }
 
@@ -315,15 +315,15 @@ package io.apibuilder.reference.api.v0.models {
     def jsObjectMember(obj: io.apibuilder.reference.api.v0.models.Member): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "organization" -> jsObjectOrganization(obj.organization),
-        "user" -> jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.reference.api.v0.models.json.jsObjectOrganization(obj.organization),
+        "user" -> io.apibuilder.reference.api.v0.models.json.jsObjectUser(obj.user),
         "role" -> play.api.libs.json.JsString(obj.role)
       )
     }
 
     implicit def jsonWritesApidocReferenceApiMember: play.api.libs.json.Writes[Member] = {
       (obj: io.apibuilder.reference.api.v0.models.Member) => {
-        jsObjectMember(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectMember(obj)
       }
     }
 
@@ -343,7 +343,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiOrganization: play.api.libs.json.Writes[Organization] = {
       (obj: io.apibuilder.reference.api.v0.models.Organization) => {
-        jsObjectOrganization(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectOrganization(obj)
       }
     }
 
@@ -371,7 +371,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiUser: play.api.libs.json.Writes[User] = {
       (obj: io.apibuilder.reference.api.v0.models.User) => {
-        jsObjectUser(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectUser(obj)
       }
     }
 
@@ -387,7 +387,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiUserList: play.api.libs.json.Writes[UserList] = {
       (obj: io.apibuilder.reference.api.v0.models.UserList) => {
-        jsObjectUserList(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectUserList(obj)
       }
     }
   }

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -181,7 +181,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiAgeGroup: play.api.libs.json.Writes[AgeGroup] = {
       (obj: io.apibuilder.reference.api.v0.models.AgeGroup) => {
-        jsonWritesApidocReferenceApiAgeGroup(obj)
+        io.apibuilder.reference.api.v0.models.json.jsonWritesApidocReferenceApiAgeGroup(obj)
       }
     }
 
@@ -247,7 +247,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiBig: play.api.libs.json.Writes[Big] = {
       (obj: io.apibuilder.reference.api.v0.models.Big) => {
-        jsObjectBig(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectBig(obj)
       }
     }
 
@@ -263,7 +263,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiEcho: play.api.libs.json.Writes[Echo] = {
       (obj: io.apibuilder.reference.api.v0.models.Echo) => {
-        jsObjectEcho(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectEcho(obj)
       }
     }
 
@@ -283,7 +283,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiError: play.api.libs.json.Writes[Error] = {
       (obj: io.apibuilder.reference.api.v0.models.Error) => {
-        jsObjectError(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectError(obj)
       }
     }
 
@@ -299,7 +299,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiGroup: play.api.libs.json.Writes[Group] = {
       (obj: io.apibuilder.reference.api.v0.models.Group) => {
-        jsObjectGroup(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectGroup(obj)
       }
     }
 
@@ -315,15 +315,15 @@ package io.apibuilder.reference.api.v0.models {
     def jsObjectMember(obj: io.apibuilder.reference.api.v0.models.Member): play.api.libs.json.JsObject = {
       play.api.libs.json.Json.obj(
         "guid" -> play.api.libs.json.JsString(obj.guid.toString),
-        "organization" -> jsObjectOrganization(obj.organization),
-        "user" -> jsObjectUser(obj.user),
+        "organization" -> io.apibuilder.reference.api.v0.models.json.jsObjectOrganization(obj.organization),
+        "user" -> io.apibuilder.reference.api.v0.models.json.jsObjectUser(obj.user),
         "role" -> play.api.libs.json.JsString(obj.role)
       )
     }
 
     implicit def jsonWritesApidocReferenceApiMember: play.api.libs.json.Writes[Member] = {
       (obj: io.apibuilder.reference.api.v0.models.Member) => {
-        jsObjectMember(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectMember(obj)
       }
     }
 
@@ -343,7 +343,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiOrganization: play.api.libs.json.Writes[Organization] = {
       (obj: io.apibuilder.reference.api.v0.models.Organization) => {
-        jsObjectOrganization(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectOrganization(obj)
       }
     }
 
@@ -371,7 +371,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiUser: play.api.libs.json.Writes[User] = {
       (obj: io.apibuilder.reference.api.v0.models.User) => {
-        jsObjectUser(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectUser(obj)
       }
     }
 
@@ -387,7 +387,7 @@ package io.apibuilder.reference.api.v0.models {
 
     implicit def jsonWritesApidocReferenceApiUserList: play.api.libs.json.Writes[UserList] = {
       (obj: io.apibuilder.reference.api.v0.models.UserList) => {
-        jsObjectUserList(obj)
+        io.apibuilder.reference.api.v0.models.json.jsObjectUserList(obj)
       }
     }
   }

--- a/lib/src/test/resources/play2enums-json-example.txt
+++ b/lib/src/test/resources/play2enums-json-example.txt
@@ -26,7 +26,7 @@ def jsObjectAgeGroup(obj: test.apidoc.apidoctest.v0.models.AgeGroup) = {
 
 implicit def jsonWritesAPIBuilderTestAgeGroup: play.api.libs.json.Writes[AgeGroup] = {
   (obj: test.apidoc.apidoctest.v0.models.AgeGroup) => {
-    jsonWritesAPIBuilderTestAgeGroup(obj)
+    test.apidoc.apidoctest.v0.models.json.jsonWritesAPIBuilderTestAgeGroup(obj)
   }
 }
 
@@ -58,6 +58,6 @@ def jsObjectGenre(obj: test.apidoc.apidoctest.v0.models.Genre) = {
 
 implicit def jsonWritesAPIBuilderTestGenre: play.api.libs.json.Writes[Genre] = {
   (obj: test.apidoc.apidoctest.v0.models.Genre) => {
-    jsonWritesAPIBuilderTestGenre(obj)
+    test.apidoc.apidoctest.v0.models.json.jsonWritesAPIBuilderTestGenre(obj)
   }
 }

--- a/lib/src/test/resources/scala-union-enums-json.txt
+++ b/lib/src/test/resources/scala-union-enums-json.txt
@@ -17,6 +17,6 @@ def jsObjectUserType(obj: test.apidoc.apidoctest.v0.models.UserType): play.api.l
 }
 implicit def jsonWritesAPIBuilderTestUserType: play.api.libs.json.Writes[UserType] = {
   (obj: test.apidoc.apidoctest.v0.models.UserType) => {
-    jsObjectUserType(obj)
+    test.apidoc.apidoctest.v0.models.json.jsObjectUserType(obj)
   }
 }

--- a/lib/src/test/resources/scala-union-models-json-union-type-writers.txt
+++ b/lib/src/test/resources/scala-union-models-json-union-type-writers.txt
@@ -1,12 +1,12 @@
 def jsObjectUser(obj: test.apidoc.apidoctest.v0.models.User): play.api.libs.json.JsObject = {
   obj match {
-    case x: test.apidoc.apidoctest.v0.models.RegisteredUser => play.api.libs.json.Json.obj("registered_user" -> jsObjectRegisteredUser(x))
-    case x: test.apidoc.apidoctest.v0.models.GuestUser => play.api.libs.json.Json.obj("guest_user" -> jsObjectGuestUser(x))
+    case x: test.apidoc.apidoctest.v0.models.RegisteredUser => play.api.libs.json.Json.obj("registered_user" -> test.apidoc.apidoctest.v0.models.json.jsObjectRegisteredUser(x))
+    case x: test.apidoc.apidoctest.v0.models.GuestUser => play.api.libs.json.Json.obj("guest_user" -> test.apidoc.apidoctest.v0.models.json.jsObjectGuestUser(x))
     case x: test.apidoc.apidoctest.v0.models.UserUndefinedType => sys.error(s"The type[test.apidoc.apidoctest.v0.models.UserUndefinedType] should never be serialized")
   }
 }
 implicit def jsonWritesAPIBuilderTestUser: play.api.libs.json.Writes[User] = {
   (obj: test.apidoc.apidoctest.v0.models.User) => {
-    jsObjectUser(obj)
+    test.apidoc.apidoctest.v0.models.json.jsObjectUser(obj)
   }
 }

--- a/lib/src/test/resources/scala-union-models-json.txt
+++ b/lib/src/test/resources/scala-union-models-json.txt
@@ -20,7 +20,7 @@ def jsObjectGuestUser(obj: test.apidoc.apidoctest.v0.models.GuestUser): play.api
 
 implicit def jsonWritesAPIBuilderTestGuestUser: play.api.libs.json.Writes[GuestUser] = {
   (obj: test.apidoc.apidoctest.v0.models.GuestUser) => {
-    jsObjectGuestUser(obj)
+    test.apidoc.apidoctest.v0.models.json.jsObjectGuestUser(obj)
   }
 }
 
@@ -46,7 +46,7 @@ def jsObjectRegisteredUser(obj: test.apidoc.apidoctest.v0.models.RegisteredUser)
 
 implicit def jsonWritesAPIBuilderTestRegisteredUser: play.api.libs.json.Writes[RegisteredUser] = {
   (obj: test.apidoc.apidoctest.v0.models.RegisteredUser) => {
-    jsObjectRegisteredUser(obj)
+    test.apidoc.apidoctest.v0.models.json.jsObjectRegisteredUser(obj)
   }
 }
 
@@ -62,13 +62,13 @@ implicit def jsonReadsAPIBuilderTestUser: play.api.libs.json.Reads[test.apidoc.a
 
 def jsObjectUser(obj: test.apidoc.apidoctest.v0.models.User): play.api.libs.json.JsObject = {
   obj match {
-    case x: test.apidoc.apidoctest.v0.models.RegisteredUser => play.api.libs.json.Json.obj("registered_user" -> jsObjectRegisteredUser(x))
-    case x: test.apidoc.apidoctest.v0.models.GuestUser => play.api.libs.json.Json.obj("guest_user" -> jsObjectGuestUser(x))
+    case x: test.apidoc.apidoctest.v0.models.RegisteredUser => play.api.libs.json.Json.obj("registered_user" -> test.apidoc.apidoctest.v0.models.json.jsObjectRegisteredUser(x))
+    case x: test.apidoc.apidoctest.v0.models.GuestUser => play.api.libs.json.Json.obj("guest_user" -> test.apidoc.apidoctest.v0.models.json.jsObjectGuestUser(x))
     case x: test.apidoc.apidoctest.v0.models.UserUndefinedType => sys.error(s"The type[test.apidoc.apidoctest.v0.models.UserUndefinedType] should never be serialized")
   }
 }
 implicit def jsonWritesAPIBuilderTestUser: play.api.libs.json.Writes[User] = {
   (obj: test.apidoc.apidoctest.v0.models.User) => {
-    jsObjectUser(obj)
+    test.apidoc.apidoctest.v0.models.json.jsObjectUser(obj)
   }
 }

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -177,7 +177,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
 
     implicit def jsonWritesApidocExampleUnionTypesDiscriminatorSystemUser: play.api.libs.json.Writes[SystemUser] = {
       (obj: io.apibuilder.example.union.types.discriminator.v0.models.SystemUser) => {
-        jsObjectSystemUser(obj)
+        io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectSystemUser(obj)
       }
     }
 
@@ -199,7 +199,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
 
     implicit def jsonWritesApidocExampleUnionTypesDiscriminatorGuestUser: play.api.libs.json.Writes[GuestUser] = {
       (obj: io.apibuilder.example.union.types.discriminator.v0.models.GuestUser) => {
-        jsObjectGuestUser(obj)
+        io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectGuestUser(obj)
       }
     }
 
@@ -219,7 +219,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
 
     implicit def jsonWritesApidocExampleUnionTypesDiscriminatorRegisteredUser: play.api.libs.json.Writes[RegisteredUser] = {
       (obj: io.apibuilder.example.union.types.discriminator.v0.models.RegisteredUser) => {
-        jsObjectRegisteredUser(obj)
+        io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectRegisteredUser(obj)
       }
     }
 
@@ -230,10 +230,10 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
     implicit def jsonReadsApidocExampleUnionTypesDiscriminatorUser: play.api.libs.json.Reads[io.apibuilder.example.union.types.discriminator.v0.models.User] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "registered_user" => jsonReadsApidocExampleUnionTypesDiscriminatorRegisteredUser.reads(js)
-          case "guest_user" => jsonReadsApidocExampleUnionTypesDiscriminatorGuestUser.reads(js)
-          case "system_user" => jsonReadsApidocExampleUnionTypesDiscriminatorSystemUser.reads(js)
-          case "string" => jsonReadsApidocExampleUnionTypesDiscriminatorString.reads(js)
+          case "registered_user" => io.apibuilder.example.union.types.discriminator.v0.models.json.jsonReadsApidocExampleUnionTypesDiscriminatorRegisteredUser.reads(js)
+          case "guest_user" => io.apibuilder.example.union.types.discriminator.v0.models.json.jsonReadsApidocExampleUnionTypesDiscriminatorGuestUser.reads(js)
+          case "system_user" => io.apibuilder.example.union.types.discriminator.v0.models.json.jsonReadsApidocExampleUnionTypesDiscriminatorSystemUser.reads(js)
+          case "string" => io.apibuilder.example.union.types.discriminator.v0.models.json.jsonReadsApidocExampleUnionTypesDiscriminatorString.reads(js)
           case other => play.api.libs.json.JsSuccess(io.apibuilder.example.union.types.discriminator.v0.models.UserUndefinedType(other))
         }
       }
@@ -245,9 +245,9 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
 
     def jsObjectUser(obj: io.apibuilder.example.union.types.discriminator.v0.models.User): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.example.union.types.discriminator.v0.models.RegisteredUser => jsObjectRegisteredUser(x)
-        case x: io.apibuilder.example.union.types.discriminator.v0.models.GuestUser => jsObjectGuestUser(x)
-        case x: io.apibuilder.example.union.types.discriminator.v0.models.SystemUser => jsObjectSystemUser(x)
+        case x: io.apibuilder.example.union.types.discriminator.v0.models.RegisteredUser => io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectRegisteredUser(x)
+        case x: io.apibuilder.example.union.types.discriminator.v0.models.GuestUser => io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectGuestUser(x)
+        case x: io.apibuilder.example.union.types.discriminator.v0.models.SystemUser => io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectSystemUser(x)
         case x: io.apibuilder.example.union.types.discriminator.v0.models.UserString => play.api.libs.json.Json.obj("discriminator" -> "string", "value" -> play.api.libs.json.JsString(x.value))
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
@@ -256,7 +256,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
     }
     implicit def jsonWritesApidocExampleUnionTypesDiscriminatorUser: play.api.libs.json.Writes[User] = {
       (obj: io.apibuilder.example.union.types.discriminator.v0.models.User) => {
-        jsObjectUser(obj)
+        io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectUser(obj)
       }
     }
   }

--- a/lib/src/test/resources/union-types-discriminator-service-play-27.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-27.txt
@@ -177,7 +177,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
 
     implicit def jsonWritesApidocExampleUnionTypesDiscriminatorSystemUser: play.api.libs.json.Writes[SystemUser] = {
       (obj: io.apibuilder.example.union.types.discriminator.v0.models.SystemUser) => {
-        jsObjectSystemUser(obj)
+        io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectSystemUser(obj)
       }
     }
 
@@ -199,7 +199,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
 
     implicit def jsonWritesApidocExampleUnionTypesDiscriminatorGuestUser: play.api.libs.json.Writes[GuestUser] = {
       (obj: io.apibuilder.example.union.types.discriminator.v0.models.GuestUser) => {
-        jsObjectGuestUser(obj)
+        io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectGuestUser(obj)
       }
     }
 
@@ -219,7 +219,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
 
     implicit def jsonWritesApidocExampleUnionTypesDiscriminatorRegisteredUser: play.api.libs.json.Writes[RegisteredUser] = {
       (obj: io.apibuilder.example.union.types.discriminator.v0.models.RegisteredUser) => {
-        jsObjectRegisteredUser(obj)
+        io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectRegisteredUser(obj)
       }
     }
 
@@ -230,10 +230,10 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
     implicit def jsonReadsApidocExampleUnionTypesDiscriminatorUser: play.api.libs.json.Reads[io.apibuilder.example.union.types.discriminator.v0.models.User] = (js: play.api.libs.json.JsValue) => {
       def readDiscriminator(discriminator: String) = {
         discriminator match {
-          case "registered_user" => jsonReadsApidocExampleUnionTypesDiscriminatorRegisteredUser.reads(js)
-          case "guest_user" => jsonReadsApidocExampleUnionTypesDiscriminatorGuestUser.reads(js)
-          case "system_user" => jsonReadsApidocExampleUnionTypesDiscriminatorSystemUser.reads(js)
-          case "string" => jsonReadsApidocExampleUnionTypesDiscriminatorString.reads(js)
+          case "registered_user" => io.apibuilder.example.union.types.discriminator.v0.models.json.jsonReadsApidocExampleUnionTypesDiscriminatorRegisteredUser.reads(js)
+          case "guest_user" => io.apibuilder.example.union.types.discriminator.v0.models.json.jsonReadsApidocExampleUnionTypesDiscriminatorGuestUser.reads(js)
+          case "system_user" => io.apibuilder.example.union.types.discriminator.v0.models.json.jsonReadsApidocExampleUnionTypesDiscriminatorSystemUser.reads(js)
+          case "string" => io.apibuilder.example.union.types.discriminator.v0.models.json.jsonReadsApidocExampleUnionTypesDiscriminatorString.reads(js)
           case other => play.api.libs.json.JsSuccess(io.apibuilder.example.union.types.discriminator.v0.models.UserUndefinedType(other))
         }
       }
@@ -245,9 +245,9 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
 
     def jsObjectUser(obj: io.apibuilder.example.union.types.discriminator.v0.models.User): play.api.libs.json.JsObject = {
       obj match {
-        case x: io.apibuilder.example.union.types.discriminator.v0.models.RegisteredUser => jsObjectRegisteredUser(x)
-        case x: io.apibuilder.example.union.types.discriminator.v0.models.GuestUser => jsObjectGuestUser(x)
-        case x: io.apibuilder.example.union.types.discriminator.v0.models.SystemUser => jsObjectSystemUser(x)
+        case x: io.apibuilder.example.union.types.discriminator.v0.models.RegisteredUser => io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectRegisteredUser(x)
+        case x: io.apibuilder.example.union.types.discriminator.v0.models.GuestUser => io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectGuestUser(x)
+        case x: io.apibuilder.example.union.types.discriminator.v0.models.SystemUser => io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectSystemUser(x)
         case x: io.apibuilder.example.union.types.discriminator.v0.models.UserString => play.api.libs.json.Json.obj("discriminator" -> "string", "value" -> play.api.libs.json.JsString(x.value))
         case other => {
           sys.error(s"The type[${other.getClass.getName}] has no JSON writer")
@@ -256,7 +256,7 @@ package io.apibuilder.example.union.types.discriminator.v0.models {
     }
     implicit def jsonWritesApidocExampleUnionTypesDiscriminatorUser: play.api.libs.json.Writes[User] = {
       (obj: io.apibuilder.example.union.types.discriminator.v0.models.User) => {
-        jsObjectUser(obj)
+        io.apibuilder.example.union.types.discriminator.v0.models.json.jsObjectUser(obj)
       }
     }
   }

--- a/scala-generator/src/main/scala/models/generator/ScalaUtil.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaUtil.scala
@@ -62,7 +62,7 @@ object ScalaUtil {
     (interfaces ++ unions).toList.filterNot(_ == className).distinct.sorted
   }
 
-  def trimTrailingWhitespace(text: String): String = {
+  private def trimTrailingWhitespace(text: String): String = {
     text.reverse.dropWhile(_ == ' ').reverse
   }
 
@@ -128,7 +128,6 @@ object ScalaUtil {
       case ScalaDatatype.Option(inner) => s"Some(${inner.default(value)})"
       case _ => datatype.default(value)
     }
-
   } catch {
     case e: Exception => {
       throw new RuntimeException(s"parsing default `$value` for datatype $datatype", e)


### PR DESCRIPTION
This fixed a bug where if you import services that define the same model, previously there would be multiple matching methods. Here we explicitly select the correct reader/writer.

```
-    implicit def jsonReadsApibuilderGeneratorInvocation: play.api.libs.json.Reads[Invocation] = {
+    implicit def jsonReadsApibuilderGeneratorInvocation: play.api.libs.json.Reads[io.apibuilder.generator.v0.models.Invocation] = {
       for {
         source <- (__ \ "source").read[String]
         files <- (__ \ "files").read[Seq[io.apibuilder.generator.v0.models.File]]
@@ -329,11 +329,11 @@ package io.apibuilder.generator.v0.models {

     implicit def jsonWritesApibuilderGeneratorInvocation: play.api.libs.json.Writes[Invocation] = {
       (obj: io.apibuilder.generator.v0.models.Invocation) => {
-        jsObjectInvocation(obj)
+        io.apibuilder.generator.v0.models.json.jsObjectInvocation(obj)
       }
     }
```