### PR TITLE
Complete graphql generator removal from build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,17 +130,6 @@ lazy val androidGenerator = project
     commonSettings: _*
   )
 
-lazy val graphQLGenerator = project
-  .in(file("graphql-generator"))
-  .dependsOn(lib, lib % "test->test")
-  .settings(commonSettings: _*)
-  .settings(resolversSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "io.apibuilder" %% "apibuilder-graphql" % "0.0.10",
-    ),
-  )
-
 val kotlinLangVersion = "1.3.72"
 val mockitoVersion = "4.5.1"
 val scalatestVersion = "3.2.12"


### PR DESCRIPTION
## Summary

PR #720 removed `graphQLGenerator` from the `generator` project's `.dependsOn` and `.aggregate` lists, but left the subproject definition in `build.sbt`. sbt resolves dependencies for all defined subprojects regardless of whether they appear in the aggregate, so it still attempted to download `io.apibuilder:apibuilder-graphql_2.13:0.0.10` — which is unavailable — causing CI to fail on every build since the merge.

This PR removes the `graphQLGenerator` project definition entirely from `build.sbt`, completing the removal started in #720.

## Dependencies

None.

## Test plan

- CI should pass with the graphql resolve error gone
- The `graphql-generator/` source directory is left on disk but sbt will no longer load or compile it

## Eng-Review Summary

- Revision: bb254017
- Timestamp: 2026-06-02T00:00:00Z
- Status: passed
- Issues: None
