### PR TITLE
Remove graphql generator for now

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,8 +52,8 @@ lazy val lib = project
 
 lazy val generator = project
   .in(file("generator"))
-  .dependsOn(csharpGenerator, scalaGenerator, rubyGenerator, javaGenerator, goGenerator, androidGenerator, kotlinGenerator, graphQLGenerator, javaAwsLambdaPojos, postmanGenerator, csvGenerator, openapiGenerator)
-  .aggregate(csharpGenerator, scalaGenerator, rubyGenerator, javaGenerator, goGenerator, androidGenerator, kotlinGenerator, graphQLGenerator, javaAwsLambdaPojos, postmanGenerator, csvGenerator, openapiGenerator)
+  .dependsOn(csharpGenerator, scalaGenerator, rubyGenerator, javaGenerator, goGenerator, androidGenerator, kotlinGenerator, javaAwsLambdaPojos, postmanGenerator, csvGenerator, openapiGenerator)
+  .aggregate(csharpGenerator, scalaGenerator, rubyGenerator, javaGenerator, goGenerator, androidGenerator, kotlinGenerator, javaAwsLambdaPojos, postmanGenerator, csvGenerator, openapiGenerator)
   .enablePlugins(PlayScala)
   .enablePlugins(JavaAgent)
   .settings(commonSettings: _*)

--- a/generator/app/controllers/Generators.scala
+++ b/generator/app/controllers/Generators.scala
@@ -570,26 +570,6 @@ object Generators {
     ),
     CodeGenTarget(
       metaData = Generator(
-        key = "graphql",
-        name = "GraphQL Schema Generator. See https://github.com/apicollective/apibuilder-examples/tree/main/graphql/users",
-        description = Some("Generates GraphQL Schema"),
-        language = Some("graphql")
-      ),
-      status = lib.generator.Status.Beta,
-      codeGenerator = Some(generator.graphql.GraphQLSchemaGenerator)
-    ),
-    CodeGenTarget(
-      metaData = Generator(
-        key = "graphql_apollo",
-        name = "GraphQL Apollo Server Generator. See https://github.com/apicollective/apibuilder-examples/tree/main/graphql/users",
-        description = Some("Generates GraphQL Schema and Apollo Server Adapters"),
-        language = Some("graphql, typescript")
-      ),
-      status = lib.generator.Status.Beta,
-      codeGenerator = Some(generator.graphql.GraphQLApolloGenerator)
-    ),
-    CodeGenTarget(
-      metaData = Generator(
         key = "csharp",
         name = "C# Generator",
         description = None,


### PR DESCRIPTION
With it we get the following when building the image
```
 (graphQLGenerator / update) sbt.librarymanagement.ResolveException: Error downloading io.apibuilder:apibuilder-graphql_2.13:0.0.10 
```